### PR TITLE
feat(cli): add status, doctor, agents commands (WP1.5c)

### DIFF
--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -8,6 +8,7 @@ import typer
 from ai_guard import __version__
 from ai_guard.cli.init import init_command
 from ai_guard.cli.install import install_command, uninstall_command, update_command
+from ai_guard.cli.status import agents_command, doctor_command, status_command
 
 app = typer.Typer(
     name="guard",
@@ -160,3 +161,49 @@ def uninstall(
     """
     project_root = Path.cwd()
     uninstall_command(project_root=project_root, keep_config=keep_config)
+
+
+@app.command()
+def status(
+    rules: Annotated[
+        bool,
+        typer.Option(
+            "--rules",
+            help="Display active rule list with sources",
+        ),
+    ] = False,
+    config: Annotated[
+        Path,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to guard.yaml",
+        ),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Show installation status, drift detection, and artifact integrity."""
+    project_root = config.parent.resolve()
+    status_command(project_root=project_root, config_path=config, show_rules=rules)
+
+
+@app.command()
+def doctor(
+    config: Annotated[
+        Path,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to guard.yaml",
+        ),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Run environment diagnostics and check system health."""
+    project_root = config.parent.resolve()
+    doctor_command(project_root=project_root, config_path=config)
+
+
+@app.command()
+def agents() -> None:
+    """Display agent capability matrix and installation status."""
+    project_root = Path.cwd()
+    agents_command(project_root=project_root)

--- a/src/ai_guard/cli/status.py
+++ b/src/ai_guard/cli/status.py
@@ -1,0 +1,302 @@
+"""status, doctor, and agents command implementations for AI Guard CLI.
+
+Provides diagnostic and informational commands for inspecting
+AI Guard installation state, environment health, and agent capabilities.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+from ai_guard import __version__
+from ai_guard.adapters.registry import get_adapter, list_adapters
+from ai_guard.config.exceptions import ConfigError
+from ai_guard.config.loader import load_config
+from ai_guard.config.merger import resolve_config
+from ai_guard.generator.core import read_state
+
+__all__ = ["status_command", "doctor_command", "agents_command"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_config_hash(path: Path) -> str:
+    """SHA-256 of the file bytes, truncated to 8 hex chars."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# status command
+# ---------------------------------------------------------------------------
+
+
+def status_command(
+    project_root: Path,
+    config_path: Path,
+    show_rules: bool,
+) -> None:
+    """Execute the status command.
+
+    Shows installation status, drift detection, and artifact integrity.
+
+    Args:
+        project_root: Path to project root directory.
+        config_path: Path to guard.yaml.
+        show_rules: Whether to display the active rule list.
+    """
+    state = read_state(project_root)
+    if state is None:
+        print("AI Guard is not installed.")
+        print("Run 'guard install --agent <name>' to install.")
+        return
+
+    # Installation info
+    print(f"Installed agents: {', '.join(state.installed_agents)}")
+    print(f"AI Guard version: {state.ai_guard_version}")
+    print(f"Installed at: {state.installed_at.isoformat()}")
+
+    # Version mismatch check
+    if state.ai_guard_version != __version__:
+        msg = (
+            f"\nVersion mismatch: install version {state.ai_guard_version}, "
+            f"current version {__version__}."
+        )
+        print(msg)
+        print("Run 'guard update' to sync.")
+
+    # Drift detection
+    if config_path.is_file():
+        current_hash = _compute_config_hash(config_path)
+        if current_hash != state.config_hash:
+            print(
+                "\nConfiguration drift detected: guard.yaml has changed "
+                "since last install/update. Run 'guard update'."
+            )
+        else:
+            print("\nConfiguration: up to date (no drift)")
+    else:
+        print("\nWarning: guard.yaml not found.")
+
+    # Artifact integrity check
+    missing = []
+    for artifact_path in state.artifacts:
+        full_path = project_root / artifact_path
+        if not full_path.is_file():
+            missing.append(artifact_path)
+
+    if missing:
+        print(f"\nMissing artifacts ({len(missing)}):")
+        for path in missing:
+            print(f"  {path}")
+        print("Run 'guard update' to regenerate.")
+    else:
+        print(f"\nAll {len(state.artifacts)} artifact(s) present.")
+
+    # Rules display
+    if show_rules:
+        _print_rules(config_path)
+
+
+def _print_rules(config_path: Path) -> None:
+    """Print active rules from resolved config.
+
+    Args:
+        config_path: Path to guard.yaml.
+    """
+    try:
+        resolved = resolve_config(config_path)
+    except ConfigError as e:
+        print(f"\nCannot load rules: {e}")
+        return
+
+    print("\nActive rules:")
+    for op_name, op_rules in [
+        ("read", resolved.behavior.read),
+        ("write", resolved.behavior.write),
+        ("execute", resolved.behavior.execute),
+    ]:
+        for tier_name, rules in [
+            ("forbidden", op_rules.forbidden),
+            ("require_approval", op_rules.require_approval),
+            ("allow", op_rules.allow),
+        ]:
+            for rule in rules:
+                print(f"  {op_name}.{tier_name}: {rule.pattern} " f"[{rule.source}]")
+
+
+# ---------------------------------------------------------------------------
+# doctor command
+# ---------------------------------------------------------------------------
+
+
+def doctor_command(
+    project_root: Path,
+    config_path: Path,
+) -> None:
+    """Execute the doctor command.
+
+    Performs systematic environment diagnostics.
+
+    Args:
+        project_root: Path to project root directory.
+        config_path: Path to guard.yaml.
+    """
+    print("AI Guard Doctor")
+    print("=" * 40)
+
+    # 1. Tool dependencies
+    print("\n1. Tool Dependencies")
+    _check_python()
+    _check_git()
+    _check_pre_commit()
+
+    # 2. Configuration state
+    print("\n2. Configuration")
+    _check_config(config_path)
+
+    # 3. File integrity
+    print("\n3. File Integrity")
+    _check_file_integrity(project_root)
+
+    # 4. Drift detection
+    print("\n4. Drift Detection")
+    _check_drift(project_root, config_path)
+
+
+def _check_python() -> None:
+    """Check Python version."""
+    version = sys.version.split()[0]
+    major, minor = sys.version_info[:2]
+    if major >= 3 and minor >= 10:
+        print(f"  [ok] Python {version}")
+    else:
+        print(f"  [FAIL] Python {version} (requires >= 3.10)")
+
+
+def _check_git() -> None:
+    """Check git availability."""
+    git_path = shutil.which("git")
+    if git_path:
+        print(f"  [ok] git found at {git_path}")
+    else:
+        print("  [FAIL] git not found. Install git.")
+
+
+def _check_pre_commit() -> None:
+    """Check pre-commit availability."""
+    pc_path = shutil.which("pre-commit")
+    if pc_path:
+        print(f"  [ok] pre-commit found at {pc_path}")
+    else:
+        print("  [WARN] pre-commit not found. Install: pip install pre-commit")
+
+
+def _check_config(config_path: Path) -> None:
+    """Validate guard.yaml configuration.
+
+    Args:
+        config_path: Path to guard.yaml.
+    """
+    if not config_path.is_file():
+        print(f"  [FAIL] guard.yaml not found at {config_path}")
+        print("         Run 'guard init' to create one.")
+        return
+
+    try:
+        load_config(config_path)
+        print(f"  [ok] guard.yaml valid ({config_path})")
+    except ConfigError as e:
+        print(f"  [FAIL] guard.yaml invalid: {e}")
+
+
+def _check_file_integrity(project_root: Path) -> None:
+    """Check artifact file integrity.
+
+    Args:
+        project_root: Path to project root directory.
+    """
+    state = read_state(project_root)
+    if state is None:
+        print("  [WARN] Not installed (no state.json)")
+        return
+
+    missing = []
+    for artifact_path in state.artifacts:
+        full_path = project_root / artifact_path
+        if not full_path.is_file():
+            missing.append(artifact_path)
+
+    if missing:
+        print(f"  [FAIL] {len(missing)} artifact(s) missing:")
+        for path in missing:
+            print(f"         {path}")
+        print("         Run 'guard update' to regenerate.")
+    else:
+        print(f"  [ok] All {len(state.artifacts)} artifact(s) present")
+
+
+def _check_drift(project_root: Path, config_path: Path) -> None:
+    """Check configuration drift.
+
+    Args:
+        project_root: Path to project root directory.
+        config_path: Path to guard.yaml.
+    """
+    state = read_state(project_root)
+    if state is None:
+        print("  [SKIP] Not installed")
+        return
+
+    if not config_path.is_file():
+        print("  [WARN] guard.yaml not found")
+        return
+
+    current_hash = _compute_config_hash(config_path)
+    if current_hash != state.config_hash:
+        print("  [WARN] Configuration drift detected")
+        print("         Run 'guard update' to sync.")
+    else:
+        print("  [ok] No drift")
+
+
+# ---------------------------------------------------------------------------
+# agents command
+# ---------------------------------------------------------------------------
+
+
+def agents_command(project_root: Path) -> None:
+    """Execute the agents command.
+
+    Displays agent capability matrix with installation status.
+
+    Args:
+        project_root: Path to project root directory.
+    """
+    state = read_state(project_root)
+    installed = set(state.installed_agents) if state else set()
+
+    print("Agent Capability Matrix")
+    print("-" * 72)
+    print(f"{'Agent':<15} {'Block':<7} {'Ask':<7} {'Rule Doc':<25} {'Status'}")
+    print("-" * 72)
+
+    for name in list_adapters():
+        adapter = get_adapter(name)
+        caps = adapter.capabilities
+        block_str = "yes" if caps.can_block else "no"
+        ask_str = "yes" if caps.can_ask else "no"
+        doc_path = adapter.rule_doc_path()
+        status_str = "INSTALLED" if name in installed else "-"
+        print(f"  {name:<13} {block_str:<7} {ask_str:<7} {doc_path:<25} {status_str}")
+
+    print("-" * 72)
+    if installed:
+        print(f"\n{len(installed)} agent(s) installed.")
+    else:
+        print("\nNo agents installed. Run 'guard install --agent <name>'.")

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -1,0 +1,258 @@
+"""Tests for status, doctor, and agents commands (WP1.5c)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from ai_guard.cli.main import app
+from ai_guard.generator.models import STATE_FILE, GeneratedState
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_guard_yaml(tmp_path: Path, data: dict | None = None) -> Path:
+    """Write a guard.yaml and return its path."""
+    config = tmp_path / "guard.yaml"
+    if data is None:
+        data = {"version": 1, "project": {"name": "test", "language": "python"}}
+    config.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return config
+
+
+def _config_hash(path: Path) -> str:
+    """Compute config hash matching merger._compute_config_hash."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
+
+
+def _write_state(
+    project_root: Path,
+    agents: list[str] | None = None,
+    config_hash: str = "abcd1234",
+    artifacts: list[str] | None = None,
+) -> GeneratedState:
+    """Write a state.json and return the GeneratedState."""
+    state = GeneratedState(
+        ai_guard_version="0.1.0",
+        installed_agents=agents or ["claude-code"],
+        config_hash=config_hash,
+        artifacts=artifacts or ["CLAUDE.md", ".ai-guard/policy.json"],
+    )
+    state_path = project_root / STATE_FILE
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(state.to_json(), encoding="utf-8")
+    return state
+
+
+@pytest.fixture()
+def installed_project(tmp_path: Path) -> Path:
+    """Project with guard.yaml, .git, state.json, and artifacts."""
+    config = _write_guard_yaml(tmp_path)
+    (tmp_path / ".git").mkdir()
+    config_hash = _config_hash(config)
+    _write_state(
+        tmp_path,
+        agents=["claude-code"],
+        config_hash=config_hash,
+        artifacts=["CLAUDE.md", ".ai-guard/policy.json", ".pre-commit-config.yaml"],
+    )
+    # Create actual artifact files
+    (tmp_path / "CLAUDE.md").write_text("# Rules\n")
+    (tmp_path / ".ai-guard" / "policy.json").write_text(
+        json.dumps({"config_hash": config_hash})
+    )
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestStatusCommand
+# ---------------------------------------------------------------------------
+
+
+class TestStatusCommand:
+    """Tests for guard status command."""
+
+    def test_status_shows_installed_agents(self, installed_project: Path) -> None:
+        """status shows which agents are installed."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+
+    def test_status_not_installed(self, tmp_path: Path) -> None:
+        """status when not installed reports it."""
+        _write_guard_yaml(tmp_path)
+        config = tmp_path / "guard.yaml"
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "not installed" in result.output.lower()
+
+    def test_status_detects_drift(self, installed_project: Path) -> None:
+        """status detects config drift when guard.yaml changed."""
+        config = installed_project / "guard.yaml"
+        # Modify config to create drift
+        config.write_text(
+            yaml.dump(
+                {"version": 1, "project": {"name": "changed", "language": "go"}},
+                default_flow_style=False,
+            ),
+        )
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "drift" in result.output.lower() or "changed" in result.output.lower()
+
+    def test_status_no_drift_when_synced(self, installed_project: Path) -> None:
+        """status shows no drift when config hash matches."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert (
+            "up to date" in result.output.lower() or "synced" in result.output.lower()
+        )
+
+    def test_status_reports_missing_artifacts(self, installed_project: Path) -> None:
+        """status reports artifacts listed in state but missing from disk."""
+        config = installed_project / "guard.yaml"
+        # Remove an artifact
+        (installed_project / "CLAUDE.md").unlink()
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "CLAUDE.md" in result.output
+
+    def test_status_with_rules_flag(self, installed_project: Path) -> None:
+        """status --rules shows rule listing."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["status", "--rules", "--config", str(config)])
+        assert result.exit_code == 0
+        # Should show rules section (system protection rules at minimum)
+        assert "rule" in result.output.lower()
+
+    def test_status_version_mismatch(self, installed_project: Path) -> None:
+        """status detects tool version mismatch."""
+        config = installed_project / "guard.yaml"
+        # Set state version to something different
+        state_path = installed_project / STATE_FILE
+        state = GeneratedState.from_json(state_path.read_text())
+        state.ai_guard_version = "99.99.99"
+        state_path.write_text(state.to_json())
+        result = runner.invoke(app, ["status", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "version" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestDoctorCommand
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCommand:
+    """Tests for guard doctor command."""
+
+    def test_doctor_checks_python(self, installed_project: Path) -> None:
+        """doctor checks Python version."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "python" in result.output.lower()
+
+    def test_doctor_checks_git(self, installed_project: Path) -> None:
+        """doctor checks git availability."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "git" in result.output.lower()
+
+    def test_doctor_checks_config(self, installed_project: Path) -> None:
+        """doctor validates guard.yaml."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert (
+            "guard.yaml" in result.output.lower() or "config" in result.output.lower()
+        )
+
+    def test_doctor_not_initialized(self, tmp_path: Path) -> None:
+        """doctor reports when not initialized."""
+        config = tmp_path / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "guard.yaml" in result.output.lower()
+
+    def test_doctor_checks_artifacts(self, installed_project: Path) -> None:
+        """doctor checks artifact integrity."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        # Should mention artifacts or files check
+        assert "artifact" in result.output.lower() or "file" in result.output.lower()
+
+    def test_doctor_checks_pre_commit(self, installed_project: Path) -> None:
+        """doctor checks pre-commit availability."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "pre-commit" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestAgentsCommand
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsCommand:
+    """Tests for guard agents command."""
+
+    def test_agents_lists_all(self) -> None:
+        """agents shows all supported agents."""
+        result = runner.invoke(app, ["agents"])
+        assert result.exit_code == 0
+        assert "claude-code" in result.output.lower()
+        assert "cursor" in result.output.lower()
+        assert "opencode" in result.output.lower()
+        assert "copilot" in result.output.lower()
+        assert "kilocode" in result.output.lower()
+
+    def test_agents_shows_capabilities(self) -> None:
+        """agents shows capability information."""
+        result = runner.invoke(app, ["agents"])
+        assert result.exit_code == 0
+        assert "block" in result.output.lower()
+
+    def test_agents_shows_installed_status(
+        self, installed_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """agents marks installed agents."""
+        monkeypatch.chdir(installed_project)
+        result = runner.invoke(app, ["agents"])
+        assert result.exit_code == 0
+        # claude-code should be marked as installed
+        output_lower = result.output.lower()
+        assert "claude-code" in output_lower
+        assert "installed" in output_lower
+
+    def test_agents_no_installation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """agents works when nothing is installed."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["agents"])
+        assert result.exit_code == 0
+        # Should still list all agents
+        assert "claude-code" in result.output.lower()
+
+    def test_agents_shows_rule_doc_path(self) -> None:
+        """agents shows rule document paths."""
+        result = runner.invoke(app, ["agents"])
+        assert result.exit_code == 0
+        assert "claude.md" in result.output.lower()


### PR DESCRIPTION
## Summary

- Add `guard status [--rules]` command: shows installation state, config drift detection, artifact integrity check, and optionally active rules with sources
- Add `guard doctor` command: systematic environment diagnostics checking Python/git/pre-commit availability, config validity, artifact integrity, and configuration drift
- Add `guard agents` command: displays agent capability matrix (block/ask support, rule doc paths) with installation status

Closes #11

## Test plan

- [x] 18 unit tests covering all three commands (status/doctor/agents)
- [x] Status: installed agents display, not-installed state, drift detection, no-drift sync, missing artifacts, rules flag, version mismatch
- [x] Doctor: Python check, git check, pre-commit check, config validation, not-initialized, artifact integrity
- [x] Agents: all agents listed, capabilities shown, installed status, no-installation, rule doc paths
- [x] Full test suite (422 tests) passes with no regressions
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)