### PR TITLE
T2: Add Config data models (WP1.2a)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,8 @@ line-length = 88
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["ai_guard"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]

--- a/src/ai_guard/config/__init__.py
+++ b/src/ai_guard/config/__init__.py
@@ -1,0 +1,27 @@
+"""Configuration system for AI Guard."""
+
+from ai_guard.config.models import (
+    AuditConfig,
+    BehaviorConfig,
+    CheckItem,
+    CodeConfig,
+    LanguageTools,
+    OperationRules,
+    OutputConfig,
+    PrReportConfig,
+    ResolvedConfig,
+    Rule,
+)
+
+__all__ = [
+    "Rule",
+    "OperationRules",
+    "BehaviorConfig",
+    "CheckItem",
+    "CodeConfig",
+    "LanguageTools",
+    "AuditConfig",
+    "PrReportConfig",
+    "OutputConfig",
+    "ResolvedConfig",
+]

--- a/src/ai_guard/config/models.py
+++ b/src/ai_guard/config/models.py
@@ -1,4 +1,9 @@
-"""Configuration data models for AI Guard."""
+"""Configuration data models for AI Guard.
+
+All config-related dataclasses that represent the parsed and merged
+guard.yaml configuration. These are pure data containers with no
+validation logic — schema validation belongs in the config loader.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +25,20 @@ __all__ = [
 
 @dataclass
 class Rule:
-    """A single behavior constraint rule."""
+    """A single behavior constraint rule.
+
+    Attributes:
+        pattern: Resource pattern with scheme prefix
+            (file:/shell:/mcp:/web:). Supports glob by default.
+        reason: Human-readable reason shown when a violation
+            is denied.
+        message: Custom message shown when asking for user
+            approval (require_approval rules).
+        regex: If True, pattern uses regex matching instead
+            of glob.
+        source: Origin of this rule. One of "default",
+            "ruleset:<name>", "user", or "system".
+    """
 
     pattern: str
     reason: str | None = None
@@ -31,7 +49,16 @@ class Rule:
 
 @dataclass
 class OperationRules:
-    """Three-tier rules for a single operation type (read/write/execute)."""
+    """Three-tier rules for a single operation type.
+
+    Attributes:
+        forbidden: Rules that unconditionally block the
+            operation.
+        require_approval: Rules that pause and ask the user
+            for confirmation.
+        allow: Rules that explicitly permit the operation,
+            overriding default-deny in strict mode.
+    """
 
     forbidden: list[Rule]
     require_approval: list[Rule]
@@ -39,13 +66,25 @@ class OperationRules:
 
     @classmethod
     def empty(cls) -> OperationRules:
-        """Create an instance with empty rule lists."""
+        """Create an instance with empty rule lists.
+
+        Returns:
+            OperationRules with empty forbidden,
+            require_approval, and allow lists.
+        """
         return cls(forbidden=[], require_approval=[], allow=[])
 
 
 @dataclass
 class BehaviorConfig:
-    """Behavior constraints across read, write, and execute dimensions."""
+    """Behavior constraints across three operation dimensions.
+
+    Attributes:
+        read: Rules for file/resource read operations.
+        write: Rules for file/resource write operations.
+        execute: Rules for shell command and MCP tool
+            execution.
+    """
 
     read: OperationRules
     write: OperationRules
@@ -53,7 +92,12 @@ class BehaviorConfig:
 
     @classmethod
     def empty(cls) -> BehaviorConfig:
-        """Create an instance with empty operation rules."""
+        """Create an instance with empty operation rules.
+
+        Returns:
+            BehaviorConfig with empty read, write, and execute
+            OperationRules.
+        """
         return cls(
             read=OperationRules.empty(),
             write=OperationRules.empty(),
@@ -63,7 +107,17 @@ class BehaviorConfig:
 
 @dataclass
 class CheckItem:
-    """A single code check definition."""
+    """A single code check definition.
+
+    Attributes:
+        command: Shell command to execute for this check.
+        timeout: Maximum execution time in seconds.
+        enabled: Whether this check is active.
+        types: File type filter (e.g. ["python"]). None
+            means all files.
+        pass_filenames: Whether to append changed filenames
+            to the command.
+    """
 
     command: str
     timeout: int = 300
@@ -74,7 +128,18 @@ class CheckItem:
 
 @dataclass
 class CodeConfig:
-    """Code quality check configuration for commit and push stages."""
+    """Code quality check configuration.
+
+    Attributes:
+        commit_format: Enable format checking at commit stage.
+        commit_naming: Enable naming convention checking at
+            commit stage.
+        commit_checks: Custom check items run at commit stage,
+            keyed by check name.
+        push_lint: Enable semantic lint at push stage.
+        push_checks: Custom check items run at push stage,
+            keyed by check name.
+    """
 
     commit_format: bool = True
     commit_naming: bool = True
@@ -85,7 +150,12 @@ class CodeConfig:
 
 @dataclass
 class LanguageTools:
-    """Format and lint tool mapping for a programming language."""
+    """Format and lint tool mapping for a programming language.
+
+    Attributes:
+        format: Formatter tool name (e.g. "black", "prettier").
+        lint: Linter tool name (e.g. "ruff", "eslint").
+    """
 
     format: str
     lint: str
@@ -93,7 +163,14 @@ class LanguageTools:
 
 @dataclass
 class AuditConfig:
-    """Audit logging configuration."""
+    """Audit logging configuration.
+
+    Attributes:
+        enabled: Whether audit logging is active.
+        path: File path for the audit log (JSON Lines).
+        retention: Number of days to retain audit records.
+            0 means permanent.
+    """
 
     enabled: bool = True
     path: str = ".ai-guard/audit.jsonl"
@@ -102,7 +179,17 @@ class AuditConfig:
 
 @dataclass
 class PrReportConfig:
-    """Pull request report configuration."""
+    """Pull request report configuration.
+
+    Attributes:
+        enabled: Whether PR report posting is active.
+        platform: Code hosting platform. One of "github",
+            "gitlab", "gitea", or "bitbucket".
+        api_url: Custom API endpoint for self-hosted
+            instances. None uses the platform default.
+        token_env: Environment variable name that holds
+            the platform access token.
+    """
 
     enabled: bool = False
     platform: str = "github"
@@ -112,7 +199,15 @@ class PrReportConfig:
 
 @dataclass
 class OutputConfig:
-    """Output and reporting configuration."""
+    """Output and reporting configuration.
+
+    Attributes:
+        verbosity: Output detail level. One of "quiet",
+            "normal", or "verbose".
+        locale: Report language code ("en" or "zh-CN").
+        audit: Audit logging settings.
+        pr_report: PR report posting settings.
+    """
 
     verbosity: str = "normal"
     locale: str = "en"
@@ -122,7 +217,31 @@ class OutputConfig:
 
 @dataclass
 class ResolvedConfig:
-    """Final merged configuration consumed by all AI Guard modules."""
+    """Final merged configuration consumed by all modules.
+
+    Produced by the config loader after merging defaults,
+    rulesets, and the project guard.yaml. This is the single
+    configuration object passed to Generator, Enforcer, and
+    other modules.
+
+    Attributes:
+        version: Configuration schema version number.
+        project_name: Project display name, defaults to
+            the directory name.
+        project_language: Primary programming language
+            (e.g. "python", "typescript").
+        behavior: Behavior constraint rules across read,
+            write, and execute dimensions.
+        code: Code quality check configuration for commit
+            and push stages.
+        languages: Per-language tool mappings, keyed by
+            language name.
+        output: Output and reporting settings.
+        build_command: Optional build command run before
+            push-stage checks.
+        config_hash: SHA hash of the source guard.yaml,
+            used for drift detection.
+    """
 
     version: int
     project_name: str

--- a/src/ai_guard/config/models.py
+++ b/src/ai_guard/config/models.py
@@ -1,0 +1,135 @@
+"""Configuration data models for AI Guard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "Rule",
+    "OperationRules",
+    "BehaviorConfig",
+    "CheckItem",
+    "CodeConfig",
+    "LanguageTools",
+    "AuditConfig",
+    "PrReportConfig",
+    "OutputConfig",
+    "ResolvedConfig",
+]
+
+
+@dataclass
+class Rule:
+    """A single behavior constraint rule."""
+
+    pattern: str
+    reason: str | None = None
+    message: str | None = None
+    regex: bool = False
+    source: str = "user"
+
+
+@dataclass
+class OperationRules:
+    """Three-tier rules for a single operation type (read/write/execute)."""
+
+    forbidden: list[Rule]
+    require_approval: list[Rule]
+    allow: list[Rule]
+
+    @classmethod
+    def empty(cls) -> OperationRules:
+        """Create an instance with empty rule lists."""
+        return cls(forbidden=[], require_approval=[], allow=[])
+
+
+@dataclass
+class BehaviorConfig:
+    """Behavior constraints across read, write, and execute dimensions."""
+
+    read: OperationRules
+    write: OperationRules
+    execute: OperationRules
+
+    @classmethod
+    def empty(cls) -> BehaviorConfig:
+        """Create an instance with empty operation rules."""
+        return cls(
+            read=OperationRules.empty(),
+            write=OperationRules.empty(),
+            execute=OperationRules.empty(),
+        )
+
+
+@dataclass
+class CheckItem:
+    """A single code check definition."""
+
+    command: str
+    timeout: int = 300
+    enabled: bool = True
+    types: list[str] | None = None
+    pass_filenames: bool = True
+
+
+@dataclass
+class CodeConfig:
+    """Code quality check configuration for commit and push stages."""
+
+    commit_format: bool = True
+    commit_naming: bool = True
+    commit_checks: dict[str, CheckItem] = field(default_factory=dict)
+    push_lint: bool = True
+    push_checks: dict[str, CheckItem] = field(default_factory=dict)
+
+
+@dataclass
+class LanguageTools:
+    """Format and lint tool mapping for a programming language."""
+
+    format: str
+    lint: str
+
+
+@dataclass
+class AuditConfig:
+    """Audit logging configuration."""
+
+    enabled: bool = True
+    path: str = ".ai-guard/audit.jsonl"
+    retention: int = 30
+
+
+@dataclass
+class PrReportConfig:
+    """Pull request report configuration."""
+
+    enabled: bool = False
+    platform: str = "github"
+    api_url: str | None = None
+    token_env: str = "GITHUB_TOKEN"
+
+
+@dataclass
+class OutputConfig:
+    """Output and reporting configuration."""
+
+    verbosity: str = "normal"
+    locale: str = "en"
+    audit: AuditConfig = field(default_factory=AuditConfig)
+    pr_report: PrReportConfig = field(default_factory=PrReportConfig)
+
+
+@dataclass
+class ResolvedConfig:
+    """Final merged configuration consumed by all AI Guard modules."""
+
+    version: int
+    project_name: str
+    project_language: str
+    behavior: BehaviorConfig
+    code: CodeConfig
+    languages: dict[str, LanguageTools]
+    output: OutputConfig
+    build_command: str | None = None
+    config_hash: str = ""

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -1,8 +1,9 @@
 """Smoke tests for CLI entry point."""
 
+from typer.testing import CliRunner
+
 from ai_guard import __version__
 from ai_guard.cli.main import app
-from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -1,9 +1,8 @@
 """Smoke tests for CLI entry point."""
 
-from typer.testing import CliRunner
-
 from ai_guard import __version__
 from ai_guard.cli.main import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from ai_guard.config.models import (
     AuditConfig,
     BehaviorConfig,

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from ai_guard.config.models import (
     AuditConfig,
     BehaviorConfig,
@@ -16,7 +15,6 @@ from ai_guard.config.models import (
     ResolvedConfig,
     Rule,
 )
-
 
 # ---------------------------------------------------------------------------
 # A. Rule
@@ -174,7 +172,7 @@ class TestCodeConfig:
 
     def test_with_check_items(self):
         cfg = CodeConfig(
-            commit_checks={"license": CheckItem(command="./check-license.sh")},
+            commit_checks={"license": CheckItem(command="check-license")},
             push_checks={"test": CheckItem(command="pytest", timeout=600)},
         )
         assert "license" in cfg.commit_checks
@@ -316,7 +314,9 @@ class TestResolvedConfig:
             behavior=BehaviorConfig(
                 read=OperationRules.empty(),
                 write=OperationRules(
-                    forbidden=[Rule(pattern="file:vendor/**", reason="no vendor edits")],
+                    forbidden=[
+                        Rule(pattern="file:vendor/**", reason="no vendor edits"),
+                    ],
                     require_approval=[],
                     allow=[Rule(pattern="file:src/**")],
                 ),

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -1,0 +1,371 @@
+"""Tests for ai_guard.config.models — Config data model definitions."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_guard.config.models import (
+    AuditConfig,
+    BehaviorConfig,
+    CheckItem,
+    CodeConfig,
+    LanguageTools,
+    OperationRules,
+    OutputConfig,
+    PrReportConfig,
+    ResolvedConfig,
+    Rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# A. Rule
+# ---------------------------------------------------------------------------
+
+
+class TestRule:
+    def test_required_pattern(self):
+        rule = Rule(pattern="file:*.py")
+        assert rule.pattern == "file:*.py"
+
+    def test_defaults(self):
+        rule = Rule(pattern="file:*.py")
+        assert rule.reason is None
+        assert rule.message is None
+        assert rule.regex is False
+        assert rule.source == "user"
+
+    def test_all_fields(self):
+        rule = Rule(
+            pattern="shell:rm -rf*",
+            reason="dangerous",
+            message="blocked",
+            regex=True,
+            source="system",
+        )
+        assert rule.pattern == "shell:rm -rf*"
+        assert rule.reason == "dangerous"
+        assert rule.message == "blocked"
+        assert rule.regex is True
+        assert rule.source == "system"
+
+    def test_regex_flag(self):
+        rule = Rule(pattern=r"shell:git\s+push.*", regex=True)
+        assert rule.regex is True
+
+    def test_source_variants(self):
+        for src in ("default", "ruleset:security", "user", "system"):
+            rule = Rule(pattern="file:x", source=src)
+            assert rule.source == src
+
+    def test_missing_pattern_raises(self):
+        with pytest.raises(TypeError):
+            Rule()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# B. OperationRules
+# ---------------------------------------------------------------------------
+
+
+class TestOperationRules:
+    def test_construction(self):
+        rules = OperationRules(
+            forbidden=[Rule(pattern="file:.env")],
+            require_approval=[Rule(pattern="file:.github/**")],
+            allow=[Rule(pattern="file:src/**")],
+        )
+        assert len(rules.forbidden) == 1
+        assert len(rules.require_approval) == 1
+        assert len(rules.allow) == 1
+
+    def test_empty_lists(self):
+        rules = OperationRules(forbidden=[], require_approval=[], allow=[])
+        assert rules.forbidden == []
+        assert rules.require_approval == []
+        assert rules.allow == []
+
+    def test_missing_field_raises(self):
+        with pytest.raises(TypeError):
+            OperationRules(forbidden=[])  # type: ignore[call-arg]
+
+    def test_empty_factory(self):
+        rules = OperationRules.empty()
+        assert rules.forbidden == []
+        assert rules.require_approval == []
+        assert rules.allow == []
+
+
+# ---------------------------------------------------------------------------
+# C. BehaviorConfig
+# ---------------------------------------------------------------------------
+
+
+class TestBehaviorConfig:
+    def test_construction(self):
+        ops = OperationRules.empty()
+        cfg = BehaviorConfig(read=ops, write=ops, execute=ops)
+        assert cfg.read is ops
+
+    def test_missing_field_raises(self):
+        with pytest.raises(TypeError):
+            BehaviorConfig(read=OperationRules.empty())  # type: ignore[call-arg]
+
+    def test_empty_factory(self):
+        cfg = BehaviorConfig.empty()
+        assert cfg.read.forbidden == []
+        assert cfg.write.forbidden == []
+        assert cfg.execute.forbidden == []
+
+
+# ---------------------------------------------------------------------------
+# D. CheckItem
+# ---------------------------------------------------------------------------
+
+
+class TestCheckItem:
+    def test_required_command(self):
+        item = CheckItem(command="ruff check")
+        assert item.command == "ruff check"
+
+    def test_defaults(self):
+        item = CheckItem(command="ruff check")
+        assert item.timeout == 300
+        assert item.enabled is True
+        assert item.types is None
+        assert item.pass_filenames is True
+
+    def test_all_fields(self):
+        item = CheckItem(
+            command="pytest",
+            timeout=600,
+            enabled=False,
+            types=["python"],
+            pass_filenames=False,
+        )
+        assert item.command == "pytest"
+        assert item.timeout == 600
+        assert item.enabled is False
+        assert item.types == ["python"]
+        assert item.pass_filenames is False
+
+    def test_missing_command_raises(self):
+        with pytest.raises(TypeError):
+            CheckItem()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# E. CodeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCodeConfig:
+    def test_all_defaults(self):
+        cfg = CodeConfig()
+        assert cfg is not None
+
+    def test_defaults_values(self):
+        cfg = CodeConfig()
+        assert cfg.commit_format is True
+        assert cfg.commit_naming is True
+        assert cfg.commit_checks == {}
+        assert cfg.push_lint is True
+        assert cfg.push_checks == {}
+
+    def test_with_check_items(self):
+        cfg = CodeConfig(
+            commit_checks={"license": CheckItem(command="./check-license.sh")},
+            push_checks={"test": CheckItem(command="pytest", timeout=600)},
+        )
+        assert "license" in cfg.commit_checks
+        assert cfg.push_checks["test"].timeout == 600
+
+    def test_default_factory_independence(self):
+        a = CodeConfig()
+        b = CodeConfig()
+        a.commit_checks["x"] = CheckItem(command="x")
+        assert "x" not in b.commit_checks
+
+
+# ---------------------------------------------------------------------------
+# F. LanguageTools
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageTools:
+    def test_construction(self):
+        tools = LanguageTools(format="black", lint="ruff")
+        assert tools.format == "black"
+        assert tools.lint == "ruff"
+
+    def test_missing_field_raises(self):
+        with pytest.raises(TypeError):
+            LanguageTools(format="black")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# G. AuditConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAuditConfig:
+    def test_all_defaults(self):
+        cfg = AuditConfig()
+        assert cfg is not None
+
+    def test_defaults_values(self):
+        cfg = AuditConfig()
+        assert cfg.enabled is True
+        assert cfg.path == ".ai-guard/audit.jsonl"
+        assert cfg.retention == 30
+
+    def test_custom_values(self):
+        cfg = AuditConfig(enabled=False, path="/tmp/audit.jsonl", retention=0)
+        assert cfg.enabled is False
+        assert cfg.path == "/tmp/audit.jsonl"
+        assert cfg.retention == 0
+
+
+# ---------------------------------------------------------------------------
+# H. PrReportConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPrReportConfig:
+    def test_all_defaults(self):
+        cfg = PrReportConfig()
+        assert cfg is not None
+
+    def test_defaults_values(self):
+        cfg = PrReportConfig()
+        assert cfg.enabled is False
+        assert cfg.platform == "github"
+        assert cfg.api_url is None
+        assert cfg.token_env == "GITHUB_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# I. OutputConfig
+# ---------------------------------------------------------------------------
+
+
+class TestOutputConfig:
+    def test_all_defaults(self):
+        cfg = OutputConfig()
+        assert cfg is not None
+
+    def test_defaults_values(self):
+        cfg = OutputConfig()
+        assert cfg.verbosity == "normal"
+        assert cfg.locale == "en"
+        assert isinstance(cfg.audit, AuditConfig)
+        assert isinstance(cfg.pr_report, PrReportConfig)
+
+    def test_nested_custom(self):
+        cfg = OutputConfig(
+            audit=AuditConfig(retention=7),
+            pr_report=PrReportConfig(enabled=True, platform="gitlab"),
+        )
+        assert cfg.audit.retention == 7
+        assert cfg.pr_report.platform == "gitlab"
+
+    def test_default_factory_independence(self):
+        a = OutputConfig()
+        b = OutputConfig()
+        a.audit.retention = 999
+        assert b.audit.retention == 30
+
+
+# ---------------------------------------------------------------------------
+# J. ResolvedConfig
+# ---------------------------------------------------------------------------
+
+
+def _make_resolved_config(**overrides) -> ResolvedConfig:
+    """Build a minimal valid ResolvedConfig for testing."""
+    defaults = dict(
+        version=1,
+        project_name="test-project",
+        project_language="python",
+        behavior=BehaviorConfig.empty(),
+        code=CodeConfig(),
+        languages={"python": LanguageTools(format="black", lint="ruff")},
+        output=OutputConfig(),
+    )
+    defaults.update(overrides)
+    return ResolvedConfig(**defaults)
+
+
+class TestResolvedConfig:
+    def test_construction(self):
+        cfg = _make_resolved_config()
+        assert cfg.version == 1
+        assert cfg.project_name == "test-project"
+
+    def test_required_fields(self):
+        with pytest.raises(TypeError):
+            ResolvedConfig(version=1, project_name="x")  # type: ignore[call-arg]
+
+    def test_optional_defaults(self):
+        cfg = _make_resolved_config()
+        assert cfg.build_command is None
+        assert cfg.config_hash == ""
+
+    def test_full_nested_access(self):
+        cfg = _make_resolved_config(
+            behavior=BehaviorConfig(
+                read=OperationRules.empty(),
+                write=OperationRules(
+                    forbidden=[Rule(pattern="file:vendor/**", reason="no vendor edits")],
+                    require_approval=[],
+                    allow=[Rule(pattern="file:src/**")],
+                ),
+                execute=OperationRules.empty(),
+            ),
+            languages={
+                "python": LanguageTools(format="black", lint="ruff"),
+                "typescript": LanguageTools(format="prettier", lint="eslint"),
+            },
+        )
+        assert cfg.behavior.write.forbidden[0].pattern == "file:vendor/**"
+        assert cfg.behavior.write.forbidden[0].reason == "no vendor edits"
+        assert cfg.behavior.write.allow[0].pattern == "file:src/**"
+        assert cfg.languages["typescript"].lint == "eslint"
+
+
+# ---------------------------------------------------------------------------
+# K. Module exports
+# ---------------------------------------------------------------------------
+
+
+class TestModuleExports:
+    def test_config_package_exports(self):
+        from ai_guard.config import (  # noqa: F401
+            AuditConfig,
+            BehaviorConfig,
+            CheckItem,
+            CodeConfig,
+            LanguageTools,
+            OperationRules,
+            OutputConfig,
+            PrReportConfig,
+            ResolvedConfig,
+            Rule,
+        )
+
+    def test_config_all_list(self):
+        import ai_guard.config as config_mod
+
+        expected = {
+            "Rule",
+            "OperationRules",
+            "BehaviorConfig",
+            "CheckItem",
+            "CodeConfig",
+            "LanguageTools",
+            "AuditConfig",
+            "PrReportConfig",
+            "OutputConfig",
+            "ResolvedConfig",
+        }
+        assert set(config_mod.__all__) == expected


### PR DESCRIPTION
## Summary

- Implement 10 config dataclasses in `src/ai_guard/config/models.py`: Rule, OperationRules, BehaviorConfig, CheckItem, CodeConfig, LanguageTools, AuditConfig, PrReportConfig, OutputConfig, ResolvedConfig
- Add `OperationRules.empty()` and `BehaviorConfig.empty()` factory methods for the config merge pipeline
- Export all models from `ai_guard.config` package with `__all__`

## Test plan

- [x] 38 unit tests covering construction, defaults, required field validation, factory methods, and default_factory independence
- [x] All 41 tests pass (38 new + 3 existing CLI tests)
- [x] ruff lint + format clean
- [x] No external dependencies (stdlib only)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)