### PR TITLE
chore(ci): expand Ruff lint rules for better code quality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,37 @@ target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
+select = [
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "W",      # pycodestyle warnings
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "SIM",    # flake8-simplify
+    "RUF",    # ruff-specific
+    "N",      # pep8-naming
+    "C90",    # mccabe (complexity)
+    "PLR0913", # pylint: too-many-arguments
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "SIM108", # ternary operator (sometimes if-else is clearer)
+    "RUF022", # unsorted-dunder-all (we use comment-grouped __all__)
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 5
 
 [tool.ruff.lint.isort]
 known-first-party = ["ai_guard"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D", "ANN", "ARG", "PLR0913", "C408"]  # relax requirements for tests
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -1,7 +1,5 @@
 """AI Guard CLI entry point."""
 
-from typing import Optional
-
 import typer
 
 from ai_guard import __version__
@@ -16,7 +14,7 @@ app = typer.Typer(
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
-    show_version: Optional[bool] = typer.Option(
+    show_version: bool | None = typer.Option(
         None, "--version", "-V", help="Print version and exit."
     ),
 ) -> None:

--- a/src/ai_guard/config/loader.py
+++ b/src/ai_guard/config/loader.py
@@ -21,7 +21,7 @@ from ai_guard.config.exceptions import (
 )
 from ai_guard.config.validator import validate_raw_config
 
-__all__ = ["load_config", "RawConfig"]
+__all__ = ["RawConfig", "load_config"]
 
 
 # --- RawConfig TypedDicts ---

--- a/src/ai_guard/config/models.py
+++ b/src/ai_guard/config/models.py
@@ -10,16 +10,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 __all__ = [
-    "Rule",
-    "OperationRules",
+    "AuditConfig",
     "BehaviorConfig",
     "CheckItem",
     "CodeConfig",
     "LanguageTools",
-    "AuditConfig",
-    "PrReportConfig",
+    "OperationRules",
     "OutputConfig",
+    "PrReportConfig",
     "ResolvedConfig",
+    "Rule",
 ]
 
 

--- a/src/ai_guard/config/validator.py
+++ b/src/ai_guard/config/validator.py
@@ -188,7 +188,7 @@ _CODE_CONFIG = Dict(fields={"commit": _COMMIT_STAGE, "push": _PUSH_STAGE})
 
 _BUILD_CONFIG = Dict(fields={"command": Str()})
 
-_BEHAVIOR_CONFIG = Dict(fields={op: _OPERATION for op in ("read", "write", "execute")})
+_BEHAVIOR_CONFIG = Dict(fields=dict.fromkeys(("read", "write", "execute"), _OPERATION))
 
 # Root schema
 _ROOT = Dict(
@@ -345,17 +345,21 @@ class _Validator:
                 self._walk(data[name], child_node, child_path)
 
         # Special: validate regex pattern when regex=True
-        if node.check_regex and isinstance(data, dict):
-            if data.get("regex") is True and isinstance(data.get("pattern"), str):
-                try:
-                    re.compile(data["pattern"])
-                except re.error as exc:
-                    pattern_path = f"{path}.pattern" if path else "pattern"
-                    self._add(
-                        pattern_path,
-                        f"invalid regex pattern: {exc}",
-                        data["pattern"],
-                    )
+        if (
+            node.check_regex
+            and isinstance(data, dict)
+            and data.get("regex") is True
+            and isinstance(data.get("pattern"), str)
+        ):
+            try:
+                re.compile(data["pattern"])
+            except re.error as exc:
+                pattern_path = f"{path}.pattern" if path else "pattern"
+                self._add(
+                    pattern_path,
+                    f"invalid regex pattern: {exc}",
+                    data["pattern"],
+                )
 
     def _check_dyndict(self, data: Any, node: DynDict, path: str) -> None:
         if not isinstance(data, dict):


### PR DESCRIPTION
## Summary
- 扩展 Ruff lint 规则，对标 Top 开源项目标准
- 新增复杂度看护（C90, max=10）和参数个数看护（PLR0913, max=5）
- 应用自动修复并验证所有检查通过

## 新增规则

| 类别 | 前缀 | 看护内容 |
|------|------|----------|
| 现代化 | UP | Python 新语法（PEP604 union 等） |
| Bug 预防 | B | 常见 bug 模式检测 |
| 代码质量 | C4, SIM | 推导优化 + 代码简化 |
| 命名规范 | N | PEP8 命名约定 |
| 复杂度 | C90 | McCabe 复杂度 ≤ 10 |
| 参数个数 | PLR0913 | 函数参数 ≤ 5 |
| Ruff 特有 | RUF | Ruff 专属规则 |

## 阈值配置

- 复杂度上限：10（mccabe）
- 参数上限：5（pylint）
- 测试文件放宽：忽略 D/ANN/ARG/PLR0913/C408

## 已应用的自动修复

- UP045: `Optional[X]` → `X | None`（PEP604）
- SIM102: 合并嵌套 if 语句

## Test plan
- [x] Ruff lint 检查通过
- [x] Ruff format 检查通过
- [x] 116 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)