### PR TITLE
feat(config): add config multi-source merger (WP1.2c)

### DIFF
--- a/src/ai_guard/config/__init__.py
+++ b/src/ai_guard/config/__init__.py
@@ -5,9 +5,11 @@ from ai_guard.config.exceptions import (
     ConfigFileNotFoundError,
     ConfigSyntaxError,
     ConfigValidationError,
+    ConfigWarning,
     ValidationIssue,
 )
 from ai_guard.config.loader import RawConfig, load_config
+from ai_guard.config.merger import resolve_config
 from ai_guard.config.models import (
     AuditConfig,
     BehaviorConfig,
@@ -28,10 +30,13 @@ __all__ = [
     "ConfigFileNotFoundError",
     "ConfigSyntaxError",
     "ConfigValidationError",
+    "ConfigWarning",
     "ValidationIssue",
     # Loader
     "load_config",
     "RawConfig",
+    # Merger
+    "resolve_config",
     # Validator
     "validate_raw_config",
     # Models

--- a/src/ai_guard/config/exceptions.py
+++ b/src/ai_guard/config/exceptions.py
@@ -16,6 +16,7 @@ __all__ = [
     "ConfigFileNotFoundError",
     "ConfigSyntaxError",
     "ConfigValidationError",
+    "ConfigWarning",
     "ValidationIssue",
 ]
 
@@ -34,6 +35,14 @@ class ValidationIssue:
     path: str
     message: str
     value: Any = None
+
+
+class ConfigWarning(UserWarning):
+    """Warning for non-fatal config merge issues.
+
+    Emitted when a ``remove`` target is not found (possible typo)
+    or when a ``remove`` targets a system-protected rule.
+    """
 
 
 class ConfigError(Exception):

--- a/src/ai_guard/config/merger.py
+++ b/src/ai_guard/config/merger.py
@@ -1,0 +1,442 @@
+"""Configuration multi-source merger for AI Guard (WP1.2c).
+
+Combines built-in defaults, rulesets, and the project guard.yaml into
+a single :class:`ResolvedConfig`.  Merge semantics follow the design
+document section 5.3:
+
+* **List fields** (forbidden / require_approval / allow) — append.
+* **``remove`` list** — exact-match removal after all sources merged.
+* **``checks`` dict** — deep merge (field-level override per key).
+* **Scalar values** — latter source overrides former.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import warnings
+from pathlib import Path
+from typing import Any
+
+from ai_guard.config.exceptions import ConfigWarning
+from ai_guard.config.loader import (
+    RawConfig,
+    load_config,
+)
+from ai_guard.config.models import (
+    AuditConfig,
+    BehaviorConfig,
+    CheckItem,
+    CodeConfig,
+    LanguageTools,
+    OperationRules,
+    OutputConfig,
+    PrReportConfig,
+    ResolvedConfig,
+    Rule,
+)
+
+__all__ = ["resolve_config"]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BUILTIN_DEFAULTS: RawConfig = {  # type: ignore[typeddict-unknown-key]
+    "version": 1,
+    "project": {"name": "", "language": ""},
+    "behavior": {
+        "read": {},
+        "write": {},
+        "execute": {},
+    },
+    "code": {
+        "commit": {"format": True, "naming": True, "checks": {}},
+        "push": {"lint": True, "checks": {}},
+    },
+    "output": {
+        "verbosity": "normal",
+        "locale": "en",
+        "audit": {"enabled": True, "path": ".ai-guard/audit.jsonl", "retention": 30},
+        "pr_report": {
+            "enabled": False,
+            "platform": "github",
+            "token_env": "GITHUB_TOKEN",
+        },
+    },
+}
+
+_SYSTEM_PROTECTION_PATTERNS: list[str] = [
+    "file:guard.yaml",
+    "file:.ai-guard/**",
+    "file:.pre-commit-config.yaml",
+    "file:.git/hooks/**",
+]
+
+# ---------------------------------------------------------------------------
+# Low-level merge helpers (pure functions — never mutate inputs)
+# ---------------------------------------------------------------------------
+
+
+def _merge_raw_configs(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge *overlay* on top of *base*, returning a new dict."""
+    merged: dict[str, Any] = copy.deepcopy(base)
+
+    for key, value in overlay.items():
+        if key == "behavior":
+            merged["behavior"] = _merge_behavior(merged.get("behavior", {}), value)
+        elif key == "code":
+            merged["code"] = _merge_code(merged.get("code", {}), value)
+        elif key == "output":
+            merged["output"] = _merge_output(merged.get("output", {}), value)
+        elif key == "languages":
+            merged["languages"] = _merge_languages(merged.get("languages", {}), value)
+        elif key == "project":
+            merged["project"] = {**merged.get("project", {}), **value}
+        else:
+            # Scalars (version, build, rulesets, …) — latter wins
+            merged[key] = copy.deepcopy(value)
+
+    return merged
+
+
+def _merge_behavior(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for op in ("read", "write", "execute"):
+        if op in overlay:
+            merged[op] = _merge_operation_rules(merged.get(op, {}), overlay[op])
+    return merged
+
+
+def _merge_operation_rules(
+    base: dict[str, Any], overlay: dict[str, Any]
+) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for tier in ("forbidden", "require_approval", "allow"):
+        if tier in overlay:
+            merged[tier] = merged.get(tier, []) + copy.deepcopy(overlay[tier])
+    # Accumulate remove lists for later processing
+    if "remove" in overlay:
+        merged["remove"] = merged.get("remove", []) + copy.deepcopy(overlay["remove"])
+    return merged
+
+
+def _merge_code(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for stage in ("commit", "push"):
+        if stage in overlay:
+            merged[stage] = _merge_code_stage(merged.get(stage, {}), overlay[stage])
+    return merged
+
+
+def _merge_code_stage(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key == "checks":
+            merged["checks"] = _deep_merge_checks(merged.get("checks", {}), value)
+        else:
+            # Scalar bools (format, naming, lint)
+            merged[key] = value
+    return merged
+
+
+def _deep_merge_checks(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for name, check in overlay.items():
+        if name in merged:
+            merged[name] = {**merged[name], **copy.deepcopy(check)}
+        else:
+            merged[name] = copy.deepcopy(check)
+    return merged
+
+
+def _merge_output(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = {**merged[key], **copy.deepcopy(value)}
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _merge_languages(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for lang, entry in overlay.items():
+        if lang in merged:
+            # Deep-merge the tools sub-dict
+            base_tools = merged[lang].get("tools", {})
+            overlay_tools = entry.get("tools", {})
+            merged[lang] = {"tools": {**base_tools, **overlay_tools}}
+        else:
+            merged[lang] = copy.deepcopy(entry)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Source tagging
+# ---------------------------------------------------------------------------
+
+
+def _tag_rules(raw_config: dict[str, Any], source: str) -> None:
+    """Inject ``_source`` into every rule dict in the behavior section.
+
+    Mutates *raw_config* in place — call on a deep-copied dict.
+    """
+    behavior = raw_config.get("behavior", {})
+    for op in ("read", "write", "execute"):
+        op_rules = behavior.get(op, {})
+        for tier in ("forbidden", "require_approval", "allow"):
+            for rule in op_rules.get(tier, []):
+                rule["_source"] = source
+
+
+# ---------------------------------------------------------------------------
+# System protection rules
+# ---------------------------------------------------------------------------
+
+
+def _inject_system_rules(merged: dict[str, Any]) -> None:
+    """Add system protection rules into ``write.require_approval``.
+
+    Mutates *merged* in place.
+    """
+    behavior = merged.setdefault("behavior", {})
+    write = behavior.setdefault("write", {})
+    ra = write.setdefault("require_approval", [])
+
+    for pattern in _SYSTEM_PROTECTION_PATTERNS:
+        ra.append({"pattern": pattern, "_source": "system"})
+
+
+# ---------------------------------------------------------------------------
+# Remove processing
+# ---------------------------------------------------------------------------
+
+
+def _process_removes(behavior: dict[str, Any]) -> None:
+    """Process and strip ``remove`` lists from *behavior*.
+
+    For each operation type, removes matching rules from the three tiers.
+    Emits :class:`ConfigWarning` for:
+    - remove targets that match no rule (possible typo)
+    - remove targets that match a system-protected rule (immutable)
+
+    Mutates *behavior* in place.
+    """
+    for op in ("read", "write", "execute"):
+        op_rules = behavior.get(op, {})
+        removes = op_rules.pop("remove", [])
+        for remove_entry in removes:
+            pattern = remove_entry.get("pattern", "")
+            found = False
+            for tier in ("forbidden", "require_approval", "allow"):
+                rules_list: list[dict[str, Any]] = op_rules.get(tier, [])
+                for rule in rules_list:
+                    if rule.get("pattern") == pattern:
+                        if rule.get("_source") == "system":
+                            warnings.warn(
+                                f"Cannot remove system-protected rule: {pattern}",
+                                ConfigWarning,
+                                stacklevel=2,
+                            )
+                            found = True
+                            break
+                        rules_list.remove(rule)
+                        found = True
+                        break
+                if found:
+                    break
+            if not found:
+                warnings.warn(
+                    f"Remove target not found (possible typo): {pattern}",
+                    ConfigWarning,
+                    stacklevel=2,
+                )
+
+
+# ---------------------------------------------------------------------------
+# RawConfig → ResolvedConfig conversion
+# ---------------------------------------------------------------------------
+
+
+def _to_resolved_config(
+    merged: dict[str, Any],
+    *,
+    config_hash: str,
+    default_project_name: str,
+) -> ResolvedConfig:
+    """Convert a merged raw dict tree into a :class:`ResolvedConfig`."""
+    project = merged.get("project", {})
+    return ResolvedConfig(
+        version=merged.get("version", 1),
+        project_name=project.get("name") or default_project_name,
+        project_language=project.get("language", ""),
+        behavior=_to_behavior(merged.get("behavior", {})),
+        code=_to_code(merged.get("code", {})),
+        languages=_to_languages(merged.get("languages", {})),
+        output=_to_output(merged.get("output", {})),
+        build_command=merged.get("build", {}).get("command"),
+        config_hash=config_hash,
+    )
+
+
+def _to_behavior(raw: dict[str, Any]) -> BehaviorConfig:
+    return BehaviorConfig(
+        read=_to_operation_rules(raw.get("read", {})),
+        write=_to_operation_rules(raw.get("write", {})),
+        execute=_to_operation_rules(raw.get("execute", {})),
+    )
+
+
+def _to_operation_rules(raw: dict[str, Any]) -> OperationRules:
+    return OperationRules(
+        forbidden=[_to_rule(r) for r in raw.get("forbidden", [])],
+        require_approval=[_to_rule(r) for r in raw.get("require_approval", [])],
+        allow=[_to_rule(r) for r in raw.get("allow", [])],
+    )
+
+
+def _to_rule(raw: dict[str, Any]) -> Rule:
+    return Rule(
+        pattern=raw["pattern"],
+        reason=raw.get("reason"),
+        message=raw.get("message"),
+        regex=raw.get("regex", False),
+        source=raw.get("_source", "user"),
+    )
+
+
+def _to_code(raw: dict[str, Any]) -> CodeConfig:
+    commit = raw.get("commit", {})
+    push = raw.get("push", {})
+    return CodeConfig(
+        commit_format=commit.get("format", True),
+        commit_naming=commit.get("naming", True),
+        commit_checks={
+            name: _to_check_item(item)
+            for name, item in commit.get("checks", {}).items()
+        },
+        push_lint=push.get("lint", True),
+        push_checks={
+            name: _to_check_item(item) for name, item in push.get("checks", {}).items()
+        },
+    )
+
+
+def _to_check_item(raw: dict[str, Any]) -> CheckItem:
+    return CheckItem(
+        command=raw["command"],
+        timeout=raw.get("timeout", 300),
+        enabled=raw.get("enabled", True),
+        types=raw.get("types"),
+        pass_filenames=raw.get("pass_filenames", True),
+    )
+
+
+def _to_languages(raw: dict[str, Any]) -> dict[str, LanguageTools]:
+    result: dict[str, LanguageTools] = {}
+    for lang, entry in raw.items():
+        tools = entry.get("tools", {})
+        result[lang] = LanguageTools(
+            format=tools.get("format", ""),
+            lint=tools.get("lint", ""),
+        )
+    return result
+
+
+def _to_output(raw: dict[str, Any]) -> OutputConfig:
+    audit_raw = raw.get("audit", {})
+    pr_raw = raw.get("pr_report", {})
+    return OutputConfig(
+        verbosity=raw.get("verbosity", "normal"),
+        locale=raw.get("locale", "en"),
+        audit=AuditConfig(
+            enabled=audit_raw.get("enabled", True),
+            path=audit_raw.get("path", ".ai-guard/audit.jsonl"),
+            retention=audit_raw.get("retention", 30),
+        ),
+        pr_report=PrReportConfig(
+            enabled=pr_raw.get("enabled", False),
+            platform=pr_raw.get("platform", "github"),
+            api_url=pr_raw.get("api_url"),
+            token_env=pr_raw.get("token_env", "GITHUB_TOKEN"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config hash
+# ---------------------------------------------------------------------------
+
+
+def _compute_config_hash(path: Path) -> str:
+    """SHA-256 of the guard.yaml file bytes, truncated to 8 hex chars."""
+    data = path.read_bytes()
+    return hashlib.sha256(data).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_config(
+    path: str | Path,
+    *,
+    rulesets: list[tuple[str, RawConfig]] | None = None,
+) -> ResolvedConfig:
+    """Load and merge all config sources into a :class:`ResolvedConfig`.
+
+    Merge order (later wins):
+    ``built-in defaults → rulesets[0] → … → rulesets[N] → guard.yaml``
+
+    Args:
+        path: Path to the project's ``guard.yaml``.
+        rulesets: Pre-loaded rulesets as ``(name, raw_config)`` pairs,
+            in merge order.  Defaults to an empty list.
+
+    Returns:
+        A fully populated :class:`ResolvedConfig`.
+
+    Raises:
+        ConfigFileNotFoundError: ``guard.yaml`` does not exist.
+        ConfigSyntaxError: YAML parsing failed.
+        ConfigValidationError: Schema validation failed.
+    """
+    resolved_path = Path(path)
+
+    # 1. Load and validate the user's guard.yaml (may raise)
+    user_config: dict[str, Any] = dict(load_config(resolved_path))
+
+    # 2. Hash the source file for drift detection
+    config_hash = _compute_config_hash(resolved_path)
+
+    # 3. Start from built-in defaults
+    merged = copy.deepcopy(_BUILTIN_DEFAULTS)
+    _tag_rules(merged, "default")
+
+    # 4. Merge rulesets in order
+    for name, raw in rulesets or []:
+        ruleset_copy: dict[str, Any] = copy.deepcopy(dict(raw))
+        _tag_rules(ruleset_copy, f"ruleset:{name}")
+        merged = _merge_raw_configs(merged, ruleset_copy)
+
+    # 5. Merge user config
+    user_copy: dict[str, Any] = copy.deepcopy(user_config)
+    _tag_rules(user_copy, "user")
+    merged = _merge_raw_configs(merged, user_copy)
+
+    # 6. Inject system protection rules
+    _inject_system_rules(merged)
+
+    # 7. Process remove lists
+    _process_removes(merged.get("behavior", {}))
+
+    # 8. Convert to dataclasses
+    default_project_name = resolved_path.parent.name
+    return _to_resolved_config(
+        merged,
+        config_hash=config_hash,
+        default_project_name=default_project_name,
+    )

--- a/tests/unit/test_config/test_merger.py
+++ b/tests/unit/test_config/test_merger.py
@@ -1,0 +1,746 @@
+"""Tests for config multi-source merger (WP1.2c)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_guard.config.exceptions import (
+    ConfigFileNotFoundError,
+    ConfigSyntaxError,
+    ConfigWarning,
+)
+from ai_guard.config.merger import (
+    _SYSTEM_PROTECTION_PATTERNS,
+    resolve_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(tmp_path: Path, data: dict, filename: str = "guard.yaml") -> Path:
+    """Dump *data* as YAML into a temporary file and return its path."""
+    p = tmp_path / filename
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+def _minimal_guard(**overrides: object) -> dict:
+    """Return a minimal valid guard.yaml dict with optional overrides."""
+    base: dict = {"version": 1, "project": {"language": "python"}}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# TestResolveConfigMinimal
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConfigMinimal:
+    """Minimal guard.yaml produces valid ResolvedConfig with defaults."""
+
+    def test_returns_resolved_config(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.version == 1
+        assert result.project_language == "python"
+
+    def test_project_name_defaults_to_dir_name(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.project_name == tmp_path.name
+
+    def test_explicit_project_name(self, tmp_path: Path) -> None:
+        data = _minimal_guard()
+        data["project"]["name"] = "my-project"
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.project_name == "my-project"
+
+    def test_config_hash_non_empty(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.config_hash
+        assert len(result.config_hash) == 8
+
+    def test_default_code_config(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.code.commit_format is True
+        assert result.code.commit_naming is True
+        assert result.code.push_lint is True
+        assert result.code.commit_checks == {}
+        assert result.code.push_checks == {}
+
+    def test_default_output_config(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.output.verbosity == "normal"
+        assert result.output.locale == "en"
+        assert result.output.audit.enabled is True
+        assert result.output.audit.retention == 30
+        assert result.output.pr_report.enabled is False
+
+    def test_default_behavior_empty(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        # read and execute should be empty
+        assert result.behavior.read.forbidden == []
+        assert result.behavior.execute.forbidden == []
+
+    def test_build_command_none_by_default(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.build_command is None
+
+    def test_no_rulesets(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        # Should work fine with no rulesets
+        assert result.version == 1
+
+
+# ---------------------------------------------------------------------------
+# TestScalarOverride
+# ---------------------------------------------------------------------------
+
+
+class TestScalarOverride:
+    """User guard.yaml overrides built-in default scalars."""
+
+    def test_override_verbosity(self, tmp_path: Path) -> None:
+        data = _minimal_guard(output={"verbosity": "verbose"})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.verbosity == "verbose"
+
+    def test_override_locale(self, tmp_path: Path) -> None:
+        data = _minimal_guard(output={"locale": "zh-CN"})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.locale == "zh-CN"
+
+    def test_override_commit_format(self, tmp_path: Path) -> None:
+        data = _minimal_guard(code={"commit": {"format": False}})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.code.commit_format is False
+        # naming should still be True (from default)
+        assert result.code.commit_naming is True
+
+    def test_override_push_lint(self, tmp_path: Path) -> None:
+        data = _minimal_guard(code={"push": {"lint": False}})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.code.push_lint is False
+
+    def test_build_command(self, tmp_path: Path) -> None:
+        data = _minimal_guard(build={"command": "make build"})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.build_command == "make build"
+
+    def test_audit_retention_override(self, tmp_path: Path) -> None:
+        data = _minimal_guard(output={"audit": {"retention": 90}})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.audit.retention == 90
+        # Other audit fields should keep defaults
+        assert result.output.audit.enabled is True
+        assert result.output.audit.path == ".ai-guard/audit.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# TestRuleListAppend
+# ---------------------------------------------------------------------------
+
+
+class TestRuleListAppend:
+    """Rules from multiple sources are appended, not replaced."""
+
+    def test_user_rules_appended(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            behavior={
+                "read": {
+                    "forbidden": [
+                        {"pattern": "file:**/secret.*", "reason": "no secrets"}
+                    ],
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        patterns = [r.pattern for r in result.behavior.read.forbidden]
+        assert "file:**/secret.*" in patterns
+
+    def test_ruleset_then_user_rules_ordered(self, tmp_path: Path) -> None:
+        ruleset_raw: dict = {
+            "behavior": {
+                "read": {
+                    "forbidden": [{"pattern": "file:*.key"}],
+                },
+            },
+        }
+        data = _minimal_guard(
+            behavior={
+                "read": {
+                    "forbidden": [{"pattern": "file:*.pem"}],
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("company", ruleset_raw)])
+        patterns = [r.pattern for r in result.behavior.read.forbidden]
+        # Ruleset rule comes before user rule
+        assert patterns.index("file:*.key") < patterns.index("file:*.pem")
+
+    def test_multiple_rulesets_append_in_order(self, tmp_path: Path) -> None:
+        rs1: dict = {
+            "behavior": {"execute": {"forbidden": [{"pattern": "shell:rm -rf *"}]}},
+        }
+        rs2: dict = {
+            "behavior": {
+                "execute": {"forbidden": [{"pattern": "shell:drop database"}]}
+            },
+        }
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=[("rs1", rs1), ("rs2", rs2)])
+        patterns = [r.pattern for r in result.behavior.execute.forbidden]
+        assert patterns.index("shell:rm -rf *") < patterns.index("shell:drop database")
+
+
+# ---------------------------------------------------------------------------
+# TestRuleSourceTracking
+# ---------------------------------------------------------------------------
+
+
+class TestRuleSourceTracking:
+    """Each rule is tagged with its origin source."""
+
+    def test_user_rule_source(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            behavior={
+                "read": {"forbidden": [{"pattern": "file:*.env"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        rule = next(
+            r for r in result.behavior.read.forbidden if r.pattern == "file:*.env"
+        )
+        assert rule.source == "user"
+
+    def test_ruleset_rule_source(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "behavior": {"read": {"forbidden": [{"pattern": "file:*.key"}]}},
+        }
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=[("company", rs)])
+        rule = next(
+            r for r in result.behavior.read.forbidden if r.pattern == "file:*.key"
+        )
+        assert rule.source == "ruleset:company"
+
+    def test_system_rule_source(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        system_rules = [
+            r for r in result.behavior.write.require_approval if r.source == "system"
+        ]
+        assert len(system_rules) == len(_SYSTEM_PROTECTION_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# TestSystemProtectionRules
+# ---------------------------------------------------------------------------
+
+
+class TestSystemProtectionRules:
+    """System protection rules are injected and immutable."""
+
+    def test_system_rules_present(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        patterns = [r.pattern for r in result.behavior.write.require_approval]
+        for expected in _SYSTEM_PROTECTION_PATTERNS:
+            assert expected in patterns
+
+    def test_system_rules_count(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        system_rules = [
+            r for r in result.behavior.write.require_approval if r.source == "system"
+        ]
+        assert len(system_rules) == 4
+
+    def test_system_rules_have_correct_source(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        for rule in result.behavior.write.require_approval:
+            if rule.pattern in _SYSTEM_PROTECTION_PATTERNS:
+                assert rule.source == "system"
+
+    def test_user_rules_coexist_with_system_rules(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            behavior={
+                "write": {
+                    "require_approval": [{"pattern": "file:deploy/**"}],
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        patterns = [r.pattern for r in result.behavior.write.require_approval]
+        assert "file:deploy/**" in patterns
+        for expected in _SYSTEM_PROTECTION_PATTERNS:
+            assert expected in patterns
+
+
+# ---------------------------------------------------------------------------
+# TestRemoveProcessing
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveProcessing:
+    """Remove entries remove matching rules; warnings for edge cases."""
+
+    def test_remove_matching_rule(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "behavior": {
+                "read": {"forbidden": [{"pattern": "file:*.log"}]},
+            },
+        }
+        data = _minimal_guard(
+            behavior={
+                "read": {"remove": [{"pattern": "file:*.log"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        patterns = [r.pattern for r in result.behavior.read.forbidden]
+        assert "file:*.log" not in patterns
+
+    def test_remove_nonexistent_warns(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            behavior={
+                "read": {"remove": [{"pattern": "file:nonexistent"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        with pytest.warns(ConfigWarning, match="not found"):
+            resolve_config(path)
+
+    def test_remove_system_rule_warns(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            behavior={
+                "write": {"remove": [{"pattern": "file:guard.yaml"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        with pytest.warns(ConfigWarning, match="system-protected"):
+            result = resolve_config(path)
+        # System rule should still be present
+        patterns = [r.pattern for r in result.behavior.write.require_approval]
+        assert "file:guard.yaml" in patterns
+
+    def test_remove_from_require_approval_tier(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "behavior": {
+                "execute": {
+                    "require_approval": [{"pattern": "shell:docker *"}],
+                },
+            },
+        }
+        data = _minimal_guard(
+            behavior={
+                "execute": {"remove": [{"pattern": "shell:docker *"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        patterns = [r.pattern for r in result.behavior.execute.require_approval]
+        assert "shell:docker *" not in patterns
+
+    def test_remove_from_allow_tier(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "behavior": {
+                "write": {"allow": [{"pattern": "file:tmp/**"}]},
+            },
+        }
+        data = _minimal_guard(
+            behavior={
+                "write": {"remove": [{"pattern": "file:tmp/**"}]},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        patterns = [r.pattern for r in result.behavior.write.allow]
+        assert "file:tmp/**" not in patterns
+
+    def test_multiple_removes(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "behavior": {
+                "read": {
+                    "forbidden": [
+                        {"pattern": "file:*.key"},
+                        {"pattern": "file:*.pem"},
+                        {"pattern": "file:*.env"},
+                    ],
+                },
+            },
+        }
+        data = _minimal_guard(
+            behavior={
+                "read": {
+                    "remove": [
+                        {"pattern": "file:*.key"},
+                        {"pattern": "file:*.pem"},
+                    ],
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        patterns = [r.pattern for r in result.behavior.read.forbidden]
+        assert "file:*.key" not in patterns
+        assert "file:*.pem" not in patterns
+        assert "file:*.env" in patterns
+
+
+# ---------------------------------------------------------------------------
+# TestDeepMergeChecks
+# ---------------------------------------------------------------------------
+
+
+class TestDeepMergeChecks:
+    """checks dicts are deep-merged at the field level."""
+
+    def test_override_check_field(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "code": {
+                "commit": {
+                    "checks": {
+                        "mytest": {"command": "pytest", "timeout": 300},
+                    },
+                },
+            },
+        }
+        data = _minimal_guard(
+            code={
+                "commit": {
+                    "checks": {
+                        "mytest": {"command": "pytest -x", "timeout": 600},
+                    },
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        check = result.code.commit_checks["mytest"]
+        assert check.command == "pytest -x"
+        assert check.timeout == 600
+
+    def test_add_new_check(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "code": {
+                "push": {
+                    "checks": {
+                        "lint": {"command": "ruff check ."},
+                    },
+                },
+            },
+        }
+        data = _minimal_guard(
+            code={
+                "push": {
+                    "checks": {
+                        "typecheck": {"command": "mypy src/"},
+                    },
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        assert "lint" in result.code.push_checks
+        assert "typecheck" in result.code.push_checks
+
+    def test_preserve_unmentioned_check(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "code": {
+                "commit": {
+                    "checks": {
+                        "existing": {"command": "echo ok"},
+                    },
+                },
+            },
+        }
+        data = _minimal_guard(
+            code={
+                "commit": {
+                    "checks": {
+                        "new": {"command": "echo new"},
+                    },
+                },
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        assert "existing" in result.code.commit_checks
+        assert "new" in result.code.commit_checks
+
+    def test_partial_field_override(self, tmp_path: Path) -> None:
+        """Overlay changes only timeout; command preserved from base."""
+        rs: dict = {
+            "code": {
+                "commit": {
+                    "checks": {
+                        "test": {"command": "pytest", "timeout": 300},
+                    },
+                },
+            },
+        }
+        # User guard.yaml must pass validation, so command is required.
+        # But two rulesets can do partial override between them.
+        rs2: dict = {
+            "code": {
+                "commit": {
+                    "checks": {
+                        "test": {"command": "pytest", "timeout": 600},
+                    },
+                },
+            },
+        }
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=[("rs1", rs), ("rs2", rs2)])
+        check = result.code.commit_checks["test"]
+        assert check.command == "pytest"
+        assert check.timeout == 600
+
+
+# ---------------------------------------------------------------------------
+# TestLanguageMerge
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageMerge:
+    """Language tool mappings are deep-merged."""
+
+    def test_add_new_language(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            languages={
+                "python": {"tools": {"format": "black", "lint": "ruff"}},
+                "go": {"tools": {"format": "gofmt", "lint": "golangci-lint"}},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert "python" in result.languages
+        assert "go" in result.languages
+
+    def test_override_existing_tool(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "languages": {
+                "python": {"tools": {"format": "black", "lint": "ruff"}},
+            },
+        }
+        # User guard.yaml must have both format+lint (validator requirement),
+        # but the merge should still override per-field from rulesets.
+        data = _minimal_guard(
+            languages={
+                "python": {"tools": {"format": "ruff format", "lint": "ruff"}},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        assert result.languages["python"].format == "ruff format"
+        assert result.languages["python"].lint == "ruff"
+
+    def test_ruleset_override_between_rulesets(self, tmp_path: Path) -> None:
+        """Rulesets (not validated) can do partial tool override."""
+        rs1: dict = {
+            "languages": {
+                "python": {"tools": {"format": "black", "lint": "ruff"}},
+            },
+        }
+        rs2: dict = {
+            "languages": {
+                "python": {"tools": {"format": "ruff format"}},
+            },
+        }
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=[("rs1", rs1), ("rs2", rs2)])
+        assert result.languages["python"].format == "ruff format"
+        # lint preserved from rs1
+        assert result.languages["python"].lint == "ruff"
+
+    def test_preserve_base_language(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "languages": {
+                "python": {"tools": {"format": "black", "lint": "ruff"}},
+                "go": {"tools": {"format": "gofmt", "lint": "golangci-lint"}},
+            },
+        }
+        data = _minimal_guard(
+            languages={
+                "python": {"tools": {"format": "ruff format", "lint": "ruff"}},
+            }
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        assert "go" in result.languages
+        assert result.languages["go"].format == "gofmt"
+
+
+# ---------------------------------------------------------------------------
+# TestOutputMerge
+# ---------------------------------------------------------------------------
+
+
+class TestOutputMerge:
+    """Output config nested dicts are field-level merged."""
+
+    def test_audit_partial_override(self, tmp_path: Path) -> None:
+        data = _minimal_guard(output={"audit": {"retention": 90}})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.audit.retention == 90
+        assert result.output.audit.enabled is True  # default preserved
+
+    def test_pr_report_partial_override(self, tmp_path: Path) -> None:
+        data = _minimal_guard(
+            output={"pr_report": {"enabled": True, "platform": "gitlab"}}
+        )
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.pr_report.enabled is True
+        assert result.output.pr_report.platform == "gitlab"
+        assert result.output.pr_report.token_env == "GITHUB_TOKEN"  # default
+
+    def test_scalar_override(self, tmp_path: Path) -> None:
+        data = _minimal_guard(output={"verbosity": "quiet", "locale": "zh-CN"})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.output.verbosity == "quiet"
+        assert result.output.locale == "zh-CN"
+
+    def test_ruleset_output_then_user_override(self, tmp_path: Path) -> None:
+        rs: dict = {
+            "output": {"verbosity": "verbose", "audit": {"retention": 60}},
+        }
+        data = _minimal_guard(output={"audit": {"retention": 90}})
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path, rulesets=[("rs", rs)])
+        # User overrides ruleset
+        assert result.output.audit.retention == 90
+        # Ruleset overrides default
+        assert result.output.verbosity == "verbose"
+
+
+# ---------------------------------------------------------------------------
+# TestConfigHash
+# ---------------------------------------------------------------------------
+
+
+class TestConfigHash:
+    """config_hash is a deterministic 8-char hex fingerprint."""
+
+    def test_same_content_same_hash(self, tmp_path: Path) -> None:
+        data = _minimal_guard()
+        sub1 = tmp_path / "a"
+        sub2 = tmp_path / "b"
+        sub1.mkdir()
+        sub2.mkdir()
+        p1 = _write_yaml(sub1, data)
+        p2 = _write_yaml(sub2, data)
+        r1 = resolve_config(p1)
+        r2 = resolve_config(p2)
+        assert r1.config_hash == r2.config_hash
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        d1 = _minimal_guard()
+        d2 = _minimal_guard(output={"verbosity": "verbose"})
+        sub1 = tmp_path / "a"
+        sub2 = tmp_path / "b"
+        sub1.mkdir()
+        sub2.mkdir()
+        p1 = _write_yaml(sub1, d1)
+        p2 = _write_yaml(sub2, d2)
+        r1 = resolve_config(p1)
+        r2 = resolve_config(p2)
+        assert r1.config_hash != r2.config_hash
+
+    def test_hash_is_hex_string(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert len(result.config_hash) == 8
+        int(result.config_hash, 16)  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# TestErrorPropagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    """Errors from loader are propagated through resolve_config."""
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigFileNotFoundError):
+            resolve_config(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "guard.yaml"
+        p.write_text(":\n  :\n    - [invalid", encoding="utf-8")
+        with pytest.raises(ConfigSyntaxError):
+            resolve_config(p)
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_rulesets_list(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=[])
+        assert result.version == 1
+
+    def test_none_rulesets(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path, rulesets=None)
+        assert result.version == 1
+
+    def test_guard_yaml_with_only_project(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.behavior.read.forbidden == []
+        assert result.code.commit_format is True
+
+    def test_no_mutation_of_input(self, tmp_path: Path) -> None:
+        """resolve_config must not mutate the ruleset RawConfig dicts."""
+        rs: dict = {
+            "behavior": {
+                "read": {"forbidden": [{"pattern": "file:*.key"}]},
+            },
+        }
+        import copy
+
+        original = copy.deepcopy(rs)
+        path = _write_yaml(tmp_path, _minimal_guard())
+        resolve_config(path, rulesets=[("rs", rs)])
+        # The _source key should not leak into the original
+        assert "_source" not in rs["behavior"]["read"]["forbidden"][0]
+        assert rs == original
+
+    def test_languages_empty_by_default(self, tmp_path: Path) -> None:
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        assert result.languages == {}

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -363,10 +363,13 @@ class TestModuleExports:
             "ConfigFileNotFoundError",
             "ConfigSyntaxError",
             "ConfigValidationError",
+            "ConfigWarning",
             "ValidationIssue",
             # Loader
             "load_config",
             "RawConfig",
+            # Merger
+            "resolve_config",
             # Validator
             "validate_raw_config",
             # Models


### PR DESCRIPTION
Closes #4

## Summary

- Add `resolve_config()` that merges built-in defaults → rulesets → user guard.yaml into a single `ResolvedConfig`, following design doc §5.3 merge semantics (lists append, scalars override, checks deep-merge, `remove` exact-match deletion)
- Inject 4 system protection rules into `write.require_approval` (immutable, source=`"system"`)
- Track rule origins via `Rule.source` (`"default"` / `"ruleset:<name>"` / `"user" / `"system"`)
- Add `ConfigWarning` for non-fatal merge issues (remove target not found / system-protected)
- Compute 8-char SHA-256 `config_hash` for drift detection

## Changes

| File | Change |
|------|--------|
| `src/ai_guard/config/merger.py` | New — core merger module |
| `src/ai_guard/config/exceptions.py` | Add `ConfigWarning(UserWarning)` |
| `src/ai_guard/config/__init__.py` | Export `resolve_config`, `ConfigWarning` |
| `tests/unit/test_config/test_merger.py` | New — 53 tests across 11 test classes |
| `tests/unit/test_config/test_models.py` | Update `__all__` assertion |

## Test plan

- [x] 53 new merger tests covering: minimal config, scalar override, rule list append, source tracking, system protection rules, remove processing, deep merge checks, language merge, output merge, config hash, error propagation, edge cases
- [x] All 172 tests pass (119 existing + 53 new)
- [x] Ruff lint + format clean
- [x] All pre-commit hooks pass (coverage, docstring, type hints, import deps, security, naming, test structure, path integrity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)