### PR TITLE
feat(cli): add install, update, uninstall commands (WP1.5b)

### DIFF
--- a/src/ai_guard/cli/install.py
+++ b/src/ai_guard/cli/install.py
@@ -1,0 +1,334 @@
+"""install, update, and uninstall command implementations for AI Guard CLI.
+
+Orchestrates config loading, adapter resolution, generator pipeline (G1-G7),
+and state management to manage AI Guard artifact lifecycle.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+from ai_guard.adapters.base import AgentAdapter
+from ai_guard.adapters.registry import AdapterNotFoundError, get_adapter, list_adapters
+from ai_guard.config.exceptions import (
+    ConfigError,
+)
+from ai_guard.config.loader import load_config
+from ai_guard.config.merger import resolve_config
+from ai_guard.config.models import ResolvedConfig
+from ai_guard.generator.core import (
+    create_state,
+    delete_artifacts,
+    generate_git_hooks,
+    generate_hook_files,
+    generate_policy_cache,
+    generate_precommit_config,
+    generate_rule_docs,
+    generate_tool_configs,
+    read_state,
+    write_artifacts,
+    write_state,
+)
+from ai_guard.generator.exceptions import ArtifactWriteError
+from ai_guard.generator.models import STATE_FILE
+
+__all__ = ["install_command", "update_command", "uninstall_command"]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_adapters(agent_names: list[str]) -> list[AgentAdapter]:
+    """Resolve agent names to adapter instances.
+
+    Args:
+        agent_names: List of agent identifiers.
+
+    Returns:
+        List of AgentAdapter instances.
+
+    Raises:
+        AdapterNotFoundError: If any name is not registered.
+    """
+    return [get_adapter(name) for name in agent_names]
+
+
+def _run_generator_pipeline(
+    resolved_config: ResolvedConfig,
+    adapters: list[AgentAdapter],
+    project_root: Path,
+    rulesets: list[str],
+) -> list[str]:
+    """Run G1-G7 generator primitives and write artifacts.
+
+    Args:
+        resolved_config: Fully resolved configuration.
+        adapters: List of agent adapters to generate for.
+        project_root: Path to project root directory.
+        rulesets: List of ruleset names for tool config generation.
+
+    Returns:
+        List of written artifact paths (relative to project root).
+
+    Raises:
+        ArtifactWriteError: If file writes fail.
+    """
+    from ai_guard.shared.types import FileSpec
+
+    artifacts: list[FileSpec] = []
+
+    # G1: Rule documents
+    artifacts.extend(generate_rule_docs(adapters, resolved_config.behavior))
+
+    # G2: Hook files
+    artifacts.extend(generate_hook_files(adapters, resolved_config.behavior))
+
+    # G3: Tool configs from rulesets
+    artifacts.extend(generate_tool_configs(project_root, rulesets))
+
+    # G4: Pre-commit config
+    artifacts.append(
+        generate_precommit_config(resolved_config.code, resolved_config.languages)
+    )
+
+    # G5: Policy cache
+    artifacts.append(
+        generate_policy_cache(resolved_config.behavior, resolved_config.config_hash)
+    )
+
+    # G6: Git hooks
+    git_hooks = generate_git_hooks(project_root)
+    if not git_hooks:
+        print("Warning: .git directory not found. Git hooks were not installed.")
+    artifacts.extend(git_hooks)
+
+    # G7: Write all artifacts to disk
+    return write_artifacts(project_root, artifacts)
+
+
+def _print_available_agents() -> None:
+    """Print list of available agents with capabilities."""
+    print("Available agents:")
+    for name in list_adapters():
+        adapter = get_adapter(name)
+        caps = adapter.capabilities
+        cap_desc = []
+        if caps.can_block:
+            cap_desc.append("can block")
+        if caps.can_ask:
+            cap_desc.append("can ask")
+        if not cap_desc:
+            cap_desc.append("rule docs only")
+        print(f"  {name:<15} ({' + '.join(cap_desc)})")
+    print("\nUsage: guard install --agent <name>[,<name>,...]")
+
+
+def _print_install_summary(
+    written_paths: list[str],
+    agents: list[str],
+) -> None:
+    """Print installation summary.
+
+    Args:
+        written_paths: List of artifact paths written.
+        agents: List of installed agent names.
+    """
+    print(f"\nAI Guard installed for: {', '.join(agents)}")
+    print(f"\nGenerated {len(written_paths)} artifact(s):")
+    for path in sorted(written_paths):
+        print(f"  {path}")
+
+
+def _merge_agents(existing: list[str], new: list[str]) -> list[str]:
+    """Merge new agents into existing list, preserving order and deduplicating.
+
+    Args:
+        existing: Previously installed agent names.
+        new: New agent names to add.
+
+    Returns:
+        Merged list with no duplicates.
+    """
+    seen = set(existing)
+    merged = list(existing)
+    for name in new:
+        if name not in seen:
+            merged.append(name)
+            seen.add(name)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public command functions
+# ---------------------------------------------------------------------------
+
+
+def install_command(
+    agents: list[str],
+    project_root: Path,
+    config_path: Path,
+) -> None:
+    """Execute the install command.
+
+    Without agents, lists available agents. With agents, generates
+    all artifacts and updates installation state.
+
+    Args:
+        agents: Agent names to install (empty to list available).
+        project_root: Path to project root directory.
+        config_path: Path to guard.yaml.
+    """
+    if not agents:
+        _print_available_agents()
+        return
+
+    # Normalize agent names
+    agents = [a.strip().lower() for a in agents if a.strip()]
+
+    # Validate all agent names first
+    available = list_adapters()
+    unknown = [name for name in agents if name not in available]
+    if unknown:
+        print(
+            f"Error: Unknown agent(s): {', '.join(unknown)}. "
+            f"Available: {', '.join(available)}"
+        )
+        raise SystemExit(1)
+
+    # Load and resolve config
+    try:
+        raw_config = load_config(config_path)
+        resolved = resolve_config(config_path)
+    except ConfigError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None
+
+    rulesets: list[str] = raw_config.get("rulesets", [])
+
+    # Read existing state for incremental install
+    existing_state = read_state(project_root)
+    existing_agents = existing_state.installed_agents if existing_state else []
+    all_agents = _merge_agents(existing_agents, agents)
+
+    # Resolve all adapters
+    adapters = _resolve_adapters(all_agents)
+
+    # Run generator pipeline
+    try:
+        written_paths = _run_generator_pipeline(
+            resolved, adapters, project_root, rulesets
+        )
+    except ArtifactWriteError as e:
+        print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")
+        raise SystemExit(1) from None
+
+    # Update state
+    state = create_state(all_agents, resolved.config_hash, written_paths)
+    write_state(project_root, state)
+
+    _print_install_summary(written_paths, all_agents)
+
+
+def update_command(
+    project_root: Path,
+    config_path: Path,
+) -> None:
+    """Execute the update command.
+
+    Re-generates all artifacts for previously installed agents.
+
+    Args:
+        project_root: Path to project root directory.
+        config_path: Path to guard.yaml.
+    """
+    existing_state = read_state(project_root)
+    if existing_state is None:
+        print("Error: AI Guard is not installed. Run 'guard install' first.")
+        raise SystemExit(1)
+
+    # Load and resolve config
+    try:
+        raw_config = load_config(config_path)
+        resolved = resolve_config(config_path)
+    except ConfigError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None
+
+    rulesets: list[str] = raw_config.get("rulesets", [])
+
+    # Resolve adapters for installed agents
+    try:
+        adapters = _resolve_adapters(existing_state.installed_agents)
+    except AdapterNotFoundError as e:
+        print(f"Error: {e}")
+        print("Consider reinstalling with 'guard install --agent <agents>'.")
+        raise SystemExit(1) from None
+
+    # Run generator pipeline
+    try:
+        written_paths = _run_generator_pipeline(
+            resolved, adapters, project_root, rulesets
+        )
+    except ArtifactWriteError as e:
+        print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")
+        raise SystemExit(1) from None
+
+    # Update state
+    state = create_state(
+        existing_state.installed_agents, resolved.config_hash, written_paths
+    )
+    write_state(project_root, state)
+
+    agents_str = ", ".join(existing_state.installed_agents)
+    print(f"Updated {len(written_paths)} artifact(s) for agents: {agents_str}")
+
+
+def uninstall_command(
+    project_root: Path,
+    keep_config: bool,
+) -> None:
+    """Execute the uninstall command.
+
+    Deletes all generated artifacts and state file.
+
+    Args:
+        project_root: Path to project root directory.
+        keep_config: If True, preserves guard.yaml.
+    """
+    existing_state = read_state(project_root)
+    if existing_state is None:
+        print("Nothing to uninstall.")
+        return
+
+    # Delete artifacts tracked in state
+    deleted = delete_artifacts(project_root, existing_state.artifacts)
+
+    # Delete state.json
+    state_path = project_root / STATE_FILE
+    if state_path.is_file():
+        state_path.unlink()
+        deleted.append(STATE_FILE)
+
+    # Clean up .ai-guard directory if empty
+    ai_guard_dir = project_root / ".ai-guard"
+    if ai_guard_dir.is_dir():
+        with contextlib.suppress(OSError):
+            ai_guard_dir.rmdir()  # Only removes if empty
+
+    # Delete guard.yaml unless --keep-config
+    if not keep_config:
+        config_path = project_root / "guard.yaml"
+        if config_path.is_file():
+            config_path.unlink()
+            deleted.append("guard.yaml")
+
+    not_deleted = set(existing_state.artifacts) - set(deleted)
+
+    print(f"Uninstalled. Removed {len(deleted)} file(s).")
+    if not_deleted:
+        print("Warning: Could not delete:")
+        for path in sorted(not_deleted):
+            print(f"  {path}")

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -7,6 +7,7 @@ import typer
 
 from ai_guard import __version__
 from ai_guard.cli.init import init_command
+from ai_guard.cli.install import install_command, uninstall_command, update_command
 
 app = typer.Typer(
     name="guard",
@@ -91,3 +92,71 @@ def init(
         force=force,
         output=output,
     )
+
+
+@app.command()
+def install(
+    agent: Annotated[
+        str | None,
+        typer.Option(
+            "--agent",
+            "-a",
+            help="Comma-separated agent names (e.g., claude-code,cursor)",
+        ),
+    ] = None,
+    config: Annotated[
+        Path,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to guard.yaml",
+        ),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Install AI Guard artifacts for specified agents.
+
+    Without --agent, lists available agents. With --agent, generates
+    rule documents, Hook scripts, tool configs, and Git hooks.
+    """
+    agents = [a.strip() for a in agent.split(",") if a.strip()] if agent else []
+    project_root = config.parent.resolve()
+    install_command(agents=agents, project_root=project_root, config_path=config)
+
+
+@app.command()
+def update(
+    config: Annotated[
+        Path,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to guard.yaml",
+        ),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Re-generate all artifacts for installed agents.
+
+    Reads the current installation state and regenerates all
+    artifacts based on the latest guard.yaml configuration.
+    """
+    project_root = config.parent.resolve()
+    update_command(project_root=project_root, config_path=config)
+
+
+@app.command()
+def uninstall(
+    keep_config: Annotated[
+        bool,
+        typer.Option(
+            "--keep-config",
+            help="Keep guard.yaml after uninstall",
+        ),
+    ] = False,
+) -> None:
+    """Remove all AI Guard artifacts.
+
+    Deletes generated files tracked in .ai-guard/state.json.
+    Use --keep-config to preserve guard.yaml.
+    """
+    project_root = Path.cwd()
+    uninstall_command(project_root=project_root, keep_config=keep_config)

--- a/src/ai_guard/config/merger.py
+++ b/src/ai_guard/config/merger.py
@@ -278,6 +278,7 @@ def _to_resolved_config(
         output=_to_output(merged.get("output", {})),
         build_command=merged.get("build", {}).get("command"),
         config_hash=config_hash,
+        rulesets=merged.get("rulesets", []),
     )
 
 

--- a/tests/unit/test_cli/test_install.py
+++ b/tests/unit/test_cli/test_install.py
@@ -1,0 +1,304 @@
+"""Tests for install, update, and uninstall commands (WP1.5b)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from ai_guard.cli.main import app
+from ai_guard.generator.models import STATE_FILE, GeneratedState
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def project_with_config(tmp_path: Path) -> Path:
+    """Create a minimal project directory with guard.yaml and .git."""
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {"version": 1, "project": {"name": "test", "language": "python"}},
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def installed_project(project_with_config: Path) -> Path:
+    """Create a project with an existing installation state."""
+    state = GeneratedState(
+        ai_guard_version="0.1.0",
+        installed_agents=["claude-code"],
+        config_hash="abcd1234",
+        artifacts=["CLAUDE.md", ".ai-guard/policy.json"],
+    )
+    state_path = project_with_config / STATE_FILE
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(state.to_json(), encoding="utf-8")
+    # Create the artifact files so uninstall can delete them
+    (project_with_config / "CLAUDE.md").write_text("# Rules\n")
+    policy_dir = project_with_config / ".ai-guard"
+    (policy_dir / "policy.json").write_text("{}")
+    return project_with_config
+
+
+# ---------------------------------------------------------------------------
+# TestInstallCommand
+# ---------------------------------------------------------------------------
+
+
+class TestInstallCommand:
+    """Tests for guard install command."""
+
+    def test_install_no_agent_lists_available(self, tmp_path: Path) -> None:
+        """install without --agent lists available agents."""
+        config = tmp_path / "guard.yaml"
+        config.write_text(
+            yaml.dump(
+                {"version": 1, "project": {"name": "t", "language": "python"}},
+                default_flow_style=False,
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["install", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+        assert "cursor" in result.output
+
+    def test_install_single_agent_creates_artifacts(
+        self, project_with_config: Path
+    ) -> None:
+        """install --agent claude-code creates artifacts and state."""
+        config = project_with_config / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        # State file should exist
+        state_path = project_with_config / STATE_FILE
+        assert state_path.is_file()
+        state = GeneratedState.from_json(state_path.read_text())
+        assert "claude-code" in state.installed_agents
+        # Rule doc should exist
+        assert (project_with_config / "CLAUDE.md").is_file()
+
+    def test_install_multiple_agents(self, project_with_config: Path) -> None:
+        """install --agent with comma-separated agents installs both."""
+        config = project_with_config / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code,cursor", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        state_path = project_with_config / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        assert "claude-code" in state.installed_agents
+        assert "cursor" in state.installed_agents
+
+    def test_install_incremental_appends_agents(self, installed_project: Path) -> None:
+        """Second install appends new agent to existing agents."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "cursor", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        state_path = installed_project / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        assert "claude-code" in state.installed_agents
+        assert "cursor" in state.installed_agents
+
+    def test_install_duplicate_agent_is_idempotent(
+        self, installed_project: Path
+    ) -> None:
+        """Installing same agent again doesn't duplicate it."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        state_path = installed_project / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        assert state.installed_agents.count("claude-code") == 1
+
+    def test_install_unknown_agent_fails(self, project_with_config: Path) -> None:
+        """install with unknown agent name fails with error."""
+        config = project_with_config / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "nonexistent", "--config", str(config)],
+        )
+        assert result.exit_code == 1
+        assert "nonexistent" in result.output
+
+    def test_install_no_config_fails(self, tmp_path: Path) -> None:
+        """install without guard.yaml fails."""
+        config = tmp_path / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config)],
+        )
+        assert result.exit_code == 1
+
+    def test_install_no_git_dir_warns_continues(self, tmp_path: Path) -> None:
+        """install without .git directory warns but continues."""
+        config = tmp_path / "guard.yaml"
+        config.write_text(
+            yaml.dump(
+                {"version": 1, "project": {"name": "t", "language": "python"}},
+                default_flow_style=False,
+            ),
+        )
+        # No .git directory
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        assert "Warning" in result.output or "warning" in result.output
+        # State should still be created
+        state_path = tmp_path / STATE_FILE
+        assert state_path.is_file()
+
+    def test_install_creates_state_json(self, project_with_config: Path) -> None:
+        """install creates state.json with correct structure."""
+        config = project_with_config / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        state_path = project_with_config / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        assert state.ai_guard_version
+        assert state.config_hash
+        assert len(state.artifacts) > 0
+        assert state.installed_agents == ["claude-code"]
+
+
+# ---------------------------------------------------------------------------
+# TestUpdateCommand
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCommand:
+    """Tests for guard update command."""
+
+    def test_update_regenerates_artifacts(self, installed_project: Path) -> None:
+        """update regenerates artifacts for installed agents."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["update", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        # State should still have claude-code
+        state_path = installed_project / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        assert "claude-code" in state.installed_agents
+
+    def test_update_no_state_fails(self, project_with_config: Path) -> None:
+        """update without prior install fails."""
+        config = project_with_config / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["update", "--config", str(config)],
+        )
+        assert result.exit_code == 1
+        assert "install" in result.output.lower()
+
+    def test_update_reflects_config_changes(self, installed_project: Path) -> None:
+        """update picks up config changes (new hash)."""
+        config = installed_project / "guard.yaml"
+        old_state = GeneratedState.from_json(
+            (installed_project / STATE_FILE).read_text()
+        )
+        # Modify config
+        config.write_text(
+            yaml.dump(
+                {
+                    "version": 1,
+                    "project": {"name": "changed", "language": "python"},
+                },
+                default_flow_style=False,
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["update", "--config", str(config)],
+        )
+        assert result.exit_code == 0
+        new_state = GeneratedState.from_json(
+            (installed_project / STATE_FILE).read_text()
+        )
+        assert new_state.config_hash != old_state.config_hash
+
+
+# ---------------------------------------------------------------------------
+# TestUninstallCommand
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallCommand:
+    """Tests for guard uninstall command."""
+
+    def test_uninstall_deletes_artifacts(
+        self, installed_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uninstall deletes generated artifacts."""
+        monkeypatch.chdir(installed_project)
+        result = runner.invoke(app, ["uninstall"])
+        assert result.exit_code == 0
+        assert not (installed_project / "CLAUDE.md").exists()
+        assert not (installed_project / STATE_FILE).exists()
+
+    def test_uninstall_no_state_exits_clean(
+        self, project_with_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uninstall when nothing is installed exits cleanly."""
+        monkeypatch.chdir(project_with_config)
+        result = runner.invoke(app, ["uninstall"])
+        assert result.exit_code == 0
+        assert "Nothing to uninstall" in result.output
+
+    def test_uninstall_keep_config(
+        self, installed_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uninstall --keep-config preserves guard.yaml."""
+        monkeypatch.chdir(installed_project)
+        result = runner.invoke(app, ["uninstall", "--keep-config"])
+        assert result.exit_code == 0
+        assert (installed_project / "guard.yaml").exists()
+
+    def test_uninstall_removes_config(
+        self, installed_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uninstall without --keep-config removes guard.yaml."""
+        monkeypatch.chdir(installed_project)
+        result = runner.invoke(app, ["uninstall"])
+        assert result.exit_code == 0
+        assert not (installed_project / "guard.yaml").exists()
+
+    def test_uninstall_cleans_ai_guard_dir(
+        self, installed_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uninstall removes .ai-guard/ directory when empty."""
+        monkeypatch.chdir(installed_project)
+        result = runner.invoke(app, ["uninstall"])
+        assert result.exit_code == 0
+        assert not (installed_project / ".ai-guard").exists()

--- a/tests/unit/test_config/test_merger.py
+++ b/tests/unit/test_config/test_merger.py
@@ -103,6 +103,14 @@ class TestResolveConfigMinimal:
         result = resolve_config(path)
         # Should work fine with no rulesets
         assert result.version == 1
+        assert result.rulesets == []
+
+    def test_rulesets_passthrough(self, tmp_path: Path) -> None:
+        """Rulesets from guard.yaml are passed through to ResolvedConfig."""
+        data = _minimal_guard(rulesets=["security-rules", "team-conventions"])
+        path = _write_yaml(tmp_path, data)
+        result = resolve_config(path)
+        assert result.rulesets == ["security-rules", "team-conventions"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `guard install --agent <name>[,<name>]` command: generates rule docs, hook scripts, tool configs, git hooks, and policy cache for specified agents
- Add `guard update` command: regenerates all artifacts for previously installed agents based on latest config
- Add `guard uninstall [--keep-config]` command: removes all generated artifacts tracked in state.json
- Install is incremental: running install again with new agents appends them to existing installation
- Fix rulesets passthrough in config merger (`_to_resolved_config` was not forwarding rulesets to `ResolvedConfig`)

Closes #10

## Test plan

- [x] 17 unit tests covering all three commands (install/update/uninstall)
- [x] Install: no-agent listing, single/multi agent, incremental, duplicate, unknown agent, no config, no .git warning, state.json structure
- [x] Update: regenerate, no-state error, config change detection
- [x] Uninstall: artifact deletion, no-state clean exit, keep-config, config removal, .ai-guard cleanup
- [x] Full test suite (404 tests) passes with no regressions
- [x] All pre-commit hooks pass (ruff, coverage, docstring, type hints, naming, security, import deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)