### PR TITLE
feat(generator): add generator core and artifact writing (WP1.3a)

### DIFF
--- a/src/ai_guard/generator/__init__.py
+++ b/src/ai_guard/generator/__init__.py
@@ -1,0 +1,46 @@
+"""Generator module for AI Guard.
+
+Consumes ResolvedConfig and generates all static artifacts (rule docs,
+hook scripts, tool configs, pre-commit config, policy cache, git hooks).
+"""
+
+from ai_guard.generator.core import (
+    create_state,
+    delete_artifacts,
+    read_state,
+    replace_managed_block,
+    wrap_with_managed_block,
+    write_artifacts,
+    write_state,
+)
+from ai_guard.generator.exceptions import (
+    AdapterNotRegisteredError,
+    ArtifactWriteError,
+    GeneratorError,
+    GitDirectoryNotFoundError,
+)
+from ai_guard.generator.models import (
+    STATE_FILE,
+    FileSpec,
+    GeneratedState,
+)
+
+__all__ = [
+    # Exceptions
+    "GeneratorError",
+    "ArtifactWriteError",
+    "GitDirectoryNotFoundError",
+    "AdapterNotRegisteredError",
+    # Models
+    "FileSpec",
+    "GeneratedState",
+    "STATE_FILE",
+    # Core functions
+    "create_state",
+    "delete_artifacts",
+    "read_state",
+    "write_state",
+    "write_artifacts",
+    "replace_managed_block",
+    "wrap_with_managed_block",
+]

--- a/src/ai_guard/generator/core.py
+++ b/src/ai_guard/generator/core.py
@@ -1,0 +1,259 @@
+"""Generator core functions for AI Guard.
+
+Implements state management, managed block handling, and artifact
+writing primitives (G7).
+"""
+
+from __future__ import annotations
+
+import stat
+from datetime import datetime
+from pathlib import Path
+
+from ai_guard import __version__
+from ai_guard.generator.exceptions import ArtifactWriteError
+from ai_guard.generator.models import STATE_FILE, FileSpec, GeneratedState
+
+__all__ = [
+    "read_state",
+    "write_state",
+    "replace_managed_block",
+    "wrap_with_managed_block",
+    "write_artifacts",
+]
+
+# Managed block markers
+MARKER_BEGIN = "<!-- AI-GUARD:BEGIN -->"
+MARKER_END = "<!-- AI-GUARD:END -->"
+
+
+# ---------------------------------------------------------------------------
+# State Management
+# ---------------------------------------------------------------------------
+
+
+def read_state(project_root: Path) -> GeneratedState | None:
+    """Read installation state from .ai-guard/state.json.
+
+    Args:
+        project_root: Path to the project root directory.
+
+    Returns:
+        GeneratedState if state.json exists, None otherwise.
+    """
+    state_path = project_root / STATE_FILE
+    if not state_path.is_file():
+        return None
+    content = state_path.read_text(encoding="utf-8")
+    return GeneratedState.from_json(content)
+
+
+def write_state(project_root: Path, state: GeneratedState) -> None:
+    """Write installation state to .ai-guard/state.json.
+
+    Creates the .ai-guard/ directory if it doesn't exist.
+
+    Args:
+        project_root: Path to the project root directory.
+        state: The GeneratedState to write.
+    """
+    state_path = project_root / STATE_FILE
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(state.to_json(), encoding="utf-8")
+
+
+def create_state(
+    installed_agents: list[str],
+    config_hash: str,
+    artifacts: list[str],
+) -> GeneratedState:
+    """Create a new GeneratedState with current tool version.
+
+    Args:
+        installed_agents: List of agent identifiers being installed.
+        config_hash: Hash of the guard.yaml configuration.
+        artifacts: List of generated artifact paths.
+
+    Returns:
+        A new GeneratedState instance.
+    """
+    return GeneratedState(
+        ai_guard_version=__version__,
+        installed_agents=installed_agents,
+        config_hash=config_hash,
+        installed_at=datetime.now(),
+        artifacts=artifacts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Managed Block Handling
+# ---------------------------------------------------------------------------
+
+
+def wrap_with_managed_block(content: str) -> str:
+    """Wrap content with managed block markers.
+
+    Args:
+        content: The content to wrap.
+
+    Returns:
+        Content wrapped with AI-GUARD markers.
+    """
+    return f"{MARKER_BEGIN}\n{content}\n{MARKER_END}\n"
+
+
+def replace_managed_block(existing_content: str, new_content: str) -> str:
+    """Replace content within managed block markers.
+
+    If markers exist in existing_content, replaces the content between
+    them. If markers don't exist, wraps new_content with markers and
+    appends to existing content.
+
+    Args:
+        existing_content: The existing file content.
+        new_content: The new managed content to insert.
+
+    Returns:
+        Updated content with managed block replaced or appended.
+    """
+    begin_idx = existing_content.find(MARKER_BEGIN)
+    end_idx = existing_content.find(MARKER_END)
+
+    if begin_idx == -1 or end_idx == -1 or begin_idx > end_idx:
+        # Markers not found or malformed — wrap and append
+        wrapped = wrap_with_managed_block(new_content)
+        if existing_content.strip():
+            # Ensure separation from existing content
+            if not existing_content.endswith("\n"):
+                existing_content += "\n"
+            return existing_content + wrapped
+        return wrapped
+
+    # Markers found — replace content between them
+    # Preserve content before BEGIN and after END
+    before = existing_content[:begin_idx]
+    after = existing_content[end_idx + len(MARKER_END) :]
+
+    # Ensure proper line breaks
+    if before and not before.endswith("\n"):
+        before += "\n"
+    if after and not after.startswith("\n"):
+        after = "\n" + after
+
+    return f"{before}{MARKER_BEGIN}\n{new_content}\n{MARKER_END}{after}"
+
+
+# ---------------------------------------------------------------------------
+# Artifact Writing (G7)
+# ---------------------------------------------------------------------------
+
+
+def write_artifacts(  # noqa: C901
+    project_root: Path,
+    artifacts: list[FileSpec],
+    *,
+    dry_run: bool = False,
+) -> list[str]:
+    """Write all artifacts to disk (G7 primitive).
+
+    For each artifact:
+    - Creates parent directories if needed
+    - Handles managed blocks if file exists
+    - Sets executable flag if required
+
+    Args:
+        project_root: Path to the project root directory.
+        artifacts: List of FileSpec objects to write.
+        dry_run: If True, don't actually write files (for preview).
+
+    Returns:
+        List of written artifact paths (relative to project root).
+
+    Raises:
+        ArtifactWriteError: If any file write fails due to permissions.
+    """
+    if dry_run:
+        return [a.path for a in artifacts]
+
+    written_paths: list[str] = []
+    failed_paths: list[str] = []
+
+    for artifact in artifacts:
+        full_path = project_root / artifact.path
+
+        try:
+            # Ensure parent directory exists
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Handle managed blocks for existing files
+            if full_path.is_file():
+                existing = full_path.read_text(encoding="utf-8")
+                # Check if file has managed block markers
+                if MARKER_BEGIN in existing and MARKER_END in existing:
+                    content = replace_managed_block(existing, artifact.content)
+                else:
+                    # No markers — overwrite entirely
+                    content = artifact.content
+            else:
+                # New file — wrap with managed block for rule docs
+                # (hook scripts and configs don't need managed blocks)
+                if artifact.path.endswith(".md"):
+                    content = wrap_with_managed_block(artifact.content)
+                else:
+                    content = artifact.content
+
+            # Write file
+            full_path.write_text(content, encoding="utf-8")
+
+            # Set executable flag if required
+            if artifact.executable:
+                current_mode = full_path.stat().st_mode
+                full_path.chmod(
+                    current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                )
+
+            written_paths.append(artifact.path)
+
+        except PermissionError:
+            failed_paths.append(artifact.path)
+        except OSError as e:
+            # Other I/O errors (disk full, etc.)
+            if "Permission denied" in str(e) or e.errno == 13:
+                failed_paths.append(artifact.path)
+            else:
+                # Re-raise unexpected I/O errors
+                raise
+
+    if failed_paths:
+        raise ArtifactWriteError(failed_paths=failed_paths)
+
+    return written_paths
+
+
+def delete_artifacts(
+    project_root: Path,
+    artifact_paths: list[str],
+) -> list[str]:
+    """Delete previously generated artifacts.
+
+    Used by uninstall command to clean up generated files.
+
+    Args:
+        project_root: Path to the project root directory.
+        artifact_paths: List of artifact paths to delete.
+
+    Returns:
+        List of deleted artifact paths.
+    """
+    deleted: list[str] = []
+    for path in artifact_paths:
+        full_path = project_root / path
+        if full_path.is_file():
+            try:
+                full_path.unlink()
+                deleted.append(path)
+            except PermissionError:
+                # Skip files we can't delete, report later
+                pass
+    return deleted

--- a/src/ai_guard/generator/exceptions.py
+++ b/src/ai_guard/generator/exceptions.py
@@ -1,0 +1,80 @@
+"""Generator error types for AI Guard.
+
+Defines a hierarchy of exceptions for artifact generation and writing.
+All generator-related errors inherit from GeneratorError, allowing
+callers to catch broadly or handle specific failure modes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "AdapterNotRegisteredError",
+    "ArtifactWriteError",
+    "GeneratorError",
+    "GitDirectoryNotFoundError",
+]
+
+
+class GeneratorError(Exception):
+    """Base exception for all generator errors."""
+
+
+@dataclass
+class ArtifactWriteError(GeneratorError):
+    """Raised when artifact file write fails due to permissions.
+
+    Attributes:
+        failed_paths: List of file paths that could not be written.
+    """
+
+    failed_paths: list[str]
+
+    def __str__(self) -> str:
+        paths_str = ", ".join(self.failed_paths)
+        return f"Failed to write artifacts (permission denied): {paths_str}"
+
+
+class GitDirectoryNotFoundError(GeneratorError):
+    """Raised when .git directory does not exist.
+
+    This is a warning-level error — Git Hooks installation is skipped
+    but other artifact generation continues.
+
+    Attributes:
+        project_root: The project root where .git was expected.
+    """
+
+    def __init__(self, project_root: Path) -> None:
+        """Initialize with the project root path.
+
+        Args:
+            project_root: The project root directory.
+        """
+        self.project_root = project_root
+        super().__init__(
+            f".git directory not found in {project_root}. "
+            "Git Hooks installation skipped."
+        )
+
+
+@dataclass
+class AdapterNotRegisteredError(GeneratorError):
+    """Raised when requested agent adapter is not in registry.
+
+    Attributes:
+        agent_name: The agent name that was requested.
+        available_agents: List of registered agent names.
+    """
+
+    agent_name: str
+    available_agents: list[str]
+
+    def __str__(self) -> str:
+        available_str = ", ".join(self.available_agents)
+        return (
+            f"Agent adapter '{self.agent_name}' not registered. "
+            f"Available agents: {available_str}"
+        )

--- a/src/ai_guard/generator/models.py
+++ b/src/ai_guard/generator/models.py
@@ -1,0 +1,92 @@
+"""Generator data models for AI Guard.
+
+Defines dataclasses for artifact generation and state tracking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+
+__all__ = [
+    "FileSpec",
+    "GeneratedState",
+    "STATE_FILE",
+]
+
+# Path to state.json relative to project root
+STATE_FILE: str = ".ai-guard/state.json"
+
+
+@dataclass
+class FileSpec:
+    """A file to be generated and written to disk.
+
+    Attributes:
+        path: File path relative to project root.
+        content: File content as string.
+        executable: Whether the file should have executable permissions.
+    """
+
+    path: str
+    content: str
+    executable: bool = False
+
+
+@dataclass
+class GeneratedState:
+    """Installation state tracking for AI Guard artifacts.
+
+    Stored in .ai-guard/state.json to track what was installed,
+    enabling update and uninstall operations.
+
+    Attributes:
+        ai_guard_version: Tool version at install time.
+        installed_agents: List of installed agent identifiers.
+        config_hash: SHA hash of guard.yaml at install time.
+        installed_at: ISO timestamp of installation.
+        artifacts: List of generated file paths (relative to project root).
+    """
+
+    ai_guard_version: str
+    installed_agents: list[str] = field(default_factory=list)
+    config_hash: str = ""
+    installed_at: datetime = field(default_factory=datetime.now)
+    artifacts: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary suitable for JSON serialization."""
+        return {
+            "ai_guard_version": self.ai_guard_version,
+            "installed_agents": self.installed_agents,
+            "config_hash": self.config_hash,
+            "installed_at": self.installed_at.isoformat(),
+            "artifacts": self.artifacts,
+        }
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> GeneratedState:
+        """Create from dictionary (parsed from JSON)."""
+        installed_at = data.get("installed_at")
+        if isinstance(installed_at, str):
+            installed_at = datetime.fromisoformat(installed_at)
+        elif installed_at is None:
+            installed_at = datetime.now()
+        return cls(
+            ai_guard_version=data.get("ai_guard_version", "0.1.0"),
+            installed_agents=data.get("installed_agents", []),
+            config_hash=data.get("config_hash", ""),
+            installed_at=installed_at,
+            artifacts=data.get("artifacts", []),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> GeneratedState:
+        """Create from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -226,6 +227,9 @@ class TestWriteArtifacts:
         assert (tmp_path / "deep" / "path" / "to" / "file.txt").is_file()
 
     def test_sets_executable_flag(self, tmp_path: Path) -> None:
+        # Unix executable bits don't work on Windows
+        if sys.platform == "win32":
+            pytest.skip("Executable flag is Unix-specific")
         artifacts = [
             FileSpec(path="script.sh", content="#!/bin/bash", executable=True),
         ]
@@ -294,6 +298,9 @@ class TestWriteArtifacts:
     def test_raises_artifact_write_error_on_permission_denied(
         self, tmp_path: Path
     ) -> None:
+        # Windows doesn't support Unix-style permission restrictions
+        if sys.platform == "win32":
+            pytest.skip("Unix permission tests don't work on Windows")
         # This test is tricky on most systems; skip if we can't create
         # a permission-restricted directory
         if not tmp_path.exists():

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -1,0 +1,361 @@
+"""Tests for generator core functions."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from ai_guard.generator.core import (
+    MARKER_BEGIN,
+    MARKER_END,
+    create_state,
+    delete_artifacts,
+    read_state,
+    replace_managed_block,
+    wrap_with_managed_block,
+    write_artifacts,
+    write_state,
+)
+from ai_guard.generator.exceptions import ArtifactWriteError
+from ai_guard.generator.models import STATE_FILE, FileSpec, GeneratedState
+
+# ---------------------------------------------------------------------------
+# State Management Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadState:
+    """read_state function tests."""
+
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        result = read_state(tmp_path)
+        assert result is None
+
+    def test_returns_state_when_file_exists(self, tmp_path: Path) -> None:
+        state_data = {
+            "ai_guard_version": "0.1.0",
+            "installed_agents": ["claude-code"],
+            "config_hash": "abc123",
+            "installed_at": "2026-04-16T12:00:00",
+            "artifacts": ["CLAUDE.md"],
+        }
+        state_file = tmp_path / STATE_FILE
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps(state_data), encoding="utf-8")
+
+        result = read_state(tmp_path)
+        assert result is not None
+        assert result.ai_guard_version == "0.1.0"
+        assert result.installed_agents == ["claude-code"]
+
+    def test_handles_empty_state_file(self, tmp_path: Path) -> None:
+        state_file = tmp_path / STATE_FILE
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("{}", encoding="utf-8")
+
+        result = read_state(tmp_path)
+        assert result is not None
+        assert result.installed_agents == []
+
+
+class TestWriteState:
+    """write_state function tests."""
+
+    def test_creates_ai_guard_directory(self, tmp_path: Path) -> None:
+        state = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code"],
+            config_hash="abc",
+            installed_at=datetime.now(),
+            artifacts=["x"],
+        )
+        write_state(tmp_path, state)
+        assert (tmp_path / ".ai-guard").is_dir()
+        assert (tmp_path / STATE_FILE).is_file()
+
+    def test_writes_valid_json(self, tmp_path: Path) -> None:
+        state = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code", "cursor"],
+            config_hash="abc123",
+            installed_at=datetime(2026, 4, 16, 14, 0, 0),
+            artifacts=["CLAUDE.md", ".cursor/rules"],
+        )
+        write_state(tmp_path, state)
+
+        content = (tmp_path / STATE_FILE).read_text(encoding="utf-8")
+        data = json.loads(content)
+        assert data["ai_guard_version"] == "0.1.0"
+        assert data["installed_agents"] == ["claude-code", "cursor"]
+
+    def test_overwrites_existing_state(self, tmp_path: Path) -> None:
+        # Write initial state
+        state1 = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code"],
+            installed_at=datetime.now(),
+        )
+        write_state(tmp_path, state1)
+
+        # Write updated state
+        state2 = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code", "cursor"],
+            installed_at=datetime.now(),
+        )
+        write_state(tmp_path, state2)
+
+        result = read_state(tmp_path)
+        assert result is not None
+        assert result.installed_agents == ["claude-code", "cursor"]
+
+
+class TestCreateState:
+    """create_state function tests."""
+
+    def test_creates_state_with_current_version(self) -> None:
+        state = create_state(
+            installed_agents=["claude-code"],
+            config_hash="abc123",
+            artifacts=["CLAUDE.md"],
+        )
+        assert state.ai_guard_version == "0.1.0"
+        assert state.installed_agents == ["claude-code"]
+        assert state.config_hash == "abc123"
+        assert state.artifacts == ["CLAUDE.md"]
+        # installed_at should be recent
+        now = datetime.now()
+        delta = now - state.installed_at
+        assert delta.total_seconds() < 5
+
+
+# ---------------------------------------------------------------------------
+# Managed Block Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWrapWithManagedBlock:
+    """wrap_with_managed_block function tests."""
+
+    def test_wraps_content(self) -> None:
+        content = "This is managed content."
+        result = wrap_with_managed_block(content)
+        assert result.startswith(MARKER_BEGIN)
+        assert result.endswith(MARKER_END + "\n")
+        assert "This is managed content." in result
+
+    def test_includes_both_markers(self) -> None:
+        result = wrap_with_managed_block("test")
+        assert MARKER_BEGIN in result
+        assert MARKER_END in result
+        # BEGIN should come before END
+        assert result.find(MARKER_BEGIN) < result.find(MARKER_END)
+
+
+class TestReplaceManagedBlock:
+    """replace_managed_block function tests."""
+
+    def test_replaces_content_inside_markers(self) -> None:
+        existing = f"Header\n{MARKER_BEGIN}\nOld content\n{MARKER_END}\nFooter"
+        new = "New content"
+        result = replace_managed_block(existing, new)
+        assert "Header" in result
+        assert "Footer" in result
+        assert "Old content" not in result
+        assert "New content" in result
+
+    def test_preserves_content_before_markers(self) -> None:
+        existing = f"Keep this\n{MARKER_BEGIN}\nReplace this\n{MARKER_END}\n"
+        result = replace_managed_block(existing, "New")
+        assert "Keep this" in result
+
+    def test_preserves_content_after_markers(self) -> None:
+        existing = f"{MARKER_BEGIN}\nReplace\n{MARKER_END}\nKeep this too\n"
+        result = replace_managed_block(existing, "New")
+        assert "Keep this too" in result
+
+    def test_appends_wrapped_content_when_markers_missing(self) -> None:
+        existing = "Existing content without markers"
+        result = replace_managed_block(existing, "New managed content")
+        assert "Existing content without markers" in result
+        assert MARKER_BEGIN in result
+        assert MARKER_END in result
+        assert "New managed content" in result
+
+    def test_handles_empty_existing_content(self) -> None:
+        result = replace_managed_block("", "New content")
+        assert MARKER_BEGIN in result
+        assert "New content" in result
+        assert MARKER_END in result
+
+    def test_handles_multiline_content(self) -> None:
+        existing = f"{MARKER_BEGIN}\nLine 1\nLine 2\n{MARKER_END}\n"
+        new = "New line A\nNew line B"
+        result = replace_managed_block(existing, new)
+        assert "New line A" in result
+        assert "New line B" in result
+
+
+# ---------------------------------------------------------------------------
+# Artifact Writing Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteArtifacts:
+    """write_artifacts function tests."""
+
+    def test_creates_files(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="test.txt", content="hello"),
+            FileSpec(path="subdir/nested.txt", content="nested content"),
+        ]
+        written = write_artifacts(tmp_path, artifacts)
+        assert "test.txt" in written
+        assert "subdir/nested.txt" in written
+        assert (tmp_path / "test.txt").read_text() == "hello"
+        assert (tmp_path / "subdir" / "nested.txt").read_text() == "nested content"
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="deep/path/to/file.txt", content="x"),
+        ]
+        write_artifacts(tmp_path, artifacts)
+        assert (tmp_path / "deep" / "path" / "to" / "file.txt").is_file()
+
+    def test_sets_executable_flag(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="script.sh", content="#!/bin/bash", executable=True),
+        ]
+        write_artifacts(tmp_path, artifacts)
+        file_path = tmp_path / "script.sh"
+        # Check if file is executable (at least user-executable)
+        mode = file_path.stat().st_mode
+        assert mode & 0o111  # Any executable bit set
+
+    def test_wraps_md_files_with_managed_block(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="CLAUDE.md", content="# Rules\n\nDo this."),
+        ]
+        write_artifacts(tmp_path, artifacts)
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert MARKER_BEGIN in content
+        assert MARKER_END in content
+        assert "# Rules" in content
+
+    def test_does_not_wrap_non_md_files(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="config.yaml", content="key: value"),
+        ]
+        write_artifacts(tmp_path, artifacts)
+        content = (tmp_path / "config.yaml").read_text()
+        assert MARKER_BEGIN not in content
+        assert content == "key: value"
+
+    def test_replaces_managed_block_in_existing_file(self, tmp_path: Path) -> None:
+        # Create existing file with managed block
+        existing = f"User header\n{MARKER_BEGIN}\nOld rules\n{MARKER_END}\nUser footer"
+        (tmp_path / "CLAUDE.md").write_text(existing)
+
+        # Write new content
+        artifacts = [
+            FileSpec(path="CLAUDE.md", content="New rules"),
+        ]
+        write_artifacts(tmp_path, artifacts)
+
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert "User header" in content
+        assert "User footer" in content
+        assert "Old rules" not in content
+        assert "New rules" in content
+
+    def test_overwrites_file_without_markers(self, tmp_path: Path) -> None:
+        # Create existing file without markers
+        (tmp_path / "config.yaml").write_text("old: content")
+
+        artifacts = [
+            FileSpec(path="config.yaml", content="new: content"),
+        ]
+        write_artifacts(tmp_path, artifacts)
+
+        content = (tmp_path / "config.yaml").read_text()
+        assert content == "new: content"
+
+    def test_dry_run_returns_paths_without_writing(self, tmp_path: Path) -> None:
+        artifacts = [
+            FileSpec(path="test.txt", content="hello"),
+        ]
+        written = write_artifacts(tmp_path, artifacts, dry_run=True)
+        assert written == ["test.txt"]
+        assert not (tmp_path / "test.txt").exists()
+
+    def test_raises_artifact_write_error_on_permission_denied(
+        self, tmp_path: Path
+    ) -> None:
+        # This test is tricky on most systems; skip if we can't create
+        # a permission-restricted directory
+        if not tmp_path.exists():
+            pytest.skip("Cannot test permission errors reliably")
+
+        # Create a read-only directory (may not work on all platforms)
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        try:
+            readonly_dir.chmod(0o444)  # Read-only
+        except OSError:
+            pytest.skip("Cannot set directory permissions on this platform")
+
+        try:
+            artifacts = [
+                FileSpec(path="readonly/test.txt", content="x"),
+            ]
+            with pytest.raises(ArtifactWriteError) as exc_info:
+                write_artifacts(tmp_path, artifacts)
+            assert "readonly/test.txt" in exc_info.value.failed_paths
+        finally:
+            # Restore permissions for cleanup
+            readonly_dir.chmod(0o755)
+
+
+class TestDeleteArtifacts:
+    """delete_artifacts function tests."""
+
+    def test_deletes_existing_files(self, tmp_path: Path) -> None:
+        # Create some files
+        (tmp_path / "file1.txt").write_text("x")
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "subdir" / "file2.txt").write_text("y")
+
+        deleted = delete_artifacts(tmp_path, ["file1.txt", "subdir/file2.txt"])
+        assert "file1.txt" in deleted
+        assert "subdir/file2.txt" in deleted
+        assert not (tmp_path / "file1.txt").exists()
+
+    def test_skips_nonexistent_files(self, tmp_path: Path) -> None:
+        deleted = delete_artifacts(tmp_path, ["nonexistent.txt"])
+        assert deleted == []
+
+    def test_returns_deleted_paths(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("x")
+        (tmp_path / "b.txt").write_text("y")
+        deleted = delete_artifacts(tmp_path, ["a.txt", "b.txt", "c.txt"])
+        assert "a.txt" in deleted
+        assert "b.txt" in deleted
+        assert "c.txt" not in deleted
+
+
+# ---------------------------------------------------------------------------
+# Marker Constants Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerConstants:
+    """Marker constant tests."""
+
+    def test_marker_begin_format(self) -> None:
+        assert MARKER_BEGIN == "<!-- AI-GUARD:BEGIN -->"
+
+    def test_marker_end_format(self) -> None:
+        assert MARKER_END == "<!-- AI-GUARD:END -->"

--- a/tests/unit/test_generator/test_exceptions.py
+++ b/tests/unit/test_generator/test_exceptions.py
@@ -1,0 +1,90 @@
+"""Tests for generator exceptions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ai_guard.generator.exceptions import (
+    AdapterNotRegisteredError,
+    ArtifactWriteError,
+    GeneratorError,
+    GitDirectoryNotFoundError,
+)
+
+
+class TestGeneratorError:
+    """GeneratorError base exception tests."""
+
+    def test_is_exception(self) -> None:
+        assert issubclass(GeneratorError, Exception)
+
+    def test_can_raise(self) -> None:
+        with pytest.raises(GeneratorError):
+            raise GeneratorError("test error")
+
+    def test_message(self) -> None:
+        try:
+            raise GeneratorError("test message")
+        except GeneratorError as e:
+            assert str(e) == "test message"
+
+
+class TestArtifactWriteError:
+    """ArtifactWriteError tests."""
+
+    def test_failed_paths_attribute(self) -> None:
+        err = ArtifactWriteError(failed_paths=["a.txt", "b.txt"])
+        assert err.failed_paths == ["a.txt", "b.txt"]
+
+    def test_str_contains_paths(self) -> None:
+        err = ArtifactWriteError(failed_paths=["file1.txt", "file2.txt"])
+        assert "file1.txt" in str(err)
+        assert "file2.txt" in str(err)
+        assert "permission denied" in str(err)
+
+    def test_inherits_generator_error(self) -> None:
+        assert issubclass(ArtifactWriteError, GeneratorError)
+
+
+class TestGitDirectoryNotFoundError:
+    """GitDirectoryNotFoundError tests."""
+
+    def test_project_root_attribute(self) -> None:
+        path = Path("/tmp/project")
+        err = GitDirectoryNotFoundError(path)
+        assert err.project_root == path
+
+    def test_message_contains_path(self) -> None:
+        path = Path("/tmp/myproject")
+        err = GitDirectoryNotFoundError(path)
+        assert "myproject" in str(err)
+        assert ".git" in str(err)
+
+    def test_inherits_generator_error(self) -> None:
+        assert issubclass(GitDirectoryNotFoundError, GeneratorError)
+
+
+class TestAdapterNotRegisteredError:
+    """AdapterNotRegisteredError tests."""
+
+    def test_attributes(self) -> None:
+        err = AdapterNotRegisteredError(
+            agent_name="unknown-agent",
+            available_agents=["claude-code", "cursor"],
+        )
+        assert err.agent_name == "unknown-agent"
+        assert err.available_agents == ["claude-code", "cursor"]
+
+    def test_str_contains_agent_name(self) -> None:
+        err = AdapterNotRegisteredError(
+            agent_name="myagent",
+            available_agents=["agent1", "agent2"],
+        )
+        assert "myagent" in str(err)
+        assert "agent1" in str(err)
+        assert "agent2" in str(err)
+
+    def test_inherits_generator_error(self) -> None:
+        assert issubclass(AdapterNotRegisteredError, GeneratorError)

--- a/tests/unit/test_generator/test_models.py
+++ b/tests/unit/test_generator/test_models.py
@@ -1,0 +1,127 @@
+"""Tests for generator data models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ai_guard.generator.models import (
+    STATE_FILE,
+    FileSpec,
+    GeneratedState,
+)
+
+
+class TestFileSpec:
+    """FileSpec dataclass tests."""
+
+    def test_basic_construction(self) -> None:
+        fs = FileSpec(path="test.txt", content="hello")
+        assert fs.path == "test.txt"
+        assert fs.content == "hello"
+        assert fs.executable is False
+
+    def test_executable_flag(self) -> None:
+        fs = FileSpec(path="script.sh", content="#!/bin/bash", executable=True)
+        assert fs.executable is True
+
+    def test_defaults(self) -> None:
+        fs = FileSpec(path="x", content="y")
+        assert fs.executable is False
+
+
+class TestGeneratedState:
+    """GeneratedState dataclass and serialization tests."""
+
+    def test_basic_construction(self) -> None:
+        now = datetime.now()
+        state = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code"],
+            config_hash="abc123",
+            installed_at=now,
+            artifacts=["CLAUDE.md"],
+        )
+        assert state.ai_guard_version == "0.1.0"
+        assert state.installed_agents == ["claude-code"]
+        assert state.config_hash == "abc123"
+        assert state.installed_at == now
+        assert state.artifacts == ["CLAUDE.md"]
+
+    def test_defaults(self) -> None:
+        state = GeneratedState(ai_guard_version="0.1.0")
+        assert state.installed_agents == []
+        assert state.config_hash == ""
+        assert state.artifacts == []
+
+    def test_to_dict(self) -> None:
+        now = datetime(2026, 4, 16, 12, 0, 0)
+        state = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code", "cursor"],
+            config_hash="abc123",
+            installed_at=now,
+            artifacts=["CLAUDE.md", ".claude/settings.json"],
+        )
+        d = state.to_dict()
+        assert d["ai_guard_version"] == "0.1.0"
+        assert d["installed_agents"] == ["claude-code", "cursor"]
+        assert d["config_hash"] == "abc123"
+        assert d["installed_at"] == "2026-04-16T12:00:00"
+        assert d["artifacts"] == ["CLAUDE.md", ".claude/settings.json"]
+
+    def test_to_json(self) -> None:
+        state = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code"],
+            config_hash="abc",
+            installed_at=datetime(2026, 4, 16, 12, 0, 0),
+            artifacts=["x"],
+        )
+        json_str = state.to_json()
+        assert '"ai_guard_version": "0.1.0"' in json_str
+        assert '"installed_agents"' in json_str
+
+    def test_from_dict(self) -> None:
+        d = {
+            "ai_guard_version": "0.2.0",
+            "installed_agents": ["cursor"],
+            "config_hash": "def456",
+            "installed_at": "2026-04-15T10:30:00",
+            "artifacts": ["file1", "file2"],
+        }
+        state = GeneratedState.from_dict(d)
+        assert state.ai_guard_version == "0.2.0"
+        assert state.installed_agents == ["cursor"]
+        assert state.config_hash == "def456"
+        assert state.installed_at == datetime(2026, 4, 15, 10, 30, 0)
+        assert state.artifacts == ["file1", "file2"]
+
+    def test_from_dict_missing_fields(self) -> None:
+        d = {"ai_guard_version": "0.1.0"}
+        state = GeneratedState.from_dict(d)
+        assert state.installed_agents == []
+        assert state.config_hash == ""
+        assert state.artifacts == []
+
+    def test_json_roundtrip(self) -> None:
+        original = GeneratedState(
+            ai_guard_version="0.1.0",
+            installed_agents=["claude-code", "cursor"],
+            config_hash="abc123",
+            installed_at=datetime(2026, 4, 16, 14, 30, 0),
+            artifacts=["CLAUDE.md", ".cursor/rules/behavior.mdc"],
+        )
+        json_str = original.to_json()
+        restored = GeneratedState.from_json(json_str)
+        assert restored.ai_guard_version == original.ai_guard_version
+        assert restored.installed_agents == original.installed_agents
+        assert restored.config_hash == original.config_hash
+        assert restored.installed_at == original.installed_at
+        assert restored.artifacts == original.artifacts
+
+
+class TestConstants:
+    """Module constants tests."""
+
+    def test_state_file_path(self) -> None:
+        assert STATE_FILE == ".ai-guard/state.json"


### PR DESCRIPTION
Closes #5

## Summary

- Implement Generator foundation with `FileSpec` and `GeneratedState` dataclasses
- Add `write_artifacts` primitive (G7) with managed block handling for rule documents
- Add `state.json` read/write for installation tracking (`.ai-guard/state.json`)
- Add managed block mechanism with `<!-- AI-GUARD:BEGIN -->` / `<!-- AI-GUARD:END -->` markers
- Add `delete_artifacts` for uninstall cleanup
- Add exception hierarchy: `GeneratorError`, `ArtifactWriteError`, `GitDirectoryNotFoundError`, `AdapterNotRegisteredError`

This is the foundation for WP1.3b (rule docs + hooks) and WP1.3c (tool configs + pre-commit).

## Changes

| File | Action |
|------|--------|
| `src/ai_guard/generator/models.py` | New — FileSpec, GeneratedState dataclasses |
| `src/ai_guard/generator/core.py` | New — write_artifacts, state management, managed blocks |
| `src/ai_guard/generator/exceptions.py` | New — Generator exception hierarchy |
| `src/ai_guard/generator/__init__.py` | Edit — exports |
| `tests/unit/test_generator/test_models.py` | New — 12 tests |
| `tests/unit/test_generator/test_core.py` | New — 28 tests |
| `tests/unit/test_generator/test_exceptions.py` | New — 12 tests |

## Test plan

- [x] 52 new generator tests (models: 12, core: 28, exceptions: 12)
- [x] All 224 tests pass (172 existing + 52 new)
- [x] Ruff lint + format clean
- [x] All pre-commit hooks pass (coverage, docstring, type hints, import deps, security, naming, test structure, path integrity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)