### PR TITLE
feat(checker): add check orchestration module (WP3.1)

### DIFF
--- a/src/ai_guard/checker/__init__.py
+++ b/src/ai_guard/checker/__init__.py
@@ -1,0 +1,21 @@
+"""Checker module — code quality check orchestration."""
+
+from ai_guard.checker.core import (
+    get_changed_files,
+    run_build,
+    run_check,
+    run_precommit,
+    run_stage,
+)
+from ai_guard.checker.models import CheckReport, CheckResult, Violation
+
+__all__ = [
+    "CheckReport",
+    "CheckResult",
+    "Violation",
+    "get_changed_files",
+    "run_build",
+    "run_check",
+    "run_precommit",
+    "run_stage",
+]

--- a/src/ai_guard/checker/core.py
+++ b/src/ai_guard/checker/core.py
@@ -1,0 +1,416 @@
+"""Checker core — check orchestration primitives (K2-K6).
+
+Orchestrates code quality checks across commit and push stages
+by delegating to pre-commit framework and custom check commands.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+import time
+from typing import TYPE_CHECKING
+
+from ai_guard.checker.models import CheckReport, CheckResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ai_guard.config.models import CheckItem, CodeConfig
+
+__all__ = [
+    "get_changed_files",
+    "run_build",
+    "run_check",
+    "run_precommit",
+    "run_stage",
+]
+
+
+# ---------------------------------------------------------------------------
+# K2: Get changed files
+# ---------------------------------------------------------------------------
+
+
+def get_changed_files(stage: str, project_root: Path) -> list[str]:
+    """Get list of changed files for the given stage.
+
+    Args:
+        stage: Check stage ("commit" or "push").
+        project_root: Path to project root directory.
+
+    Returns:
+        List of changed file paths relative to project root.
+    """
+    if stage == "commit":
+        cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+    else:
+        # Push stage: diff against upstream
+        cmd = ["git", "diff", "origin/main..HEAD", "--name-only", "--diff-filter=ACMR"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [f for f in result.stdout.strip().split("\n") if f]
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# K3: Run pre-commit
+# ---------------------------------------------------------------------------
+
+
+def run_precommit(
+    hook_id: str,
+    files: list[str],
+    project_root: Path,
+) -> CheckResult:
+    """Run a pre-commit hook by ID.
+
+    Args:
+        hook_id: Pre-commit hook identifier (e.g., "ruff").
+        files: List of files to check.
+        project_root: Path to project root directory.
+
+    Returns:
+        CheckResult for the pre-commit hook run.
+    """
+    if not shutil.which("pre-commit"):
+        return CheckResult(
+            name=f"pre-commit:{hook_id}",
+            passed=True,
+            skipped=True,
+            output="pre-commit not installed",
+        )
+
+    if not files:
+        return CheckResult(
+            name=f"pre-commit:{hook_id}",
+            passed=True,
+            skipped=True,
+            output="No files to check",
+        )
+
+    cmd = ["pre-commit", "run", hook_id, "--files", *files]
+    start = time.monotonic()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name=f"pre-commit:{hook_id}",
+            passed=result.returncode == 0,
+            duration_ms=elapsed,
+            output=result.stdout + result.stderr,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name=f"pre-commit:{hook_id}",
+            passed=False,
+            duration_ms=elapsed,
+            output="Timed out after 120s",
+        )
+    except OSError as e:
+        return CheckResult(
+            name=f"pre-commit:{hook_id}",
+            passed=False,
+            output=str(e),
+        )
+
+
+# ---------------------------------------------------------------------------
+# K4: Run custom check command
+# ---------------------------------------------------------------------------
+
+
+def run_check(
+    check_name: str,
+    check_item: CheckItem,
+    files: list[str],
+    project_root: Path,
+) -> CheckResult:
+    """Execute a custom check command.
+
+    Args:
+        check_name: Check identifier.
+        check_item: CheckItem with command, timeout, types.
+        files: List of changed files.
+        project_root: Path to project root directory.
+
+    Returns:
+        CheckResult for the command execution.
+    """
+    if not check_item.enabled:
+        return CheckResult(
+            name=check_name, passed=True, skipped=True, output="Disabled"
+        )
+
+    # Filter files by type if specified
+    filtered = _filter_files_by_type(files, check_item.types)
+    if check_item.types and not filtered:
+        return CheckResult(
+            name=check_name,
+            passed=True,
+            skipped=True,
+            output="No matching files",
+        )
+
+    # Build command
+    command = check_item.command
+    if check_item.pass_filenames and filtered:
+        if "{files}" in command:
+            command = command.replace("{files}", " ".join(filtered))
+        else:
+            command = f"{command} {' '.join(filtered)}"
+
+    start = time.monotonic()
+
+    try:
+        result = subprocess.run(
+            shlex.split(command),
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=check_item.timeout,
+            check=False,
+        )
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name=check_name,
+            passed=result.returncode == 0,
+            duration_ms=elapsed,
+            output=result.stdout + result.stderr,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name=check_name,
+            passed=False,
+            duration_ms=elapsed,
+            output=f"Timed out after {check_item.timeout}s",
+        )
+    except OSError as e:
+        return CheckResult(
+            name=check_name,
+            passed=False,
+            output=str(e),
+        )
+
+
+def _filter_files_by_type(files: list[str], types: list[str] | None) -> list[str]:
+    """Filter file list by type extensions.
+
+    Args:
+        files: List of file paths.
+        types: File type names (e.g., ["python", "typescript"]).
+            None means no filtering.
+
+    Returns:
+        Filtered file list.
+    """
+    if types is None:
+        return files
+
+    type_extensions = {
+        "python": {".py", ".pyi"},
+        "javascript": {".js", ".jsx", ".mjs"},
+        "typescript": {".ts", ".tsx", ".mts"},
+        "go": {".go"},
+        "rust": {".rs"},
+        "java": {".java"},
+        "c": {".c", ".h"},
+        "cpp": {".cpp", ".cc", ".cxx", ".hpp", ".hh"},
+    }
+
+    valid_exts: set[str] = set()
+    for t in types:
+        valid_exts.update(type_extensions.get(t, {f".{t}"}))
+
+    return [f for f in files if any(f.endswith(ext) for ext in valid_exts)]
+
+
+# ---------------------------------------------------------------------------
+# K5: Run build
+# ---------------------------------------------------------------------------
+
+
+def run_build(build_command: str, project_root: Path) -> CheckResult:
+    """Execute the build command.
+
+    Args:
+        build_command: Shell command to run.
+        project_root: Path to project root directory.
+
+    Returns:
+        CheckResult for the build execution.
+    """
+    start = time.monotonic()
+
+    try:
+        result = subprocess.run(
+            shlex.split(build_command),
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name="build",
+            passed=result.returncode == 0,
+            duration_ms=elapsed,
+            output=result.stdout + result.stderr,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = int((time.monotonic() - start) * 1000)
+        return CheckResult(
+            name="build",
+            passed=False,
+            duration_ms=elapsed,
+            output="Build timed out after 600s",
+        )
+    except OSError as e:
+        return CheckResult(
+            name="build",
+            passed=False,
+            output=str(e),
+        )
+
+
+# ---------------------------------------------------------------------------
+# K6: Run stage (orchestration)
+# ---------------------------------------------------------------------------
+
+
+def run_stage(
+    stage: str,
+    code_config: CodeConfig,
+    project_root: Path,
+    build_command: str | None = None,
+) -> CheckReport:
+    """Orchestrate all checks for a stage.
+
+    For commit stage: format + naming + custom checks.
+    For push stage: commit first (fail-fast) + build + lint + custom checks.
+
+    Args:
+        stage: Check stage ("commit" or "push").
+        code_config: CodeConfig with enabled flags and checks.
+        project_root: Path to project root directory.
+        build_command: Optional build command (push stage only).
+
+    Returns:
+        CheckReport with aggregated results.
+    """
+    start = time.monotonic()
+
+    if stage == "push":
+        # Fail-fast: run commit stage first
+        commit_report = run_stage("commit", code_config, project_root)
+        if not commit_report.passed:
+            elapsed = int((time.monotonic() - start) * 1000)
+            return CheckReport(
+                stage="push",
+                passed=False,
+                results=commit_report.results,
+                duration_ms=elapsed,
+            )
+
+    files = get_changed_files(stage, project_root)
+    results: list[CheckResult] = []
+
+    if stage == "commit":
+        results.extend(_run_commit_checks(code_config, files, project_root))
+    else:
+        results.extend(
+            _run_push_checks(code_config, files, project_root, build_command)
+        )
+
+    elapsed = int((time.monotonic() - start) * 1000)
+    passed = all(r.passed for r in results)
+
+    return CheckReport(
+        stage=stage,
+        passed=passed,
+        results=results,
+        duration_ms=elapsed,
+    )
+
+
+def _run_commit_checks(
+    config: CodeConfig,
+    files: list[str],
+    project_root: Path,
+) -> list[CheckResult]:
+    """Run commit-stage checks.
+
+    Args:
+        config: CodeConfig with commit settings.
+        files: Changed files list.
+        project_root: Path to project root.
+
+    Returns:
+        List of CheckResults for commit stage.
+    """
+    results: list[CheckResult] = []
+
+    if config.commit_format:
+        results.append(run_precommit("format", files, project_root))
+
+    if config.commit_naming:
+        results.append(run_precommit("naming", files, project_root))
+
+    for name, check_item in config.commit_checks.items():
+        results.append(run_check(name, check_item, files, project_root))
+
+    return results
+
+
+def _run_push_checks(
+    config: CodeConfig,
+    files: list[str],
+    project_root: Path,
+    build_command: str | None,
+) -> list[CheckResult]:
+    """Run push-stage checks.
+
+    Args:
+        config: CodeConfig with push settings.
+        files: Changed files list.
+        project_root: Path to project root.
+        build_command: Optional build command.
+
+    Returns:
+        List of CheckResults for push stage.
+    """
+    results: list[CheckResult] = []
+
+    if build_command:
+        results.append(run_build(build_command, project_root))
+
+    if config.push_lint:
+        results.append(run_precommit("lint", files, project_root))
+
+    for name, check_item in config.push_checks.items():
+        results.append(run_check(name, check_item, files, project_root))
+
+    return results

--- a/src/ai_guard/checker/models.py
+++ b/src/ai_guard/checker/models.py
@@ -1,0 +1,68 @@
+"""Checker data models for check results and reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = ["CheckReport", "CheckResult", "Violation"]
+
+
+@dataclass
+class Violation:
+    """A single code quality violation found during checking.
+
+    Attributes:
+        file: File path where the violation was found.
+        line: Line number (1-based), or None if unknown.
+        column: Column number (1-based), or None if unknown.
+        severity: Severity level ("error", "warning", "info").
+        code: Rule code or identifier (e.g., "E501").
+        message: Human-readable description of the violation.
+        source: Tool that reported this violation.
+    """
+
+    file: str
+    line: int | None = None
+    column: int | None = None
+    severity: str = "error"
+    code: str = ""
+    message: str = ""
+    source: str = ""
+
+
+@dataclass
+class CheckResult:
+    """Result of running a single check or hook.
+
+    Attributes:
+        name: Check or hook name.
+        passed: Whether the check passed.
+        violations: Detailed violation list.
+        duration_ms: Execution time in milliseconds.
+        output: Captured stdout/stderr for diagnostics.
+        skipped: Whether the check was skipped.
+    """
+
+    name: str
+    passed: bool
+    violations: list[Violation] = field(default_factory=list)
+    duration_ms: int = 0
+    output: str = ""
+    skipped: bool = False
+
+
+@dataclass
+class CheckReport:
+    """Aggregated report for a check stage.
+
+    Attributes:
+        stage: Check stage ("commit" or "push").
+        passed: Whether all checks in the stage passed.
+        results: Per-check results.
+        duration_ms: Total execution time in milliseconds.
+    """
+
+    stage: str
+    passed: bool
+    results: list[CheckResult] = field(default_factory=list)
+    duration_ms: int = 0

--- a/tests/unit/test_checker/test_core.py
+++ b/tests/unit/test_checker/test_core.py
@@ -1,0 +1,182 @@
+"""Tests for Checker core orchestration (K2-K6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from ai_guard.checker.core import (
+    _filter_files_by_type,
+    get_changed_files,
+    run_build,
+    run_check,
+    run_stage,
+)
+from ai_guard.config.models import CheckItem, CodeConfig
+
+
+class TestGetChangedFiles:
+    """Tests for get_changed_files (K2)."""
+
+    def test_commit_stage_command(self, tmp_path: Path) -> None:
+        """Commit stage uses git diff --cached."""
+        with patch("ai_guard.checker.core.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "a.py\nb.py\n"
+            files = get_changed_files("commit", tmp_path)
+            assert files == ["a.py", "b.py"]
+            cmd = mock_run.call_args[0][0]
+            assert "--cached" in cmd
+
+    def test_push_stage_command(self, tmp_path: Path) -> None:
+        """Push stage uses git diff origin/main..HEAD."""
+        with patch("ai_guard.checker.core.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "c.py\n"
+            files = get_changed_files("push", tmp_path)
+            assert files == ["c.py"]
+            cmd = mock_run.call_args[0][0]
+            assert "origin/main..HEAD" in cmd
+
+    def test_empty_output(self, tmp_path: Path) -> None:
+        """Empty git output returns empty list."""
+        with patch("ai_guard.checker.core.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = ""
+            files = get_changed_files("commit", tmp_path)
+            assert files == []
+
+    def test_git_error_returns_empty(self, tmp_path: Path) -> None:
+        """Git error returns empty list."""
+        with patch("ai_guard.checker.core.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = ""
+            files = get_changed_files("commit", tmp_path)
+            assert files == []
+
+
+class TestRunCheck:
+    """Tests for run_check (K4)."""
+
+    def test_successful_command(self, tmp_path: Path) -> None:
+        """Successful command returns passed=True."""
+        check = CheckItem(command="echo ok", timeout=10)
+        result = run_check("echo-test", check, [], tmp_path)
+        assert result.passed is True
+        assert result.name == "echo-test"
+
+    def test_failing_command(self, tmp_path: Path) -> None:
+        """Failing command returns passed=False."""
+        check = CheckItem(command="exit 1", timeout=10)
+        result = run_check("fail-test", check, [], tmp_path)
+        assert result.passed is False
+
+    def test_timeout(self, tmp_path: Path) -> None:
+        """Command timeout returns passed=False."""
+        check = CheckItem(command="sleep 10", timeout=1)
+        result = run_check("timeout-test", check, [], tmp_path)
+        assert result.passed is False
+        assert "Timed out" in result.output
+
+    def test_disabled_check_skipped(self, tmp_path: Path) -> None:
+        """Disabled check is skipped."""
+        check = CheckItem(command="exit 1", enabled=False)
+        result = run_check("disabled", check, [], tmp_path)
+        assert result.passed is True
+        assert result.skipped is True
+
+    def test_no_matching_files_skipped(self, tmp_path: Path) -> None:
+        """Check with types filter and no matching files is skipped."""
+        check = CheckItem(command="ruff check", types=["python"])
+        result = run_check("ruff", check, ["main.js"], tmp_path)
+        assert result.passed is True
+        assert result.skipped is True
+
+    def test_pass_filenames(self, tmp_path: Path) -> None:
+        """Files are appended when pass_filenames is True."""
+        check = CheckItem(command="echo", types=["python"])
+        result = run_check("echo", check, ["a.py", "b.py"], tmp_path)
+        assert result.passed is True
+        assert "a.py" in result.output
+
+
+class TestRunBuild:
+    """Tests for run_build (K5)."""
+
+    def test_successful_build(self, tmp_path: Path) -> None:
+        """Successful build returns passed=True."""
+        result = run_build("echo build-ok", tmp_path)
+        assert result.passed is True
+        assert result.name == "build"
+
+    def test_failing_build(self, tmp_path: Path) -> None:
+        """Failing build returns passed=False."""
+        result = run_build("exit 1", tmp_path)
+        assert result.passed is False
+
+
+class TestFilterFilesByType:
+    """Tests for _filter_files_by_type helper."""
+
+    def test_python_filter(self) -> None:
+        """Python type filter matches .py files."""
+        files = ["a.py", "b.js", "c.py"]
+        assert _filter_files_by_type(files, ["python"]) == ["a.py", "c.py"]
+
+    def test_no_filter(self) -> None:
+        """None types returns all files."""
+        files = ["a.py", "b.js"]
+        assert _filter_files_by_type(files, None) == files
+
+    def test_multiple_types(self) -> None:
+        """Multiple type filters combined."""
+        files = ["a.py", "b.ts", "c.go", "d.txt"]
+        result = _filter_files_by_type(files, ["python", "typescript"])
+        assert result == ["a.py", "b.ts"]
+
+
+class TestRunStage:
+    """Tests for run_stage orchestration (K6)."""
+
+    def test_commit_stage_runs_checks(self, tmp_path: Path) -> None:
+        """Commit stage runs format + naming checks."""
+        config = CodeConfig(commit_format=True, commit_naming=True)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            report = run_stage("commit", config, tmp_path)
+        assert report.stage == "commit"
+        # Format and naming are pre-commit hooks — skipped with no files
+        assert report.passed is True
+
+    def test_commit_stage_with_custom_checks(self, tmp_path: Path) -> None:
+        """Commit stage runs custom checks."""
+        config = CodeConfig(
+            commit_format=False,
+            commit_naming=False,
+            commit_checks={"echo": CheckItem(command="echo ok")},
+        )
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            report = run_stage("commit", config, tmp_path)
+        assert report.passed is True
+        assert any(r.name == "echo" for r in report.results)
+
+    def test_push_stage_fail_fast(self, tmp_path: Path) -> None:
+        """Push stage fails fast if commit stage fails."""
+        config = CodeConfig(
+            commit_checks={"fail": CheckItem(command="exit 1")},
+        )
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            report = run_stage("push", config, tmp_path)
+        assert report.stage == "push"
+        assert report.passed is False
+
+    def test_push_stage_with_build(self, tmp_path: Path) -> None:
+        """Push stage runs build command."""
+        config = CodeConfig(
+            commit_format=False,
+            commit_naming=False,
+            push_lint=False,
+        )
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            report = run_stage("push", config, tmp_path, build_command="echo build")
+        assert report.passed is True
+        assert any(r.name == "build" for r in report.results)

--- a/tests/unit/test_checker/test_models.py
+++ b/tests/unit/test_checker/test_models.py
@@ -1,0 +1,90 @@
+"""Tests for Checker data models."""
+
+from __future__ import annotations
+
+from ai_guard.checker.models import CheckReport, CheckResult, Violation
+
+
+class TestViolation:
+    """Tests for Violation dataclass."""
+
+    def test_basic_construction(self) -> None:
+        """Violation with required field only."""
+        v = Violation(file="main.py")
+        assert v.file == "main.py"
+        assert v.line is None
+        assert v.severity == "error"
+
+    def test_full_construction(self) -> None:
+        """Violation with all fields."""
+        v = Violation(
+            file="main.py",
+            line=10,
+            column=5,
+            severity="warning",
+            code="E501",
+            message="line too long",
+            source="ruff",
+        )
+        assert v.line == 10
+        assert v.code == "E501"
+
+
+class TestCheckResult:
+    """Tests for CheckResult dataclass."""
+
+    def test_passed_result(self) -> None:
+        """Passing check result."""
+        r = CheckResult(name="format", passed=True)
+        assert r.passed is True
+        assert r.violations == []
+        assert r.skipped is False
+
+    def test_failed_result(self) -> None:
+        """Failed check result with violations."""
+        r = CheckResult(
+            name="lint",
+            passed=False,
+            violations=[Violation(file="a.py", message="err")],
+        )
+        assert r.passed is False
+        assert len(r.violations) == 1
+
+    def test_skipped_result(self) -> None:
+        """Skipped check result."""
+        r = CheckResult(name="build", passed=True, skipped=True)
+        assert r.skipped is True
+
+
+class TestCheckReport:
+    """Tests for CheckReport dataclass."""
+
+    def test_all_passed(self) -> None:
+        """Report with all checks passing."""
+        report = CheckReport(
+            stage="commit",
+            passed=True,
+            results=[
+                CheckResult(name="format", passed=True),
+                CheckResult(name="naming", passed=True),
+            ],
+        )
+        assert report.passed is True
+        assert len(report.results) == 2
+
+    def test_any_failed(self) -> None:
+        """Report with a failing check."""
+        report = CheckReport(
+            stage="push",
+            passed=False,
+            results=[
+                CheckResult(name="lint", passed=True),
+                CheckResult(name="test", passed=False),
+            ],
+        )
+        assert report.passed is False
+
+    def test_empty_results(self) -> None:
+        """Report with no results."""
+        report = CheckReport(stage="commit", passed=True)
+        assert report.results == []


### PR DESCRIPTION
## Summary

- Implement Checker module for code quality check orchestration (K2-K6 primitives)
- `get_changed_files()`: git diff for commit (--cached) and push (origin/main..HEAD) stages
- `run_precommit()`: delegate to pre-commit framework with file list
- `run_check()`: execute custom check commands with timeout, file type filtering, pass_filenames
- `run_build()`: execute build command (push stage only)
- `run_stage()`: two-stage orchestration — commit stage collects all errors, push stage fail-fasts on commit failure
- Data models: Violation, CheckResult, CheckReport dataclasses

Closes #18

## Test plan

- [x] 27 unit tests covering models + core primitives
- [x] get_changed_files: commit/push commands, empty output, git error
- [x] run_check: success, failure, timeout, disabled, no matching files, pass_filenames
- [x] run_build: success, failure
- [x] run_stage: commit checks, custom checks, push fail-fast, push with build
- [x] File type filtering: python, typescript, multiple types, no filter
- [x] Full test suite (577 tests) passes with no regressions
- [x] All pre-commit hooks pass

Generated with Claude Code