### PR TITLE
docs(readme): rewrite for open-source readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,234 @@
+![CI](https://github.com/ikroal/ai-code-guard/actions/workflows/ci.yml/badge.svg)
 ![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Status](https://img.shields.io/badge/status-design%20complete-yellow)
+![Tests](https://img.shields.io/badge/tests-624%20passed-brightgreen)
 
 # AI Guard
 
-**Guardian system for AI coding agents — behavior constraints and code quality gates.**
+**Guardrails for AI coding agents — behavior constraints + code quality gates, one config for all agents.**
 
 [English](README.md) | [中文](README_zh.md)
 
-> [!NOTE]
-> AI Guard is under active development. The system design is complete; Phase 1 implementation is in progress.
+---
 
-## What is AI Guard?
+AI coding agents (Claude Code, Cursor, OpenCode, Copilot, etc.) can autonomously read files, write code, and execute shell commands. Without guardrails, they can force-push, access secrets, skip hooks, or introduce quality regressions.
 
-AI coding agents (Claude Code, Cursor, OpenCode, etc.) can autonomously read/write files, execute commands, and generate code. AI Guard provides a unified guardrail system that:
+**AI Guard** provides a unified system that:
 
-- **Constrains behavior** — intercept dangerous operations at runtime via agent hooks (e.g., force push, secret file access, bypassing checks)
-- **Gates code quality** — enforce formatting, linting, naming conventions, and custom checks at commit/push time
-- **One config, all agents** — a single `guard.yaml` drives rules for every supported AI agent
+- **Intercepts dangerous operations at runtime** via agent-native hooks (deny force-push, block secret access, require approval for config changes)
+- **Enforces code quality gates** at commit and push time (formatting, linting, naming conventions, custom checks)
+- **Works across all major AI agents** from a single `guard.yaml` configuration file
+
+## Quick Start
+
+```bash
+# Install
+pip install ai-guard
+
+# Initialize configuration
+guard init --language python
+
+# Install guardrails for your AI agent
+guard install --agent claude-code
+
+# Check code quality
+guard check
+```
+
+## How It Works
+
+```
+guard.yaml (single source of truth)
+    |
+    +---> Generator ---> Rule docs (CLAUDE.md, .cursor/rules/, ...)
+    |                 +-> Hook scripts (interceptor.py, check.sh, ...)
+    |                 +-> .pre-commit-config.yaml
+    |                 +-> .ai-guard/policy.json
+    |
+    +---> Enforcer (runtime) ---> allow / deny / ask
+    |         reads policy.json
+    |         matches patterns (glob + regex)
+    |         fail-closed on errors
+    |
+    +---> Checker (commit/push) ---> PASS / FAIL
+              format + naming + lint
+              custom checks
+              build verification
+```
 
 ## Supported Agents
 
-| Agent | Behavior Interception | Code Quality Gates |
-|-------|----------------------|-------------------|
-| Claude Code | Full (Hook) | Full |
-| Cursor | Full (Hook) | Full |
-| OpenCode | Full (Plugin) | Full |
-| GitHub Copilot | Rule doc only | Full |
-| KiloCode | Rule doc only | Full |
+| Agent | Runtime Interception | Code Quality Gates | Rule Doc |
+|-------|---------------------|-------------------|----------|
+| **Claude Code** | Hook (deny + ask) | Full | `CLAUDE.md` |
+| **Cursor** | Hook (deny only) | Full | `.cursor/rules/behavior.mdc` |
+| **OpenCode** | Plugin (deny + ask) | Full | `AGENTS.md` |
+| **GitHub Copilot** | Rule doc only | Full | `.github/copilot-instructions.md` |
+| **KiloCode** | Rule doc only | Full | `.kilocode/rules/behavior.md` |
+
+**Runtime interception** means the agent's hook system blocks forbidden operations before they execute. Agents without hook support still receive behavior rules in their rule documents as soft constraints.
+
+## Configuration
+
+All rules live in `guard.yaml`:
+
+```yaml
+version: 1
+project:
+  name: my-project
+  language: python
+
+behavior:
+  write:
+    forbidden:
+      - pattern: "file:.git/**"
+        reason: "Git internals are read-only"
+      - pattern: "file:**/.env"
+        reason: "Secret files must not be modified"
+    require_approval:
+      - pattern: "file:.github/workflows/**"
+        message: "CI config changes need review"
+    allow:
+      - pattern: "file:src/**"
+      - pattern: "file:tests/**"
+  execute:
+    forbidden:
+      - pattern: "shell:git push --force*"
+        reason: "Force push is not allowed"
+      - pattern: "shell:git commit --no-verify*"
+        reason: "Cannot skip hooks"
+
+code:
+  commit:
+    format: true
+    naming: true
+    checks:
+      license-header:
+        command: "./scripts/check-license.sh"
+        types: [python]
+  push:
+    lint: true
+    checks:
+      test:
+        command: "pytest --cov"
+        pass_filenames: false
+```
+
+### Pattern Syntax
+
+Patterns use `{scheme}:{glob_or_regex}` format:
+
+| Scheme | Resource | Example |
+|--------|----------|---------|
+| `file:` | File paths | `file:**/.env`, `file:.git/**` |
+| `shell:` | Shell commands | `shell:git push --force*` |
+| `mcp:` | MCP tools | `mcp:memory:delete_*` |
+| `web:` | Web URLs | `web:*.internal.com` |
+
+Default matching is **glob** (`*` and `**`). Add `regex: true` for regex:
+
+```yaml
+- pattern: "shell:git\\s+push\\s+--force.*"
+  regex: true
+```
+
+### Three-Tier Decision Logic
+
+```
+forbidden       --> DENY   (blocks the operation)
+require_approval --> ASK    (prompts for confirmation)
+allow           --> ALLOW  (explicitly permits)
+no match        --> ALLOW  (default)
+```
+
+Priority: forbidden > require_approval > allow > default.
+
+## CLI Commands
+
+### Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `guard init --language <lang>` | Generate `guard.yaml` from presets (minimal/standard/strict) |
+| `guard install --agent <name>` | Generate rule docs, hooks, and configs for agents |
+| `guard update` | Regenerate all artifacts after config changes |
+| `guard uninstall` | Remove all generated artifacts |
+
+### Code Quality
+
+| Command | Description |
+|---------|-------------|
+| `guard check [--files ...]` | Run commit-stage checks (format + naming + custom) |
+| `guard verify [--skip-build]` | Run full push-stage validation |
+| `guard run <name>` | Run a single named check |
+| `guard gate run --stage <stage>` | Git hook entry point (minimal output) |
+
+### Diagnostics
+
+| Command | Description |
+|---------|-------------|
+| `guard status [--rules]` | Installation state, drift detection, artifact integrity |
+| `guard doctor` | Environment diagnostics (Python, Git, pre-commit) |
+| `guard agents` | Agent capability matrix with install status |
+| `guard version` | Print version |
 
 ## Architecture
 
-```mermaid
-graph LR
-    A[guard.yaml] --> B[Config]
-    B --> C[Generator]
-    B --> E[Enforcer]
-    B --> F[Checker]
-    C --> D[AgentAdapter]
-    F --> G[Reporter]
-    E --> G
+```
+src/ai_guard/
+  config/      Load, validate, merge guard.yaml
+  generator/   Produce rule docs, hooks, tool configs, git hooks
+  adapters/    Agent-specific rendering (5 adapters)
+  enforcer/    Runtime pattern matching + policy decisions
+  checker/     Commit/push check orchestration
+  reporter/    Audit logging + terminal/Markdown/gate formatting
+  cli/         Typer CLI with 13 commands
 ```
 
-| Module | Responsibility |
-|--------|---------------|
-| **Config** | Load, merge, and validate configuration |
-| **Generator** | Produce rule docs, hook scripts, tool configs, and git hooks |
-| **AgentAdapter** | Adapt unified rules to agent-specific formats |
-| **Enforcer** | Runtime policy matching and decision (allow / deny / ask) |
-| **Checker** | Orchestrate commit/push verification |
-| **Reporter** | Format and deliver check results and audit logs |
+### Key Design Decisions
 
-## Roadmap
+- **Fail-closed**: Enforcer errors default to deny (not allow)
+- **Generation vs. execution**: All config parsing happens at `install` time; runtime hooks only evaluate pre-built policy
+- **Exit-code only**: Checks pass or fail based on exit code, no output parsing
+- **Non-blocking audit**: Audit log failures never affect policy decisions
+- **Agent-agnostic core**: Enforcer and Checker know nothing about specific agents
 
-- [x] System design complete
-- [ ] **Phase 1** — Config + Generator + CLI (8 commands)
-- [ ] **Phase 2** — Enforcer + runtime behavior interception
-- [ ] **Phase 3** — Checker + Reporter + code quality gates
+## Development
 
-## Documentation
+```bash
+# Install in development mode
+pip install -e ".[dev]"
 
-- [System Design Document](design/AI_GUARD_SYSTEM_DESIGN.md) — full architecture, module design, interfaces, and data models
+# Run tests (624 tests)
+pytest
 
-## Requirements
+# Lint
+ruff check .
 
-- Python >= 3.10
-- Git >= 2.20
+# Pre-commit hooks
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+### Project Status
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| Phase 1 | Config + Generator + CLI | Done |
+| Phase 2 | Enforcer + Agent Bridge | Done |
+| Phase 3 | Checker + Reporter | Done |
+| Phase 4 | Ruleset Management | Planned |
+| Phase 5 | PR Report & Polish | Planned |
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository
+2. Create a feature branch (`feat/your-feature`)
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+4. Ensure `pytest` passes and `ruff check .` is clean
+5. Open a pull request
 
 ## License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,71 +1,230 @@
+![CI](https://github.com/ikroal/ai-code-guard/actions/workflows/ci.yml/badge.svg)
 ![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Status](https://img.shields.io/badge/status-design%20complete-yellow)
+![Tests](https://img.shields.io/badge/tests-624%20passed-brightgreen)
 
 # AI Guard
 
-**面向 AI 编码 Agent 的看护系统 — 行为约束与代码质量门禁。**
+**AI 编码 Agent 看护系统 — 行为约束 + 代码质量门禁，一份配置适配所有 Agent。**
 
 [English](README.md) | [中文](README_zh.md)
 
-> [!NOTE]
-> AI Guard 正在积极开发中。系统设计已完成，Phase 1 实现进行中。
+---
 
-## 什么是 AI Guard？
+AI 编码 Agent（Claude Code、Cursor、OpenCode、Copilot 等）能够自主读写文件、执行命令和生成代码。没有护栏的情况下，它们可能会强制推送、访问密钥、跳过检查或引入质量退化。
 
-AI 编码 Agent（Claude Code、Cursor、OpenCode 等）能够自主读写文件、执行命令和生成代码。AI Guard 提供统一的护栏系统：
+**AI Guard** 提供统一的看护系统：
 
-- **行为约束** — 通过 Agent Hook 在运行时拦截危险操作（如强制推送、访问密钥文件、绕过检查等）
-- **代码质量门禁** — 在提交/推送时自动执行格式化、Lint、命名规范和自定义检查
-- **一份配置，适配所有 Agent** — 单一 `guard.yaml` 驱动所有支持的 AI Agent 规则生成
+- **运行时拦截危险操作** — 通过 Agent 原生 Hook 阻止强制推送、封禁密钥访问、需要审批才能修改配置
+- **提交/推送时执行代码质量门禁** — 自动检查格式化、Lint、命名规范和自定义检查项
+- **一份配置适配所有主流 AI Agent** — 单一 `guard.yaml` 驱动全部规则生成
+
+## 快速开始
+
+```bash
+# 安装
+pip install ai-guard
+
+# 初始化配置
+guard init --language python
+
+# 为 AI Agent 安装护栏
+guard install --agent claude-code
+
+# 检查代码质量
+guard check
+```
+
+## 工作原理
+
+```
+guard.yaml（单一配置源）
+    |
+    +---> Generator ---> 规则文档 (CLAUDE.md, .cursor/rules/, ...)
+    |                 +-> Hook 脚本 (interceptor.py, check.sh, ...)
+    |                 +-> .pre-commit-config.yaml
+    |                 +-> .ai-guard/policy.json
+    |
+    +---> Enforcer（运行时）---> allow / deny / ask
+    |         读取 policy.json
+    |         模式匹配（glob + regex）
+    |         错误时 fail-closed
+    |
+    +---> Checker（提交/推送时）---> PASS / FAIL
+              格式化 + 命名 + Lint
+              自定义检查
+              构建验证
+```
 
 ## 支持的 Agent
 
-| Agent | 行为拦截 | 代码质量门禁 |
-|-------|---------|------------|
-| Claude Code | 完整支持（Hook） | 完整支持 |
-| Cursor | 完整支持（Hook） | 完整支持 |
-| OpenCode | 完整支持（插件） | 完整支持 |
-| GitHub Copilot | 仅规则文档 | 完整支持 |
-| KiloCode | 仅规则文档 | 完整支持 |
+| Agent | 运行时拦截 | 代码质量门禁 | 规则文档 |
+|-------|-----------|------------|---------|
+| **Claude Code** | Hook（deny + ask） | 完整 | `CLAUDE.md` |
+| **Cursor** | Hook（仅 deny） | 完整 | `.cursor/rules/behavior.mdc` |
+| **OpenCode** | Plugin（deny + ask） | 完整 | `AGENTS.md` |
+| **GitHub Copilot** | 仅规则文档 | 完整 | `.github/copilot-instructions.md` |
+| **KiloCode** | 仅规则文档 | 完整 | `.kilocode/rules/behavior.md` |
+
+**运行时拦截** 指 Agent 的 Hook 系统在操作执行前阻止禁止的操作。不支持 Hook 的 Agent 仍会在规则文档中收到行为约束作为软约束。
+
+## 配置
+
+所有规则集中在 `guard.yaml`：
+
+```yaml
+version: 1
+project:
+  name: my-project
+  language: python
+
+behavior:
+  write:
+    forbidden:
+      - pattern: "file:.git/**"
+        reason: "Git 内部文件只读"
+      - pattern: "file:**/.env"
+        reason: "密钥文件禁止修改"
+    require_approval:
+      - pattern: "file:.github/workflows/**"
+        message: "CI 配置变更需要审批"
+    allow:
+      - pattern: "file:src/**"
+      - pattern: "file:tests/**"
+  execute:
+    forbidden:
+      - pattern: "shell:git push --force*"
+        reason: "禁止强制推送"
+      - pattern: "shell:git commit --no-verify*"
+        reason: "禁止跳过 hooks"
+
+code:
+  commit:
+    format: true
+    naming: true
+  push:
+    lint: true
+    checks:
+      test:
+        command: "pytest --cov"
+        pass_filenames: false
+```
+
+### 模式语法
+
+模式使用 `{scheme}:{glob_or_regex}` 格式：
+
+| Scheme | 资源类型 | 示例 |
+|--------|---------|------|
+| `file:` | 文件路径 | `file:**/.env`, `file:.git/**` |
+| `shell:` | Shell 命令 | `shell:git push --force*` |
+| `mcp:` | MCP 工具 | `mcp:memory:delete_*` |
+| `web:` | Web URL | `web:*.internal.com` |
+
+默认使用 **glob** 匹配。添加 `regex: true` 启用正则：
+
+```yaml
+- pattern: "shell:git\\s+push\\s+--force.*"
+  regex: true
+```
+
+### 三层决策逻辑
+
+```
+forbidden        --> DENY   （阻止操作）
+require_approval --> ASK    （提示确认）
+allow            --> ALLOW  （显式许可）
+无匹配            --> ALLOW  （默认放行）
+```
+
+优先级：forbidden > require_approval > allow > 默认。
+
+## CLI 命令
+
+### 生命周期
+
+| 命令 | 说明 |
+|------|------|
+| `guard init --language <lang>` | 从预设生成 `guard.yaml`（minimal/standard/strict） |
+| `guard install --agent <name>` | 为 Agent 生成规则文档、Hook 脚本和配置 |
+| `guard update` | 配置变更后重新生成所有工件 |
+| `guard uninstall` | 移除所有生成的工件 |
+
+### 代码质量
+
+| 命令 | 说明 |
+|------|------|
+| `guard check [--files ...]` | 运行提交阶段检查（format + naming + 自定义） |
+| `guard verify [--skip-build]` | 运行完整推送阶段验证 |
+| `guard run <name>` | 运行单个指定检查项 |
+| `guard gate run --stage <stage>` | Git Hook 内部入口（精简输出） |
+
+### 诊断
+
+| 命令 | 说明 |
+|------|------|
+| `guard status [--rules]` | 安装状态、配置漂移检测、工件完整性 |
+| `guard doctor` | 环境诊断（Python、Git、pre-commit） |
+| `guard agents` | Agent 能力矩阵与安装状态 |
+| `guard version` | 打印版本号 |
 
 ## 架构
 
-```mermaid
-graph LR
-    A[guard.yaml] --> B[Config]
-    B --> C[Generator]
-    B --> E[Enforcer]
-    B --> F[Checker]
-    C --> D[AgentAdapter]
-    F --> G[Reporter]
-    E --> G
+```
+src/ai_guard/
+  config/      加载、验证、合并 guard.yaml
+  generator/   生成规则文档、Hook 脚本、工具配置、Git Hooks
+  adapters/    Agent 适配器（5 个实现）
+  enforcer/    运行时模式匹配与策略决策
+  checker/     提交/推送检查编排
+  reporter/    审计日志 + 终端/Markdown/Gate 格式化
+  cli/         Typer CLI（13 个命令）
 ```
 
-| 模块 | 职责 |
-|------|-----|
-| **Config** | 加载、合并、校验配置 |
-| **Generator** | 生成规则文档、Hook 脚本、工具配置和 Git Hook |
-| **AgentAdapter** | 将统一规则适配为各 Agent 特定格式 |
-| **Enforcer** | 运行时策略匹配与判定（allow / deny / ask） |
-| **Checker** | 编排提交/推送阶段的检查验证 |
-| **Reporter** | 格式化与分发检查结果和审计日志 |
+### 核心设计决策
 
-## 路线图
+- **Fail-closed**：Enforcer 异常默认 deny（非 allow）
+- **生成与执行分离**：所有配置解析在 `install` 时完成；运行时 Hook 仅评估预构建的 policy
+- **仅判断退出码**：检查项通过/失败仅基于命令退出码，不解析输出
+- **非阻塞审计**：审计日志写入失败不影响策略决策
+- **Agent 无关核心**：Enforcer 和 Checker 不感知具体 Agent
 
-- [x] 系统设计完成
-- [ ] **Phase 1** — Config + Generator + CLI（8 个命令）
-- [ ] **Phase 2** — Enforcer + 运行时行为拦截
-- [ ] **Phase 3** — Checker + Reporter + 代码质量门禁
+## 开发
 
-## 文档
+```bash
+# 开发模式安装
+pip install -e ".[dev]"
 
-- [系统设计文档](design/AI_GUARD_SYSTEM_DESIGN.md) — 完整的架构、模块设计、接口和数据模型
+# 运行测试（624 个测试）
+pytest
 
-## 环境要求
+# Lint
+ruff check .
 
-- Python >= 3.10
-- Git >= 2.20
+# Pre-commit Hooks
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+### 项目状态
+
+| 阶段 | 范围 | 状态 |
+|------|------|------|
+| Phase 1 | Config + Generator + CLI | 已完成 |
+| Phase 2 | Enforcer + Agent Bridge | 已完成 |
+| Phase 3 | Checker + Reporter | 已完成 |
+| Phase 4 | Ruleset 管理 | 规划中 |
+| Phase 5 | PR 报告 & 完善 | 规划中 |
+
+## 参与贡献
+
+欢迎贡献！请遵循：
+
+1. Fork 仓库
+2. 创建功能分支（`feat/your-feature`）
+3. 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/)
+4. 确保 `pytest` 通过且 `ruff check .` 无报错
+5. 提交 Pull Request
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

Rewrite both English and Chinese READMEs from "design complete, Phase 1 in progress" to fully documenting the implemented system for open-source readiness.

### New content
- Quick Start (4 steps: install → init → install agent → check)
- How It Works diagram (Generator/Enforcer/Checker pipeline)
- Agent support matrix with runtime interception details and rule doc paths
- Configuration examples (behavior rules + code quality checks)
- Pattern syntax reference (4 schemes, glob/regex)
- Three-tier decision logic (forbidden > require_approval > allow)
- Full CLI command reference (13 commands in 3 categories)
- Architecture overview with module descriptions
- Key design decisions (fail-closed, generation vs execution, exit-code only, non-blocking audit)
- Development setup instructions (624 tests)
- Updated project phase status (1-3 done, 4-5 planned)
- Contributing guidelines

### Updated badges
- Added CI status badge
- Changed status badge from "design complete" to "624 tests passed"

Generated with Claude Code