### PR TITLE
feat(cli): add check, verify, run, gate commands (WP3.3)

### DIFF
--- a/src/ai_guard/checker/core.py
+++ b/src/ai_guard/checker/core.py
@@ -306,6 +306,7 @@ def run_stage(
     code_config: CodeConfig,
     project_root: Path,
     build_command: str | None = None,
+    files: list[str] | None = None,
 ) -> CheckReport:
     """Orchestrate all checks for a stage.
 
@@ -317,6 +318,7 @@ def run_stage(
         code_config: CodeConfig with enabled flags and checks.
         project_root: Path to project root directory.
         build_command: Optional build command (push stage only).
+        files: Explicit file list. If None, auto-detect via git.
 
     Returns:
         CheckReport with aggregated results.
@@ -325,7 +327,7 @@ def run_stage(
 
     if stage == "push":
         # Fail-fast: run commit stage first
-        commit_report = run_stage("commit", code_config, project_root)
+        commit_report = run_stage("commit", code_config, project_root, files=files)
         if not commit_report.passed:
             elapsed = int((time.monotonic() - start) * 1000)
             return CheckReport(
@@ -335,7 +337,8 @@ def run_stage(
                 duration_ms=elapsed,
             )
 
-    files = get_changed_files(stage, project_root)
+    if files is None:
+        files = get_changed_files(stage, project_root)
     results: list[CheckResult] = []
 
     if stage == "commit":

--- a/src/ai_guard/cli/check.py
+++ b/src/ai_guard/cli/check.py
@@ -1,0 +1,159 @@
+"""check, verify, run, and gate command implementations for AI Guard CLI.
+
+Provides CLI entry points for code quality checking, delegating to
+the Checker module for execution and Reporter for output formatting.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai_guard.checker.core import (
+    get_changed_files,
+    run_check,
+    run_precommit,
+    run_stage,
+)
+from ai_guard.checker.models import CheckReport
+from ai_guard.config.exceptions import ConfigError
+from ai_guard.config.merger import resolve_config
+from ai_guard.reporter.formatting import format_gate, format_terminal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "check_command",
+    "gate_run_command",
+    "run_command",
+    "verify_command",
+]
+
+_BUILTIN_CHECKS = frozenset({"format", "naming", "lint"})
+
+
+def check_command(
+    files: list[str],
+    config_path: Path,
+) -> None:
+    """Execute the check command (commit-stage checks).
+
+    Args:
+        files: Explicit file list, or empty for auto-detect.
+        config_path: Path to guard.yaml.
+    """
+    resolved = _load_config(config_path)
+    project_root = config_path.parent.resolve()
+    file_list = files or None
+
+    report = run_stage("commit", resolved.code, project_root, files=file_list)
+
+    output = format_terminal(report, verbosity=resolved.output.verbosity)
+    print(output)
+    raise SystemExit(0 if report.passed else 1)
+
+
+def verify_command(
+    skip_build: bool,
+    config_path: Path,
+) -> None:
+    """Execute the verify command (push-stage validation).
+
+    Args:
+        skip_build: Whether to skip the build step.
+        config_path: Path to guard.yaml.
+    """
+    resolved = _load_config(config_path)
+    project_root = config_path.parent.resolve()
+    build_cmd = None if skip_build else resolved.build_command
+
+    report = run_stage("push", resolved.code, project_root, build_command=build_cmd)
+
+    output = format_terminal(report, verbosity=resolved.output.verbosity)
+    print(output)
+    raise SystemExit(0 if report.passed else 1)
+
+
+def run_command(
+    name: str,
+    stage: str,
+    files: list[str],
+    config_path: Path,
+) -> None:
+    """Execute the run command (single check item).
+
+    Args:
+        name: Check name to run.
+        stage: Check stage ("commit" or "push").
+        files: Explicit file list, or empty for auto-detect.
+        config_path: Path to guard.yaml.
+    """
+    resolved = _load_config(config_path)
+    project_root = config_path.parent.resolve()
+    file_list = files or get_changed_files(stage, project_root)
+
+    # Built-in pre-commit checks
+    if name in _BUILTIN_CHECKS:
+        result = run_precommit(name, file_list, project_root)
+    else:
+        # Search custom checks in both stages
+        check_item = resolved.code.commit_checks.get(name)
+        if check_item is None:
+            check_item = resolved.code.push_checks.get(name)
+        if check_item is None:
+            print(f"Error: Check '{name}' not found in {stage} stage.")
+            available = list(resolved.code.commit_checks) + list(
+                resolved.code.push_checks
+            )
+            if available:
+                print(f"Available checks: {', '.join(available)}")
+            raise SystemExit(1)
+        result = run_check(name, check_item, file_list, project_root)
+
+    report = CheckReport(
+        stage=stage,
+        passed=result.passed,
+        results=[result],
+        duration_ms=result.duration_ms,
+    )
+
+    output = format_terminal(report, verbosity=resolved.output.verbosity)
+    print(output)
+    raise SystemExit(0 if report.passed else 1)
+
+
+def gate_run_command(
+    stage: str,
+    config_path: Path,
+) -> None:
+    """Execute the gate run command (Git Hook entry).
+
+    Args:
+        stage: Check stage ("commit" or "push").
+        config_path: Path to guard.yaml.
+    """
+    resolved = _load_config(config_path)
+    project_root = config_path.parent.resolve()
+    build_cmd = resolved.build_command if stage == "push" else None
+
+    report = run_stage(stage, resolved.code, project_root, build_command=build_cmd)
+
+    message, exit_code = format_gate(report)
+    print(message)
+    raise SystemExit(exit_code)
+
+
+def _load_config(config_path: Path):
+    """Load and resolve config, handling errors.
+
+    Args:
+        config_path: Path to guard.yaml.
+
+    Returns:
+        ResolvedConfig.
+    """
+    try:
+        return resolve_config(config_path)
+    except ConfigError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -6,6 +6,12 @@ from typing import Annotated
 import typer
 
 from ai_guard import __version__
+from ai_guard.cli.check import (
+    check_command,
+    gate_run_command,
+    run_command,
+    verify_command,
+)
 from ai_guard.cli.init import init_command
 from ai_guard.cli.install import install_command, uninstall_command, update_command
 from ai_guard.cli.status import agents_command, doctor_command, status_command
@@ -207,3 +213,78 @@ def agents() -> None:
     """Display agent capability matrix and installation status."""
     project_root = Path.cwd()
     agents_command(project_root=project_root)
+
+
+@app.command()
+def check(
+    files: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--files",
+            help="Explicit file paths to check (default: staged files)",
+        ),
+    ] = None,
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Run commit-stage quality checks."""
+    check_command(files=files or [], config_path=config)
+
+
+@app.command()
+def verify(
+    skip_build: Annotated[
+        bool,
+        typer.Option("--skip-build", help="Skip the build step"),
+    ] = False,
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Run full push-stage validation (includes commit checks)."""
+    verify_command(skip_build=skip_build, config_path=config)
+
+
+@app.command(name="run")
+def run_single(
+    name: Annotated[str, typer.Argument(help="Check name to run")],
+    stage: Annotated[
+        str,
+        typer.Option("--stage", "-s", help="Check stage (commit or push)"),
+    ] = "commit",
+    files: Annotated[
+        list[str] | None,
+        typer.Option("--files", help="Explicit file paths to check"),
+    ] = None,
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Run a single named check item."""
+    run_command(name=name, stage=stage, files=files or [], config_path=config)
+
+
+# gate subcommand group
+gate_app = typer.Typer(name="gate", help="Git Hook entry points.")
+
+
+@gate_app.command(name="run")
+def gate_run(
+    stage: Annotated[
+        str,
+        typer.Option("--stage", "-s", help="Check stage (commit or push)"),
+    ] = "commit",
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Internal entry point for Git hooks."""
+    gate_run_command(stage=stage, config_path=config)
+
+
+app.add_typer(gate_app)

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -1,0 +1,235 @@
+"""Tests for check, verify, run, and gate commands (WP3.3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from typer.testing import CliRunner
+
+from ai_guard.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_config(tmp_path: Path) -> Path:
+    """Write a minimal guard.yaml and return path."""
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {"version": 1, "project": {"name": "test", "language": "python"}},
+            default_flow_style=False,
+        ),
+    )
+    return config
+
+
+def _write_config_with_checks(tmp_path: Path) -> Path:
+    """Write guard.yaml with custom checks."""
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "project": {"name": "test", "language": "python"},
+                "code": {
+                    "commit": {
+                        "format": False,
+                        "naming": False,
+                        "checks": {
+                            "echo-test": {"command": "echo ok"},
+                        },
+                    },
+                    "push": {
+                        "lint": False,
+                        "checks": {
+                            "fail-test": {"command": "exit 1"},
+                        },
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+    )
+    return config
+
+
+# ---------------------------------------------------------------------------
+# TestCheckCommand
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCommand:
+    """Tests for guard check command."""
+
+    def test_check_passed(self, tmp_path: Path) -> None:
+        """Passing checks return exit 0 and PASSED."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "PASSED" in result.output
+
+    def test_check_failed(self, tmp_path: Path) -> None:
+        """Failing checks return exit 1 and FAILED."""
+        config = _write_config_with_checks(tmp_path)
+        # Add a failing check to commit stage
+        config.write_text(
+            yaml.dump(
+                {
+                    "version": 1,
+                    "project": {"name": "test", "language": "python"},
+                    "code": {
+                        "commit": {
+                            "format": False,
+                            "naming": False,
+                            "checks": {"fail": {"command": "exit 1"}},
+                        },
+                    },
+                },
+                default_flow_style=False,
+            ),
+        )
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 1
+        assert "FAILED" in result.output
+
+    def test_check_no_config(self, tmp_path: Path) -> None:
+        """Missing guard.yaml exits with error."""
+        config = tmp_path / "guard.yaml"
+        result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 1
+
+    def test_check_with_files(self, tmp_path: Path) -> None:
+        """--files option passes files to checker."""
+        config = _write_config(tmp_path)
+        # With format/naming enabled and explicit files, pre-commit will
+        # be called but skip (no pre-commit config in tmp_path)
+        with patch("ai_guard.checker.core.shutil.which", return_value=None):
+            result = runner.invoke(
+                app,
+                [
+                    "check",
+                    "--files",
+                    "a.py",
+                    "--files",
+                    "b.py",
+                    "--config",
+                    str(config),
+                ],
+            )
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestVerifyCommand
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCommand:
+    """Tests for guard verify command."""
+
+    def test_verify_passed(self, tmp_path: Path) -> None:
+        """Passing verify returns exit 0."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["verify", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "PASSED" in result.output
+
+    def test_verify_skip_build(self, tmp_path: Path) -> None:
+        """--skip-build skips build step."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["verify", "--skip-build", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestRunCommand
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommand:
+    """Tests for guard run <name> command."""
+
+    def test_run_builtin_format(self, tmp_path: Path) -> None:
+        """Running built-in format check."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["run", "format", "--config", str(config)])
+        # pre-commit skipped (no files) → passed
+        assert result.exit_code == 0
+
+    def test_run_custom_check(self, tmp_path: Path) -> None:
+        """Running a custom check by name."""
+        config = _write_config_with_checks(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])
+        assert result.exit_code == 0
+
+    def test_run_not_found(self, tmp_path: Path) -> None:
+        """Running non-existent check exits with error."""
+        config = _write_config(tmp_path)
+        result = runner.invoke(app, ["run", "nonexistent", "--config", str(config)])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestGateRunCommand
+# ---------------------------------------------------------------------------
+
+
+class TestGateRunCommand:
+    """Tests for guard gate run command."""
+
+    def test_gate_commit_passed(self, tmp_path: Path) -> None:
+        """Gate run with passing checks outputs minimal text."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["gate", "run", "--stage", "commit", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert "passed" in result.output
+
+    def test_gate_commit_failed(self, tmp_path: Path) -> None:
+        """Gate run with failing checks exits 1."""
+        config = tmp_path / "guard.yaml"
+        config.write_text(
+            yaml.dump(
+                {
+                    "version": 1,
+                    "project": {"name": "test", "language": "python"},
+                    "code": {
+                        "commit": {
+                            "format": False,
+                            "naming": False,
+                            "checks": {"fail": {"command": "exit 1"}},
+                        },
+                    },
+                },
+                default_flow_style=False,
+            ),
+        )
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["gate", "run", "--stage", "commit", "--config", str(config)]
+            )
+        assert result.exit_code == 1
+        assert "failed" in result.output
+
+    def test_gate_push(self, tmp_path: Path) -> None:
+        """Gate run push stage works."""
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["gate", "run", "--stage", "push", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert "passed" in result.output


### PR DESCRIPTION
## Summary

- `guard check [--files]`: run commit-stage checks (format + naming + custom) with optional explicit file list
- `guard verify [--skip-build]`: run full push-stage validation including commit fail-fast, build, lint, and custom checks
- `guard run <name> [--stage]`: run a single named check item (built-in or custom) for debugging
- `guard gate run --stage`: Git Hook entry point with minimal one-line output and binary exit code (0/1)
- Add `files` parameter to `checker.run_stage()` for explicit file list override

Closes #20

## Test plan

- [x] 12 unit tests covering all four commands
- [x] check: pass/fail, missing config, explicit --files
- [x] verify: pass, --skip-build
- [x] run: built-in format, custom check, not-found error
- [x] gate: commit pass/fail, push stage
- [x] Full test suite (605 tests) passes with no regressions
- [x] All pre-commit hooks pass

Generated with Claude Code