### PR TITLE
feat(reporter): add terminal and Markdown report formatting (WP3.2)

### DIFF
--- a/src/ai_guard/reporter/__init__.py
+++ b/src/ai_guard/reporter/__init__.py
@@ -1,5 +1,12 @@
-"""Reporter module — audit logging and reporting."""
+"""Reporter module — audit logging and report formatting."""
 
 from ai_guard.reporter.audit import append_audit_log, apply_retention
+from ai_guard.reporter.formatting import format_gate, format_markdown, format_terminal
 
-__all__ = ["append_audit_log", "apply_retention"]
+__all__ = [
+    "append_audit_log",
+    "apply_retention",
+    "format_gate",
+    "format_markdown",
+    "format_terminal",
+]

--- a/src/ai_guard/reporter/_templates/report_en.md.j2
+++ b/src/ai_guard/reporter/_templates/report_en.md.j2
@@ -1,0 +1,36 @@
+## AI Guard Check Report
+
+**Stage**: {{ report.stage }} | **Result**: {{ "✅ PASSED" if report.passed else "❌ FAILED" }}
+
+| Check | Status | Time |
+|-------|--------|------|
+{% for r in report.results %}
+{% if r.skipped %}
+| {{ r.name }} | ⏭️ Skip | - |
+{% elif r.passed %}
+| {{ r.name }} | ✅ Pass | {{ r.duration_ms }}ms |
+{% else %}
+| {{ r.name }} | ❌ Fail | {{ r.duration_ms }}ms |
+{% endif %}
+{% endfor %}
+
+{% if violations %}
+<details>
+<summary>Violations</summary>
+
+```
+{% for v in violations %}
+{% if v.line is not none %}
+{{ v.file }}:{{ v.line }}: {{ v.message }}{% if v.code %} [{{ v.code }}]{% endif %}
+
+{% else %}
+{{ v.file }}: {{ v.message }}{% if v.code %} [{{ v.code }}]{% endif %}
+
+{% endif %}
+{% endfor %}
+```
+
+</details>
+{% endif %}
+
+**{{ passed }}/{{ total }}** checks passed

--- a/src/ai_guard/reporter/_templates/report_zh_cn.md.j2
+++ b/src/ai_guard/reporter/_templates/report_zh_cn.md.j2
@@ -1,0 +1,36 @@
+## AI Guard 检查报告
+
+**阶段**: {{ report.stage }} | **结果**: {{ "✅ 通过" if report.passed else "❌ 失败" }}
+
+| 检查项 | 状态 | 耗时 |
+|--------|------|------|
+{% for r in report.results %}
+{% if r.skipped %}
+| {{ r.name }} | ⏭️ 跳过 | - |
+{% elif r.passed %}
+| {{ r.name }} | ✅ 通过 | {{ r.duration_ms }}ms |
+{% else %}
+| {{ r.name }} | ❌ 失败 | {{ r.duration_ms }}ms |
+{% endif %}
+{% endfor %}
+
+{% if violations %}
+<details>
+<summary>违规详情</summary>
+
+```
+{% for v in violations %}
+{% if v.line is not none %}
+{{ v.file }}:{{ v.line }}: {{ v.message }}{% if v.code %} [{{ v.code }}]{% endif %}
+
+{% else %}
+{{ v.file }}: {{ v.message }}{% if v.code %} [{{ v.code }}]{% endif %}
+
+{% endif %}
+{% endfor %}
+```
+
+</details>
+{% endif %}
+
+**{{ passed }}/{{ total }}** 项检查通过

--- a/src/ai_guard/reporter/formatting.py
+++ b/src/ai_guard/reporter/formatting.py
@@ -1,0 +1,185 @@
+"""Reporter formatting — terminal, gate, and Markdown output.
+
+Converts CheckReport into human-readable formats for terminal
+display, Git Hook output, and PR comment rendering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jinja2 import Environment, FileSystemLoader
+
+if TYPE_CHECKING:
+    from typing import Any
+
+__all__ = ["format_gate", "format_markdown", "format_terminal"]
+
+_TEMPLATE_DIR = Path(__file__).parent / "_templates"
+
+# Jinja2 environment (singleton)
+_jinja_env: Environment | None = None
+
+_LOCALE_TEMPLATES = {
+    "en": "report_en.md.j2",
+    "zh-CN": "report_zh_cn.md.j2",
+}
+
+
+def _get_env() -> Environment:
+    """Get or create Jinja2 environment."""
+    global _jinja_env
+    if _jinja_env is None:
+        _jinja_env = Environment(
+            loader=FileSystemLoader(_TEMPLATE_DIR),
+            autoescape=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+    return _jinja_env
+
+
+# ---------------------------------------------------------------------------
+# R1: Terminal format
+# ---------------------------------------------------------------------------
+
+
+def format_terminal(
+    report: Any,
+    verbosity: str = "normal",
+) -> str:
+    """Format a CheckReport for terminal display.
+
+    Args:
+        report: Any to format.
+        verbosity: Output detail level ("quiet", "normal", "verbose").
+
+    Returns:
+        Formatted string for terminal output.
+    """
+    status = "PASSED" if report.passed else "FAILED"
+
+    if verbosity == "quiet":
+        return f"{report.stage}: {status}"
+
+    lines: list[str] = []
+    lines.append(f"Stage: {report.stage} — {status}")
+    lines.append("")
+
+    for result in report.results:
+        indicator = _result_indicator(result)
+        duration = f" ({result.duration_ms}ms)" if result.duration_ms else ""
+        lines.append(f"  [{indicator}] {result.name}{duration}")
+
+        if verbosity == "verbose" and result.output:
+            lines.extend(
+                f"    > {output_line}"
+                for output_line in result.output.strip().split("\n")
+            )
+
+        lines.extend(f"    {_format_violation(v)}" for v in result.violations)
+
+    lines.append("")
+    passed = sum(1 for r in report.results if r.passed)
+    total = len(report.results)
+    failed = total - passed
+    lines.append(f"{passed}/{total} checks passed, {failed} failed")
+
+    if report.duration_ms:
+        lines.append(f"Total time: {report.duration_ms}ms")
+
+    return "\n".join(lines)
+
+
+def _result_indicator(result: object) -> str:
+    """Return status indicator for a CheckResult.
+
+    Args:
+        result: CheckResult-like object with passed/skipped attrs.
+
+    Returns:
+        "PASS", "FAIL", or "SKIP".
+    """
+    if getattr(result, "skipped", False):
+        return "SKIP"
+    return "PASS" if result.passed else "FAIL"  # type: ignore[union-attr]
+
+
+def _format_violation(v: Any) -> str:
+    """Format a single violation for terminal display.
+
+    Args:
+        v: Any to format.
+
+    Returns:
+        Formatted violation string.
+    """
+    loc = v.file
+    if v.line is not None:
+        loc += f":{v.line}"
+        if v.column is not None:
+            loc += f":{v.column}"
+    msg = f"{loc}: {v.message}" if v.message else loc
+    if v.code:
+        msg += f" [{v.code}]"
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# R2: Gate format
+# ---------------------------------------------------------------------------
+
+
+def format_gate(report: Any) -> tuple[str, int]:
+    """Format a CheckReport for Git Hook gate output.
+
+    Args:
+        report: Any to format.
+
+    Returns:
+        Tuple of (message, exit_code).
+    """
+    if report.passed:
+        return f"ai-guard: {report.stage} checks passed", 0
+
+    failed_names = [r.name for r in report.results if not r.passed]
+    msg = f"ai-guard: {report.stage} checks failed: {', '.join(failed_names)}"
+    return msg, 1
+
+
+# ---------------------------------------------------------------------------
+# Markdown format
+# ---------------------------------------------------------------------------
+
+
+def format_markdown(
+    report: Any,
+    locale: str = "en",
+) -> str:
+    """Format a CheckReport as Markdown using Jinja2 templates.
+
+    Args:
+        report: Any to format.
+        locale: Locale for template selection ("en" or "zh-CN").
+
+    Returns:
+        Markdown-formatted string.
+    """
+    template_name = _LOCALE_TEMPLATES.get(locale, "report_en.md.j2")
+    env = _get_env()
+    template = env.get_template(template_name)
+
+    violations: list[Any] = []
+    for result in report.results:
+        violations.extend(result.violations)
+
+    passed = sum(1 for r in report.results if r.passed)
+    total = len(report.results)
+
+    return template.render(
+        report=report,
+        violations=violations,
+        passed=passed,
+        total=total,
+    )

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -1,0 +1,185 @@
+"""Tests for Reporter formatting (R1, R2, Markdown)."""
+
+from __future__ import annotations
+
+from ai_guard.checker.models import CheckReport, CheckResult, Violation
+from ai_guard.reporter.formatting import format_gate, format_markdown, format_terminal
+
+
+def _passed_report() -> CheckReport:
+    """Create a passing report for testing."""
+    return CheckReport(
+        stage="commit",
+        passed=True,
+        results=[
+            CheckResult(name="format", passed=True, duration_ms=23),
+            CheckResult(name="naming", passed=True, duration_ms=15),
+        ],
+        duration_ms=38,
+    )
+
+
+def _failed_report() -> CheckReport:
+    """Create a failing report with violations."""
+    return CheckReport(
+        stage="push",
+        passed=False,
+        results=[
+            CheckResult(name="lint", passed=True, duration_ms=50),
+            CheckResult(
+                name="test",
+                passed=False,
+                duration_ms=200,
+                violations=[
+                    Violation(
+                        file="src/main.py",
+                        line=10,
+                        column=5,
+                        code="E501",
+                        message="line too long",
+                        source="ruff",
+                    ),
+                    Violation(
+                        file="src/util.py",
+                        line=22,
+                        message="unused import",
+                        code="F401",
+                    ),
+                ],
+                output="ruff check failed\n",
+            ),
+        ],
+        duration_ms=250,
+    )
+
+
+def _skipped_report() -> CheckReport:
+    """Create a report with skipped checks."""
+    return CheckReport(
+        stage="commit",
+        passed=True,
+        results=[
+            CheckResult(name="format", passed=True, duration_ms=10),
+            CheckResult(name="build", passed=True, skipped=True),
+        ],
+        duration_ms=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestFormatTerminal
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTerminal:
+    """Tests for format_terminal (R1)."""
+
+    def test_passed_report(self) -> None:
+        """Passing report shows PASSED."""
+        output = format_terminal(_passed_report())
+        assert "PASSED" in output
+        assert "commit" in output
+
+    def test_failed_report(self) -> None:
+        """Failing report shows FAILED and violation details."""
+        output = format_terminal(_failed_report())
+        assert "FAILED" in output
+        assert "src/main.py:10" in output
+        assert "line too long" in output
+
+    def test_skipped_checks(self) -> None:
+        """Skipped checks show SKIP indicator."""
+        output = format_terminal(_skipped_report())
+        assert "SKIP" in output
+
+    def test_violations_shown(self) -> None:
+        """Violation file, line, code are displayed."""
+        output = format_terminal(_failed_report())
+        assert "E501" in output
+        assert "src/util.py:22" in output
+
+    def test_verbosity_quiet(self) -> None:
+        """Quiet mode shows minimal output."""
+        output = format_terminal(_failed_report(), verbosity="quiet")
+        assert "FAILED" in output
+        # Should not contain per-check details
+        assert "[PASS]" not in output
+        assert "[FAIL]" not in output
+
+    def test_verbosity_verbose(self) -> None:
+        """Verbose mode shows check output."""
+        output = format_terminal(_failed_report(), verbosity="verbose")
+        assert "ruff check failed" in output
+
+    def test_duration_shown(self) -> None:
+        """Duration is displayed."""
+        output = format_terminal(_passed_report())
+        assert "38ms" in output
+
+    def test_pass_fail_count(self) -> None:
+        """Shows pass/fail summary count."""
+        output = format_terminal(_failed_report())
+        assert "1/2" in output
+
+
+# ---------------------------------------------------------------------------
+# TestFormatGate
+# ---------------------------------------------------------------------------
+
+
+class TestFormatGate:
+    """Tests for format_gate (R2)."""
+
+    def test_passed_gate(self) -> None:
+        """Passing report returns exit code 0."""
+        msg, code = format_gate(_passed_report())
+        assert code == 0
+        assert "passed" in msg
+
+    def test_failed_gate(self) -> None:
+        """Failing report returns exit code 1 with failed check names."""
+        msg, code = format_gate(_failed_report())
+        assert code == 1
+        assert "test" in msg
+        assert "failed" in msg
+
+
+# ---------------------------------------------------------------------------
+# TestFormatMarkdown
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMarkdown:
+    """Tests for format_markdown."""
+
+    def test_markdown_table(self) -> None:
+        """Markdown output contains a results table."""
+        md = format_markdown(_passed_report())
+        assert "| Check" in md or "| check" in md.lower()
+        assert "format" in md
+
+    def test_violations_in_details(self) -> None:
+        """Violations are in a collapsible details section."""
+        md = format_markdown(_failed_report())
+        assert "<details>" in md
+        assert "src/main.py" in md
+
+    def test_passed_emoji(self) -> None:
+        """Passed report has success emoji."""
+        md = format_markdown(_passed_report())
+        assert "✅" in md
+
+    def test_failed_emoji(self) -> None:
+        """Failed report has failure emoji."""
+        md = format_markdown(_failed_report())
+        assert "❌" in md
+
+    def test_zh_cn_locale(self) -> None:
+        """Chinese locale produces Chinese text."""
+        md = format_markdown(_passed_report(), locale="zh-CN")
+        assert "检查" in md or "报告" in md or "通过" in md
+
+    def test_no_violations_no_details(self) -> None:
+        """Report without violations omits details block."""
+        md = format_markdown(_passed_report())
+        assert "<details>" not in md


### PR DESCRIPTION
## Summary

- `format_terminal()` (R1): structured text with PASS/FAIL/SKIP indicators, violation details (file:line:col + code), duration, pass/fail count. Supports quiet/normal/verbose verbosity.
- `format_gate()` (R2): minimal one-line output + binary exit code (0/1) for Git Hook environments
- `format_markdown()`: Jinja2 template-driven Markdown with results table, collapsible violations section, emoji status indicators
- Two locale templates: `report_en.md.j2` (English), `report_zh_cn.md.j2` (Chinese)
- Reporter uses duck typing (no checker import) for clean module layering

Closes #19

## Test plan

- [x] 16 tests covering all three formats
- [x] Terminal: passed/failed/skipped, violations, quiet/verbose, duration, counts
- [x] Gate: exit code 0 for pass, 1 for fail with failed check names
- [x] Markdown: table, violations details, emojis, zh-CN locale, no-violations
- [x] Full test suite (593 tests) passes with no regressions
- [x] All pre-commit hooks pass (including import dependency check)

Generated with Claude Code