### PR TITLE
feat(ruleset): add ruleset fetch and local cache (WP4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Status](https://img.shields.io/badge/status-design%20complete-yellow)
+![Status](https://img.shields.io/badge/status-alpha-orange)
 
 # AI Guard
 
@@ -9,7 +9,7 @@
 [English](README.md) | [中文](README_zh.md)
 
 > [!NOTE]
-> AI Guard is under active development. The system design is complete; Phase 1 implementation is in progress.
+> AI Guard is under active development. Phases 1-3 are complete; Phase 4 (Ruleset Management) is in progress.
 
 ## What is AI Guard?
 
@@ -18,6 +18,43 @@ AI coding agents (Claude Code, Cursor, OpenCode, etc.) can autonomously read/wri
 - **Constrains behavior** — intercept dangerous operations at runtime via agent hooks (e.g., force push, secret file access, bypassing checks)
 - **Gates code quality** — enforce formatting, linting, naming conventions, and custom checks at commit/push time
 - **One config, all agents** — a single `guard.yaml` drives rules for every supported AI agent
+
+## Quick Start
+
+```bash
+# Install from source
+pip install -e .
+
+# Initialize configuration
+guard init --language python
+
+# Install artifacts for your agent
+guard install --agent claude-code
+
+# Run commit-stage quality checks
+guard check
+
+# Fetch a shared ruleset
+guard ruleset fetch https://github.com/company/rules.git#v1.0
+```
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `guard init` | Generate a `guard.yaml` configuration file |
+| `guard install` | Install rule docs, hook scripts, and git hooks for agents |
+| `guard update` | Re-generate all artifacts from latest config |
+| `guard uninstall` | Remove all generated artifacts |
+| `guard status` | Show installation status and drift detection |
+| `guard doctor` | Run environment diagnostics |
+| `guard agents` | Display agent capability matrix |
+| `guard check` | Run commit-stage quality checks |
+| `guard verify` | Run full push-stage validation |
+| `guard run <name>` | Run a single named check item |
+| `guard ruleset fetch` | Fetch a ruleset from a git repository |
+| `guard ruleset list` | List cached rulesets |
+| `guard ruleset cache clear` | Clear the ruleset cache |
 
 ## Supported Agents
 
@@ -50,13 +87,16 @@ graph LR
 | **Enforcer** | Runtime policy matching and decision (allow / deny / ask) |
 | **Checker** | Orchestrate commit/push verification |
 | **Reporter** | Format and deliver check results and audit logs |
+| **Ruleset** | Fetch, cache, and manage shared external rulesets |
 
 ## Roadmap
 
 - [x] System design complete
-- [ ] **Phase 1** — Config + Generator + CLI (8 commands)
-- [ ] **Phase 2** — Enforcer + runtime behavior interception
-- [ ] **Phase 3** — Checker + Reporter + code quality gates
+- [x] **Phase 1** — Config + Generator + CLI (8 commands)
+- [x] **Phase 2** — Enforcer + runtime behavior interception
+- [x] **Phase 3** — Checker + Reporter + code quality gates
+- [ ] **Phase 4** — Ruleset fetch, caching, and management
+- [ ] **Phase 5** — PR report posting and CI/CD integration
 
 ## Documentation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 ![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Status](https://img.shields.io/badge/status-design%20complete-yellow)
+![Status](https://img.shields.io/badge/status-alpha-orange)
 
 # AI Guard
 
@@ -9,7 +9,7 @@
 [English](README.md) | [中文](README_zh.md)
 
 > [!NOTE]
-> AI Guard 正在积极开发中。系统设计已完成，Phase 1 实现进行中。
+> AI Guard 正在积极开发中。Phase 1-3 已完成，Phase 4（Ruleset 管理）进行中。
 
 ## 什么是 AI Guard？
 
@@ -18,6 +18,43 @@ AI 编码 Agent（Claude Code、Cursor、OpenCode 等）能够自主读写文件
 - **行为约束** — 通过 Agent Hook 在运行时拦截危险操作（如强制推送、访问密钥文件、绕过检查等）
 - **代码质量门禁** — 在提交/推送时自动执行格式化、Lint、命名规范和自定义检查
 - **一份配置，适配所有 Agent** — 单一 `guard.yaml` 驱动所有支持的 AI Agent 规则生成
+
+## 快速开始
+
+```bash
+# 从源码安装
+pip install -e .
+
+# 初始化配置
+guard init --language python
+
+# 为 Agent 安装工件
+guard install --agent claude-code
+
+# 运行提交阶段质量检查
+guard check
+
+# 拉取共享规则集
+guard ruleset fetch https://github.com/company/rules.git#v1.0
+```
+
+## CLI 命令
+
+| 命令 | 说明 |
+|------|------|
+| `guard init` | 生成 `guard.yaml` 配置文件 |
+| `guard install` | 为 Agent 安装规则文档、Hook 脚本和 Git Hook |
+| `guard update` | 根据最新配置重新生成所有工件 |
+| `guard uninstall` | 移除所有生成的工件 |
+| `guard status` | 显示安装状态和配置漂移检测 |
+| `guard doctor` | 运行环境诊断 |
+| `guard agents` | 显示 Agent 能力矩阵 |
+| `guard check` | 运行提交阶段质量检查 |
+| `guard verify` | 运行完整的推送阶段验证 |
+| `guard run <name>` | 运行单个命名检查项 |
+| `guard ruleset fetch` | 从 Git 仓库拉取规则集 |
+| `guard ruleset list` | 列出已缓存的规则集 |
+| `guard ruleset cache clear` | 清空规则集缓存 |
 
 ## 支持的 Agent
 
@@ -50,13 +87,16 @@ graph LR
 | **Enforcer** | 运行时策略匹配与判定（allow / deny / ask） |
 | **Checker** | 编排提交/推送阶段的检查验证 |
 | **Reporter** | 格式化与分发检查结果和审计日志 |
+| **Ruleset** | 拉取、缓存和管理共享外部规则集 |
 
 ## 路线图
 
 - [x] 系统设计完成
-- [ ] **Phase 1** — Config + Generator + CLI（8 个命令）
-- [ ] **Phase 2** — Enforcer + 运行时行为拦截
-- [ ] **Phase 3** — Checker + Reporter + 代码质量门禁
+- [x] **Phase 1** — Config + Generator + CLI（8 个命令）
+- [x] **Phase 2** — Enforcer + 运行时行为拦截
+- [x] **Phase 3** — Checker + Reporter + 代码质量门禁
+- [ ] **Phase 4** — Ruleset 拉取、缓存与管理
+- [ ] **Phase 5** — PR 报告推送与 CI/CD 集成
 
 ## 文档
 

--- a/src/ai_guard/cli/install.py
+++ b/src/ai_guard/cli/install.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
+import yaml
+
 from ai_guard.adapters.registry import AdapterNotFoundError, get_adapter, list_adapters
 from ai_guard.config.exceptions import (
     ConfigError,
 )
-from ai_guard.config.loader import load_config
+from ai_guard.config.loader import RawConfig, load_config
 from ai_guard.config.merger import resolve_config
 from ai_guard.generator.core import (
     create_state,
@@ -30,6 +32,7 @@ from ai_guard.generator.core import (
 )
 from ai_guard.generator.exceptions import ArtifactWriteError
 from ai_guard.generator.models import STATE_FILE
+from ai_guard.ruleset.cache import get_cache_dir
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -165,6 +168,49 @@ def _merge_agents(existing: list[str], new: list[str]) -> list[str]:
     return merged
 
 
+def _load_ruleset_configs(
+    project_root: Path,
+    rulesets: list[str],
+) -> list[tuple[str, RawConfig]]:
+    """Load guard.yaml from each cached ruleset.
+
+    For each ruleset name listed in the project config, looks for
+    a cached copy under ``.ai-guard/cache/<name>/guard.yaml``.
+    Warns (but does not fail) if a ruleset is not cached.
+
+    Ruleset guard.yaml files are config fragments (they may lack
+    ``version`` and ``project`` fields), so they are loaded without
+    schema validation — the merger handles partial configs.
+
+    Args:
+        project_root: Path to the project root.
+        rulesets: List of ruleset names from the project config.
+
+    Returns:
+        List of ``(name, raw_config)`` pairs for rulesets that
+        have a cached ``guard.yaml``.
+    """
+    if not rulesets:
+        return []
+
+    cache_dir = get_cache_dir(project_root)
+    pairs: list[tuple[str, RawConfig]] = []
+
+    for name in rulesets:
+        rs_config_path = cache_dir / name / "guard.yaml"
+        if rs_config_path.is_file():
+            with open(rs_config_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict):
+                pairs.append((name, data))  # type: ignore[arg-type]
+        else:
+            print(
+                f"Warning: Ruleset '{name}' not cached. Run: guard ruleset fetch <url>"
+            )
+
+    return pairs
+
+
 # ---------------------------------------------------------------------------
 # Public command functions
 # ---------------------------------------------------------------------------
@@ -202,15 +248,15 @@ def install_command(
         )
         raise SystemExit(1)
 
-    # Load and resolve config
+    # Load and resolve config (with ruleset configs from cache)
     try:
         raw_config = load_config(config_path)
-        resolved = resolve_config(config_path)
+        rulesets: list[str] = raw_config.get("rulesets", [])
+        ruleset_pairs = _load_ruleset_configs(project_root, rulesets)
+        resolved = resolve_config(config_path, rulesets=ruleset_pairs)
     except ConfigError as e:
         print(f"Error: {e}")
         raise SystemExit(1) from None
-
-    rulesets: list[str] = raw_config.get("rulesets", [])
 
     # Read existing state for incremental install
     existing_state = read_state(project_root)
@@ -253,15 +299,15 @@ def update_command(
         print("Error: AI Guard is not installed. Run 'guard install' first.")
         raise SystemExit(1)
 
-    # Load and resolve config
+    # Load and resolve config (with ruleset configs from cache)
     try:
         raw_config = load_config(config_path)
-        resolved = resolve_config(config_path)
+        rulesets: list[str] = raw_config.get("rulesets", [])
+        ruleset_pairs = _load_ruleset_configs(project_root, rulesets)
+        resolved = resolve_config(config_path, rulesets=ruleset_pairs)
     except ConfigError as e:
         print(f"Error: {e}")
         raise SystemExit(1) from None
-
-    rulesets: list[str] = raw_config.get("rulesets", [])
 
     # Resolve adapters for installed agents
     try:

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -311,7 +311,7 @@ def ruleset_fetch(
     ] = Path("."),
 ) -> None:
     """Fetch or update a ruleset from a Git repository."""
-    ruleset_fetch_command(url=url, project_root=project_root.resolve())
+    ruleset_fetch_command(url=url, project_root=Path(project_root).absolute())
 
 
 @ruleset_app.command(name="list")
@@ -322,7 +322,7 @@ def ruleset_list(
     ] = Path("."),
 ) -> None:
     """List cached rulesets."""
-    ruleset_list_command(project_root=project_root.resolve())
+    ruleset_list_command(project_root=Path(project_root).absolute())
 
 
 @cache_app.command(name="clear")
@@ -333,7 +333,7 @@ def cache_clear(
     ] = Path("."),
 ) -> None:
     """Remove all cached rulesets."""
-    ruleset_cache_clear_command(project_root=project_root.resolve())
+    ruleset_cache_clear_command(project_root=Path(project_root).absolute())
 
 
 ruleset_app.add_typer(cache_app)

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -311,7 +311,7 @@ def ruleset_fetch(
     ] = Path("."),
 ) -> None:
     """Fetch or update a ruleset from a Git repository."""
-    ruleset_fetch_command(url=url, project_root=Path(project_root).absolute())
+    ruleset_fetch_command(url=url, project_root=project_root.resolve())
 
 
 @ruleset_app.command(name="list")
@@ -322,7 +322,7 @@ def ruleset_list(
     ] = Path("."),
 ) -> None:
     """List cached rulesets."""
-    ruleset_list_command(project_root=Path(project_root).absolute())
+    ruleset_list_command(project_root=project_root.resolve())
 
 
 @cache_app.command(name="clear")
@@ -333,7 +333,7 @@ def cache_clear(
     ] = Path("."),
 ) -> None:
     """Remove all cached rulesets."""
-    ruleset_cache_clear_command(project_root=Path(project_root).absolute())
+    ruleset_cache_clear_command(project_root=project_root.resolve())
 
 
 ruleset_app.add_typer(cache_app)

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -305,21 +305,35 @@ def ruleset_fetch(
         str,
         typer.Argument(help="Git URL of the ruleset (use #version for pinning)"),
     ],
+    project_root: Annotated[
+        Path,
+        typer.Option("--project-root", "-p", help="Project root directory"),
+    ] = Path("."),
 ) -> None:
     """Fetch or update a ruleset from a Git repository."""
-    ruleset_fetch_command(url=url)
+    ruleset_fetch_command(url=url, project_root=project_root.resolve())
 
 
 @ruleset_app.command(name="list")
-def ruleset_list() -> None:
+def ruleset_list(
+    project_root: Annotated[
+        Path,
+        typer.Option("--project-root", "-p", help="Project root directory"),
+    ] = Path("."),
+) -> None:
     """List cached rulesets."""
-    ruleset_list_command()
+    ruleset_list_command(project_root=project_root.resolve())
 
 
 @cache_app.command(name="clear")
-def cache_clear() -> None:
+def cache_clear(
+    project_root: Annotated[
+        Path,
+        typer.Option("--project-root", "-p", help="Project root directory"),
+    ] = Path("."),
+) -> None:
     """Remove all cached rulesets."""
-    ruleset_cache_clear_command()
+    ruleset_cache_clear_command(project_root=project_root.resolve())
 
 
 ruleset_app.add_typer(cache_app)

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -14,6 +14,11 @@ from ai_guard.cli.check import (
 )
 from ai_guard.cli.init import init_command
 from ai_guard.cli.install import install_command, uninstall_command, update_command
+from ai_guard.cli.ruleset import (
+    ruleset_cache_clear_command,
+    ruleset_fetch_command,
+    ruleset_list_command,
+)
 from ai_guard.cli.status import agents_command, doctor_command, status_command
 
 app = typer.Typer(
@@ -288,3 +293,34 @@ def gate_run(
 
 
 app.add_typer(gate_app)
+
+# ruleset subcommand group
+ruleset_app = typer.Typer(name="ruleset", help="Manage external rulesets.")
+cache_app = typer.Typer(name="cache", help="Manage ruleset cache.")
+
+
+@ruleset_app.command(name="fetch")
+def ruleset_fetch(
+    url: Annotated[
+        str,
+        typer.Argument(help="Git URL of the ruleset (use #version for pinning)"),
+    ],
+) -> None:
+    """Fetch or update a ruleset from a Git repository."""
+    ruleset_fetch_command(url=url)
+
+
+@ruleset_app.command(name="list")
+def ruleset_list() -> None:
+    """List cached rulesets."""
+    ruleset_list_command()
+
+
+@cache_app.command(name="clear")
+def cache_clear() -> None:
+    """Remove all cached rulesets."""
+    ruleset_cache_clear_command()
+
+
+ruleset_app.add_typer(cache_app)
+app.add_typer(ruleset_app)

--- a/src/ai_guard/cli/ruleset.py
+++ b/src/ai_guard/cli/ruleset.py
@@ -1,0 +1,95 @@
+"""CLI command implementations for ruleset management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached
+from ai_guard.ruleset.exceptions import (
+    RulesetError,
+)
+from ai_guard.ruleset.fetcher import fetch_ruleset
+from ai_guard.ruleset.parser import parse_ruleset_url
+
+
+def ruleset_fetch_command(url: str, project_root: Path | None = None) -> None:
+    """Execute ``guard ruleset fetch <url>``.
+
+    Parses the URL, clones the ruleset into the local cache,
+    validates its structure, and prints a summary.
+
+    Args:
+        url: Git URL of the ruleset, optionally with ``#version``.
+        project_root: Project root directory. Defaults to cwd.
+    """
+    root = project_root or Path.cwd()
+
+    try:
+        ref = parse_ruleset_url(url)
+    except RulesetError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None
+
+    cache_root = get_cache_dir(root)
+    version_info = f" @ {ref.version}" if ref.version else ""
+    print(f"Fetching ruleset '{ref.name}'{version_info} ...")
+
+    try:
+        result_dir = fetch_ruleset(ref, cache_root)
+    except RulesetError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None
+
+    # Summarize contents
+    files_count = (
+        sum(1 for _ in (result_dir / "files").iterdir())
+        if (result_dir / "files").is_dir()
+        else 0
+    )
+    checks_count = (
+        sum(1 for _ in (result_dir / "checks").iterdir())
+        if (result_dir / "checks").is_dir()
+        else 0
+    )
+
+    print(f"Cached to {result_dir.relative_to(root)}")
+    print("  guard.yaml: found")
+    print(f"  files/: {files_count} file(s)")
+    print(f"  checks/: {checks_count} script(s)")
+
+
+def ruleset_cache_clear_command(project_root: Path | None = None) -> None:
+    """Execute ``guard ruleset cache clear``.
+
+    Removes all cached rulesets and prints the count.
+
+    Args:
+        project_root: Project root directory. Defaults to cwd.
+    """
+    root = project_root or Path.cwd()
+    count = clear_cache(root)
+
+    if count == 0:
+        print("No cached rulesets to remove.")
+    else:
+        print(f"Cleared {count} cached ruleset(s).")
+
+
+def ruleset_list_command(project_root: Path | None = None) -> None:
+    """Execute ``guard ruleset list``.
+
+    Lists cached rulesets with basic info.
+
+    Args:
+        project_root: Project root directory. Defaults to cwd.
+    """
+    root = project_root or Path.cwd()
+    names = list_cached(root)
+
+    if not names:
+        print("No cached rulesets.")
+        return
+
+    print(f"Cached rulesets ({len(names)}):")
+    for name in names:
+        print(f"  - {name}")

--- a/src/ai_guard/ruleset/__init__.py
+++ b/src/ai_guard/ruleset/__init__.py
@@ -1,0 +1,31 @@
+"""Ruleset management for AI Guard.
+
+Provides URL parsing, git-based fetch, local cache management,
+and validation for external rulesets.
+"""
+
+from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached
+from ai_guard.ruleset.exceptions import (
+    RulesetError,
+    RulesetFetchError,
+    RulesetURLError,
+    RulesetValidationError,
+)
+from ai_guard.ruleset.fetcher import fetch_ruleset, validate_ruleset_dir
+from ai_guard.ruleset.models import CACHE_DIR, RulesetRef
+from ai_guard.ruleset.parser import parse_ruleset_url
+
+__all__ = [
+    "CACHE_DIR",
+    "RulesetError",
+    "RulesetFetchError",
+    "RulesetRef",
+    "RulesetURLError",
+    "RulesetValidationError",
+    "clear_cache",
+    "fetch_ruleset",
+    "get_cache_dir",
+    "list_cached",
+    "parse_ruleset_url",
+    "validate_ruleset_dir",
+]

--- a/src/ai_guard/ruleset/cache.py
+++ b/src/ai_guard/ruleset/cache.py
@@ -7,6 +7,7 @@ cache stored under ``.ai-guard/cache/``.
 from __future__ import annotations
 
 import shutil
+import stat
 from typing import TYPE_CHECKING
 
 from ai_guard.ruleset.models import CACHE_DIR
@@ -66,6 +67,14 @@ def clear_cache(project_root: Path) -> int:
     count = 0
     for entry in cache.iterdir():
         if entry.is_dir():
-            shutil.rmtree(entry)
+            shutil.rmtree(entry, onerror=_rm_readonly)
             count += 1
     return count
+
+
+def _rm_readonly(_func: object, path: str, _exc_info: object) -> None:
+    """Error handler for shutil.rmtree on read-only files (Windows .git)."""
+    import pathlib
+
+    pathlib.Path(path).chmod(stat.S_IWRITE)
+    pathlib.Path(path).unlink()

--- a/src/ai_guard/ruleset/cache.py
+++ b/src/ai_guard/ruleset/cache.py
@@ -1,0 +1,71 @@
+"""Ruleset cache management for AI Guard.
+
+Provides functions to list, inspect, and clear the local ruleset
+cache stored under ``.ai-guard/cache/``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+from ai_guard.ruleset.models import CACHE_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["clear_cache", "get_cache_dir", "list_cached"]
+
+
+def get_cache_dir(project_root: Path) -> Path:
+    """Return the cache directory path, creating it if needed.
+
+    Args:
+        project_root: Path to the project root.
+
+    Returns:
+        Path to ``.ai-guard/cache/``.
+    """
+    cache = project_root / CACHE_DIR
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def list_cached(project_root: Path) -> list[str]:
+    """List names of cached rulesets.
+
+    Args:
+        project_root: Path to the project root.
+
+    Returns:
+        Sorted list of ruleset directory names. Empty list if the
+        cache directory does not exist.
+    """
+    cache = project_root / CACHE_DIR
+    if not cache.is_dir():
+        return []
+    return sorted(p.name for p in cache.iterdir() if p.is_dir())
+
+
+def clear_cache(project_root: Path) -> int:
+    """Remove all cached rulesets.
+
+    The cache directory itself is preserved; only its contents
+    (ruleset subdirectories) are removed.
+
+    Args:
+        project_root: Path to the project root.
+
+    Returns:
+        Number of rulesets removed.
+    """
+    cache = project_root / CACHE_DIR
+    if not cache.is_dir():
+        return 0
+
+    count = 0
+    for entry in cache.iterdir():
+        if entry.is_dir():
+            shutil.rmtree(entry)
+            count += 1
+    return count

--- a/src/ai_guard/ruleset/exceptions.py
+++ b/src/ai_guard/ruleset/exceptions.py
@@ -1,0 +1,86 @@
+"""Ruleset error types for AI Guard.
+
+Defines a hierarchy of exceptions for ruleset fetch, parse, and cache
+operations. All ruleset-related errors inherit from RulesetError,
+allowing callers to catch broadly or handle specific failure modes.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "RulesetError",
+    "RulesetFetchError",
+    "RulesetURLError",
+    "RulesetValidationError",
+]
+
+
+class RulesetError(Exception):
+    """Base exception for all ruleset operations."""
+
+
+class RulesetURLError(RulesetError):
+    """Raised when a ruleset URL cannot be parsed.
+
+    Attributes:
+        raw: The raw URL string that failed to parse.
+    """
+
+    def __init__(self, raw: str, detail: str = "") -> None:
+        """Initialize with the URL that failed to parse.
+
+        Args:
+            raw: The raw URL string.
+            detail: Additional detail about the parsing failure.
+        """
+        self.raw = raw
+        msg = f"Cannot parse ruleset URL: {raw!r}"
+        if detail:
+            msg += f" ({detail})"
+        super().__init__(msg)
+
+
+class RulesetFetchError(RulesetError):
+    """Raised when git clone or checkout fails.
+
+    Attributes:
+        url: The URL that failed.
+        stderr: Git stderr output.
+    """
+
+    def __init__(self, url: str, stderr: str = "") -> None:
+        """Initialize with the URL and git error output.
+
+        Args:
+            url: The git URL that failed.
+            stderr: Captured stderr from the git command.
+        """
+        self.url = url
+        self.stderr = stderr
+        msg = f"Failed to fetch ruleset from {url}"
+        if stderr:
+            msg += f": {stderr.strip()}"
+        super().__init__(msg)
+
+
+class RulesetValidationError(RulesetError):
+    """Raised when a cloned ruleset lacks required structure.
+
+    Attributes:
+        name: The ruleset name.
+        detail: What is missing or invalid.
+    """
+
+    def __init__(self, name: str, detail: str = "") -> None:
+        """Initialize with the ruleset name and validation detail.
+
+        Args:
+            name: The ruleset directory name.
+            detail: Description of the validation failure.
+        """
+        self.name = name
+        self.detail = detail
+        msg = f"Invalid ruleset '{name}'"
+        if detail:
+            msg += f": {detail}"
+        super().__init__(msg)

--- a/src/ai_guard/ruleset/fetcher.py
+++ b/src/ai_guard/ruleset/fetcher.py
@@ -1,0 +1,168 @@
+"""Ruleset git fetch operations for AI Guard.
+
+Handles cloning rulesets from git repositories into the local cache
+directory, with support for tag/branch/commit version pinning.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ai_guard.ruleset.exceptions import RulesetFetchError, RulesetValidationError
+
+if TYPE_CHECKING:
+    from ai_guard.ruleset.models import RulesetRef
+
+__all__ = ["fetch_ruleset", "validate_ruleset_dir"]
+
+_GIT_TIMEOUT = 60
+"""Timeout in seconds for git operations."""
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
+"""Pattern matching a plausible commit SHA (7-40 hex chars)."""
+
+
+def fetch_ruleset(ref: RulesetRef, cache_root: Path) -> Path:
+    """Clone or re-clone a ruleset into the local cache.
+
+    If the target directory already exists it is removed before
+    cloning. After a successful clone, the directory is validated
+    and a ``.ruleset-meta.json`` metadata file is written.
+
+    Args:
+        ref: Parsed ruleset reference with URL, name, and version.
+        cache_root: Path to the cache directory
+            (e.g. ``<project>/.ai-guard/cache/``).
+
+    Returns:
+        Path to the cloned ruleset directory.
+
+    Raises:
+        RulesetFetchError: If git clone or checkout fails.
+        RulesetValidationError: If the cloned directory lacks
+            a valid ``guard.yaml``.
+    """
+    target = cache_root / ref.name
+
+    # Remove existing to ensure clean state
+    if target.exists():
+        shutil.rmtree(target, onerror=_rm_readonly)
+
+    # Clone
+    if ref.version is None:
+        _run_git(["clone", "--depth", "1", ref.url, str(target)])
+    elif _is_commit_sha(ref.version):
+        # Full clone needed for arbitrary commit checkout
+        _run_git(["clone", ref.url, str(target)])
+        _run_git(["checkout", ref.version], cwd=target)
+    else:
+        # Tag or branch — shallow clone
+        _run_git(
+            ["clone", "--depth", "1", "--branch", ref.version, ref.url, str(target)]
+        )
+
+    # Validate
+    validate_ruleset_dir(target)
+
+    # Write metadata
+    _write_meta(target, ref)
+
+    return target
+
+
+def validate_ruleset_dir(ruleset_dir: Path) -> None:
+    """Verify a ruleset directory contains a ``guard.yaml``.
+
+    Args:
+        ruleset_dir: Path to the cloned ruleset directory.
+
+    Raises:
+        RulesetValidationError: If ``guard.yaml`` is missing.
+    """
+    if not (ruleset_dir / "guard.yaml").is_file():
+        raise RulesetValidationError(
+            ruleset_dir.name,
+            "guard.yaml not found in ruleset directory",
+        )
+
+
+def _is_commit_sha(version: str) -> bool:
+    """Check if a version string looks like a commit SHA.
+
+    A commit SHA is 7-40 lowercase hexadecimal characters.
+
+    Args:
+        version: The version string to check.
+
+    Returns:
+        True if the version matches the SHA pattern.
+    """
+    return bool(_SHA_PATTERN.match(version))
+
+
+def _run_git(
+    args: list[str],
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git subprocess command.
+
+    Args:
+        args: Git subcommand and arguments (without the ``git`` prefix).
+        cwd: Working directory for the command.
+
+    Returns:
+        The completed process result.
+
+    Raises:
+        RulesetFetchError: If the git command exits with non-zero code.
+    """
+    cmd = ["git", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Extract URL from args for error message
+        url = next((a for a in args if "://" in a or a.startswith("git@")), str(args))
+        raise RulesetFetchError(str(url), exc.stderr) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RulesetFetchError(
+            str(args), f"git command timed out after {_GIT_TIMEOUT}s"
+        ) from exc
+
+
+def _write_meta(target: Path, ref: RulesetRef) -> None:
+    """Write ``.ruleset-meta.json`` with fetch metadata.
+
+    Args:
+        target: The cloned ruleset directory.
+        ref: The parsed ruleset reference.
+    """
+    meta = {
+        "url": ref.url,
+        "version": ref.version,
+        "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    (target / ".ruleset-meta.json").write_text(
+        json.dumps(meta, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _rm_readonly(_func: object, path: str, _exc_info: object) -> None:
+    """Error handler for shutil.rmtree on read-only files (Windows .git)."""
+    import stat
+
+    Path(path).chmod(stat.S_IWRITE)
+    Path(path).unlink()

--- a/src/ai_guard/ruleset/models.py
+++ b/src/ai_guard/ruleset/models.py
@@ -1,0 +1,34 @@
+"""Ruleset data models for AI Guard.
+
+Pure data containers for ruleset references and metadata.
+No I/O or validation logic — those belong in parser and fetcher.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "CACHE_DIR",
+    "RulesetRef",
+]
+
+CACHE_DIR = ".ai-guard/cache"
+"""Relative path from project root to the ruleset cache directory."""
+
+
+@dataclass
+class RulesetRef:
+    """A parsed ruleset reference from a URL string.
+
+    Attributes:
+        url: The clean git clone URL (without version fragment).
+        name: Extracted repository name (e.g. ``python-rules``).
+        version: Optional tag, branch, or commit hash.
+        raw: The original reference string before parsing.
+    """
+
+    url: str
+    name: str
+    version: str | None
+    raw: str

--- a/src/ai_guard/ruleset/parser.py
+++ b/src/ai_guard/ruleset/parser.py
@@ -86,11 +86,15 @@ def _extract_name(url: str) -> str:
     if path.endswith(".git"):
         path = path[:-4]
 
-    # For SSH URLs like git@host:org/repo, take after last '/' or ':'
-    # For HTTPS like https://host/org/repo, take after last '/'
+    # Find the rightmost path separator (/, \, or :) and take what follows.
+    # This handles HTTPS (/), SSH (:), and Windows backslash paths.
+    best = -1
     for sep in ("/", "\\", ":"):
         idx = path.rfind(sep)
-        if idx != -1:
-            return path[idx + 1 :]
+        if idx > best:
+            best = idx
+
+    if best != -1:
+        return path[best + 1 :]
 
     return path

--- a/src/ai_guard/ruleset/parser.py
+++ b/src/ai_guard/ruleset/parser.py
@@ -1,0 +1,96 @@
+"""Ruleset URL parsing for AI Guard.
+
+Parses ruleset reference strings into structured RulesetRef objects.
+Supports HTTPS, SSH, and file:// URL formats with optional version
+fragments (``url#version``).
+"""
+
+from __future__ import annotations
+
+import re
+
+from ai_guard.ruleset.exceptions import RulesetURLError
+from ai_guard.ruleset.models import RulesetRef
+
+__all__ = ["parse_ruleset_url"]
+
+# Patterns that indicate a valid git-cloneable URL
+_URL_INDICATORS = re.compile(
+    r"^(https?://|git@|ssh://|file://)"
+    r"|"
+    r"\.git(/|$|#)"  # contains .git suffix
+    r"|"
+    r"[^/]+\.[^/]+/.+/"  # host.tld/org/repo pattern
+)
+
+
+def parse_ruleset_url(raw: str) -> RulesetRef:
+    """Parse a ruleset URL string into a :class:`RulesetRef`.
+
+    Splits on ``#`` to extract version. Extracts the repository name
+    from the URL path. Handles HTTPS, SSH (``git@host:org/repo``),
+    and ``file://`` URL formats.
+
+    Args:
+        raw: Raw ruleset URL string, optionally with ``#version`` suffix.
+
+    Returns:
+        A :class:`RulesetRef` with parsed components.
+
+    Raises:
+        RulesetURLError: If the URL is empty, unparseable, or has
+            an empty version fragment.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        raise RulesetURLError(raw, "empty URL")
+
+    # Split version fragment on '#'
+    url: str
+    version: str | None
+    if "#" in stripped:
+        url, fragment = stripped.rsplit("#", 1)
+        if not fragment:
+            raise RulesetURLError(raw, "empty version after '#'")
+        version = fragment
+    else:
+        url = stripped
+        version = None
+
+    # Validate that it looks like a git URL
+    if not _URL_INDICATORS.search(url):
+        raise RulesetURLError(raw, "not a valid git URL")
+
+    # Extract name from URL
+    name = _extract_name(url)
+
+    return RulesetRef(url=url, name=name, version=version, raw=raw)
+
+
+def _extract_name(url: str) -> str:
+    """Extract repository name from a git URL.
+
+    Handles both slash-separated (HTTPS/file) and colon-separated
+    (SSH) path formats. Strips ``.git`` suffix and trailing slashes.
+
+    Args:
+        url: The clean git URL (no version fragment).
+
+    Returns:
+        The repository name (e.g. ``python-rules``).
+    """
+    # Remove trailing slashes
+    path = url.rstrip("/")
+
+    # Strip .git suffix
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    # For SSH URLs like git@host:org/repo, take after last '/' or ':'
+    # For HTTPS like https://host/org/repo, take after last '/'
+    for sep in ("/", ":"):
+        idx = path.rfind(sep)
+        if idx != -1:
+            return path[idx + 1 :]
+
+    return path

--- a/src/ai_guard/ruleset/parser.py
+++ b/src/ai_guard/ruleset/parser.py
@@ -88,7 +88,7 @@ def _extract_name(url: str) -> str:
 
     # For SSH URLs like git@host:org/repo, take after last '/' or ':'
     # For HTTPS like https://host/org/repo, take after last '/'
-    for sep in ("/", ":"):
+    for sep in ("/", "\\", ":"):
         idx = path.rfind(sep)
         if idx != -1:
             return path[idx + 1 :]

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -87,7 +87,7 @@ def _create_bare_repo(
             ["git", "push", "origin", tag], cwd=work, check=True, capture_output=True
         )
 
-    return f"file://{bare}"
+    return bare.as_uri()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -1,0 +1,241 @@
+"""Integration tests for ruleset CLI commands (WP4.1).
+
+Verifies the complete ruleset management flow:
+    guard ruleset fetch → list → cache clear
+
+Uses real git repos and file I/O (no mocks), following the
+project's integration test patterns.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from ai_guard.cli.main import app
+from ai_guard.generator.models import STATE_FILE
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_bare_repo(
+    base: Path,
+    name: str = "test-rules",
+    *,
+    guard_yaml_content: dict | None = None,
+    tag: str | None = None,
+) -> str:
+    """Create a local bare git repo and return a file:// URL."""
+    base.mkdir(parents=True, exist_ok=True)
+    work = base / f"{name}-work"
+    bare = base / f"{name}.git"
+    work.mkdir()
+    bare.mkdir()
+
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "clone", str(bare), str(work)], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+
+    content = guard_yaml_content or {
+        "behavior": {
+            "read": {
+                "forbidden": [{"pattern": "file:secret/**", "reason": "no secrets"}]
+            },
+        },
+    }
+    (work / "guard.yaml").write_text(yaml.dump(content), encoding="utf-8")
+
+    (work / "files").mkdir()
+    (work / "files" / ".editorconfig").write_text("root = true\n", encoding="utf-8")
+    (work / "checks").mkdir()
+    (work / "checks" / "check_headers.py").write_text("# check\n", encoding="utf-8")
+
+    subprocess.run(["git", "add", "."], cwd=work, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=work, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "push", "origin", "HEAD"], cwd=work, check=True, capture_output=True
+    )
+
+    if tag:
+        subprocess.run(["git", "tag", tag], cwd=work, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "push", "origin", tag], cwd=work, check=True, capture_output=True
+        )
+
+    return f"file://{bare}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRulesetFetchAndCacheClear:
+    """Test guard ruleset fetch → list → cache clear lifecycle."""
+
+    def test_fetch_list_clear(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full lifecycle: fetch a ruleset, list it, then clear cache."""
+        monkeypatch.chdir(tmp_path)
+        url = _create_bare_repo(tmp_path / "repos")
+
+        # fetch
+        result = runner.invoke(app, ["ruleset", "fetch", url])
+        assert result.exit_code == 0, f"fetch failed: {result.output}"
+        assert "Fetching ruleset" in result.output
+        assert "guard.yaml: found" in result.output
+
+        # Verify cache populated
+        cache_dir = tmp_path / ".ai-guard" / "cache" / "test-rules"
+        assert cache_dir.is_dir()
+        assert (cache_dir / "guard.yaml").is_file()
+        assert (cache_dir / ".ruleset-meta.json").is_file()
+
+        # list
+        result = runner.invoke(app, ["ruleset", "list"])
+        assert result.exit_code == 0
+        assert "test-rules" in result.output
+
+        # cache clear
+        result = runner.invoke(app, ["ruleset", "cache", "clear"])
+        assert result.exit_code == 0
+        assert "Cleared 1" in result.output
+
+        # list again (empty)
+        result = runner.invoke(app, ["ruleset", "list"])
+        assert result.exit_code == 0
+        assert "No cached rulesets" in result.output
+
+    def test_fetch_with_tag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fetch a specific version using #tag."""
+        monkeypatch.chdir(tmp_path)
+        url = _create_bare_repo(tmp_path / "repos", tag="v1.0")
+
+        result = runner.invoke(app, ["ruleset", "fetch", f"{url}#v1.0"])
+        assert result.exit_code == 0, f"fetch failed: {result.output}"
+        assert "v1.0" in result.output
+
+    def test_fetch_invalid_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fetch with invalid URL shows error."""
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ruleset", "fetch", "not-a-url"])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+class TestInstallWithRuleset:
+    """Test that install merges ruleset config from cache."""
+
+    def test_install_loads_ruleset_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """fetch → init (with ruleset name) → install → verify merge."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+
+        # Create a ruleset with a custom rule
+        ruleset_config = {
+            "behavior": {
+                "read": {
+                    "forbidden": [
+                        {"pattern": "file:.env*", "reason": "env files forbidden"},
+                    ],
+                },
+            },
+        }
+        url = _create_bare_repo(
+            tmp_path / "repos",
+            name="company-rules",
+            guard_yaml_content=ruleset_config,
+        )
+
+        # Fetch the ruleset
+        result = runner.invoke(app, ["ruleset", "fetch", url])
+        assert result.exit_code == 0, f"fetch failed: {result.output}"
+
+        # Use guard init to create a valid guard.yaml, then add rulesets
+        config_path = tmp_path / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["init", "--language", "python", "--output", str(config_path)],
+        )
+        assert result.exit_code == 0, f"init failed: {result.output}"
+
+        # Append rulesets field to the config
+        text = config_path.read_text(encoding="utf-8")
+        text += '\nrulesets:\n  - "company-rules"\n'
+        config_path.write_text(text, encoding="utf-8")
+
+        # Install
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, f"install failed: {result.output}"
+
+        # Verify state was written
+        state_path = tmp_path / STATE_FILE
+        assert state_path.is_file()
+
+        # Verify the ruleset's .editorconfig was copied via G3
+        assert (tmp_path / ".editorconfig").is_file()
+
+    def test_install_warns_missing_ruleset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """install with uncached ruleset should warn."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+
+        # Use guard init to create a valid guard.yaml
+        config_path = tmp_path / "guard.yaml"
+        result = runner.invoke(
+            app,
+            ["init", "--language", "python", "--output", str(config_path)],
+        )
+        assert result.exit_code == 0
+
+        # Add a non-existent ruleset reference
+        content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        content["rulesets"] = ["nonexistent-rules"]
+        config_path.write_text(yaml.dump(content), encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["install", "--agent", "claude-code", "--config", str(config_path)],
+        )
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+        assert "nonexistent-rules" in result.output

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -99,15 +98,13 @@ def _create_bare_repo(
 class TestRulesetFetchAndCacheClear:
     """Test guard ruleset fetch → list → cache clear lifecycle."""
 
-    def test_fetch_list_clear(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fetch_list_clear(self, tmp_path: Path) -> None:
         """Full lifecycle: fetch a ruleset, list it, then clear cache."""
-        monkeypatch.chdir(tmp_path)
         url = _create_bare_repo(tmp_path / "repos")
+        pr = str(tmp_path)
 
         # fetch
-        result = runner.invoke(app, ["ruleset", "fetch", url])
+        result = runner.invoke(app, ["ruleset", "fetch", url, "--project-root", pr])
         assert result.exit_code == 0, f"fetch failed: {result.output}"
         assert "Fetching ruleset" in result.output
         assert "guard.yaml: found" in result.output
@@ -119,38 +116,36 @@ class TestRulesetFetchAndCacheClear:
         assert (cache_dir / ".ruleset-meta.json").is_file()
 
         # list
-        result = runner.invoke(app, ["ruleset", "list"])
+        result = runner.invoke(app, ["ruleset", "list", "--project-root", pr])
         assert result.exit_code == 0
         assert "test-rules" in result.output
 
         # cache clear
-        result = runner.invoke(app, ["ruleset", "cache", "clear"])
+        result = runner.invoke(app, ["ruleset", "cache", "clear", "--project-root", pr])
         assert result.exit_code == 0
         assert "Cleared 1" in result.output
 
         # list again (empty)
-        result = runner.invoke(app, ["ruleset", "list"])
+        result = runner.invoke(app, ["ruleset", "list", "--project-root", pr])
         assert result.exit_code == 0
         assert "No cached rulesets" in result.output
 
-    def test_fetch_with_tag(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fetch_with_tag(self, tmp_path: Path) -> None:
         """Fetch a specific version using #tag."""
-        monkeypatch.chdir(tmp_path)
         url = _create_bare_repo(tmp_path / "repos", tag="v1.0")
+        pr = str(tmp_path)
 
-        result = runner.invoke(app, ["ruleset", "fetch", f"{url}#v1.0"])
+        result = runner.invoke(
+            app, ["ruleset", "fetch", f"{url}#v1.0", "--project-root", pr]
+        )
         assert result.exit_code == 0, f"fetch failed: {result.output}"
         assert "v1.0" in result.output
 
-    def test_fetch_invalid_url(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fetch_invalid_url(self, tmp_path: Path) -> None:
         """Fetch with invalid URL shows error."""
-        monkeypatch.chdir(tmp_path)
-
-        result = runner.invoke(app, ["ruleset", "fetch", "not-a-url"])
+        result = runner.invoke(
+            app, ["ruleset", "fetch", "not-a-url", "--project-root", str(tmp_path)]
+        )
         assert result.exit_code == 1
         assert "Error" in result.output
 
@@ -158,12 +153,10 @@ class TestRulesetFetchAndCacheClear:
 class TestInstallWithRuleset:
     """Test that install merges ruleset config from cache."""
 
-    def test_install_loads_ruleset_config(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_install_loads_ruleset_config(self, tmp_path: Path) -> None:
         """fetch → init (with ruleset name) → install → verify merge."""
-        monkeypatch.chdir(tmp_path)
         (tmp_path / ".git").mkdir()
+        pr = str(tmp_path)
 
         # Create a ruleset with a custom rule
         ruleset_config = {
@@ -182,7 +175,7 @@ class TestInstallWithRuleset:
         )
 
         # Fetch the ruleset
-        result = runner.invoke(app, ["ruleset", "fetch", url])
+        result = runner.invoke(app, ["ruleset", "fetch", url, "--project-root", pr])
         assert result.exit_code == 0, f"fetch failed: {result.output}"
 
         # Use guard init to create a valid guard.yaml, then add rulesets
@@ -212,11 +205,8 @@ class TestInstallWithRuleset:
         # Verify the ruleset's .editorconfig was copied via G3
         assert (tmp_path / ".editorconfig").is_file()
 
-    def test_install_warns_missing_ruleset(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_install_warns_missing_ruleset(self, tmp_path: Path) -> None:
         """install with uncached ruleset should warn."""
-        monkeypatch.chdir(tmp_path)
         (tmp_path / ".git").mkdir()
 
         # Use guard init to create a valid guard.yaml
@@ -228,9 +218,9 @@ class TestInstallWithRuleset:
         assert result.exit_code == 0
 
         # Add a non-existent ruleset reference
-        content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        content["rulesets"] = ["nonexistent-rules"]
-        config_path.write_text(yaml.dump(content), encoding="utf-8")
+        text = config_path.read_text(encoding="utf-8")
+        text += '\nrulesets:\n  - "nonexistent-rules"\n'
+        config_path.write_text(text, encoding="utf-8")
 
         result = runner.invoke(
             app,

--- a/tests/unit/test_cli/test_ruleset.py
+++ b/tests/unit/test_cli/test_ruleset.py
@@ -1,0 +1,57 @@
+"""Tests for ruleset CLI command implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ai_guard.cli.ruleset import (
+    ruleset_cache_clear_command,
+    ruleset_list_command,
+)
+
+
+class TestRulesetListCommand:
+    """Test ruleset_list_command."""
+
+    def test_no_cached_rulesets(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ruleset_list_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "No cached rulesets" in captured.out
+
+    def test_lists_cached_rulesets(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "my-rules").mkdir()
+
+        ruleset_list_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "my-rules" in captured.out
+
+
+class TestRulesetCacheClearCommand:
+    """Test ruleset_cache_clear_command."""
+
+    def test_empty_cache(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ruleset_cache_clear_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "No cached rulesets" in captured.out
+
+    def test_clears_cache(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "rules-a").mkdir()
+        (cache / "rules-b").mkdir()
+
+        ruleset_cache_clear_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "Cleared 2" in captured.out

--- a/tests/unit/test_ruleset/test_cache.py
+++ b/tests/unit/test_ruleset/test_cache.py
@@ -85,6 +85,21 @@ class TestClearCache:
     def test_no_cache_dir_returns_zero(self, tmp_path: Path) -> None:
         assert clear_cache(tmp_path) == 0
 
+    def test_clears_dirs_with_readonly_files(self, tmp_path: Path) -> None:
+        """Regression: clear must handle read-only files (Windows .git packs)."""
+        import stat
+
+        cache = tmp_path / ".ai-guard" / "cache"
+        ruleset = cache / "rules"
+        ruleset.mkdir(parents=True)
+        readonly_file = ruleset / "readonly.pack"
+        readonly_file.write_text("data", encoding="utf-8")
+        readonly_file.chmod(stat.S_IREAD)
+
+        count = clear_cache(tmp_path)
+        assert count == 1
+        assert list_cached(tmp_path) == []
+
     def test_preserves_cache_dir(self, tmp_path: Path) -> None:
         """Cache directory itself should remain after clearing."""
         cache = tmp_path / ".ai-guard" / "cache"

--- a/tests/unit/test_ruleset/test_cache.py
+++ b/tests/unit/test_ruleset/test_cache.py
@@ -1,0 +1,105 @@
+"""Tests for ruleset cache management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached
+
+
+class TestGetCacheDir:
+    """Test get_cache_dir."""
+
+    def test_creates_directory(self, tmp_path: Path) -> None:
+        result = get_cache_dir(tmp_path)
+        assert result == tmp_path / ".ai-guard" / "cache"
+        assert result.is_dir()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        result1 = get_cache_dir(tmp_path)
+        result2 = get_cache_dir(tmp_path)
+        assert result1 == result2
+        assert result1.is_dir()
+
+    def test_preserves_existing_content(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "existing").mkdir()
+        result = get_cache_dir(tmp_path)
+        assert (result / "existing").is_dir()
+
+
+class TestListCached:
+    """Test list_cached."""
+
+    def test_empty_cache(self, tmp_path: Path) -> None:
+        assert list_cached(tmp_path) == []
+
+    def test_no_cache_dir(self, tmp_path: Path) -> None:
+        """No .ai-guard/cache/ directory at all."""
+        assert list_cached(tmp_path) == []
+
+    def test_lists_directories(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "alpha-rules").mkdir()
+        (cache / "beta-rules").mkdir()
+        result = list_cached(tmp_path)
+        assert result == ["alpha-rules", "beta-rules"]
+
+    def test_ignores_files(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "real-rules").mkdir()
+        (cache / "stray-file.txt").write_text("oops", encoding="utf-8")
+        result = list_cached(tmp_path)
+        assert result == ["real-rules"]
+
+    def test_sorted_output(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "zebra").mkdir()
+        (cache / "alpha").mkdir()
+        (cache / "middle").mkdir()
+        result = list_cached(tmp_path)
+        assert result == ["alpha", "middle", "zebra"]
+
+
+class TestClearCache:
+    """Test clear_cache."""
+
+    def test_clears_all(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "rules-a").mkdir()
+        (cache / "rules-b").mkdir()
+        count = clear_cache(tmp_path)
+        assert count == 2
+        assert list_cached(tmp_path) == []
+
+    def test_empty_cache_returns_zero(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        assert clear_cache(tmp_path) == 0
+
+    def test_no_cache_dir_returns_zero(self, tmp_path: Path) -> None:
+        assert clear_cache(tmp_path) == 0
+
+    def test_preserves_cache_dir(self, tmp_path: Path) -> None:
+        """Cache directory itself should remain after clearing."""
+        cache = tmp_path / ".ai-guard" / "cache"
+        cache.mkdir(parents=True)
+        (cache / "rules").mkdir()
+        clear_cache(tmp_path)
+        assert cache.is_dir()
+
+    def test_preserves_non_cache_ai_guard_files(self, tmp_path: Path) -> None:
+        """Other files in .ai-guard/ should not be touched."""
+        ai_guard = tmp_path / ".ai-guard"
+        ai_guard.mkdir()
+        (ai_guard / "state.json").write_text("{}", encoding="utf-8")
+        cache = ai_guard / "cache"
+        cache.mkdir()
+        (cache / "rules").mkdir()
+        clear_cache(tmp_path)
+        assert (ai_guard / "state.json").is_file()

--- a/tests/unit/test_ruleset/test_exceptions.py
+++ b/tests/unit/test_ruleset/test_exceptions.py
@@ -1,0 +1,66 @@
+"""Tests for ruleset exception types."""
+
+from __future__ import annotations
+
+from ai_guard.ruleset.exceptions import (
+    RulesetError,
+    RulesetFetchError,
+    RulesetURLError,
+    RulesetValidationError,
+)
+
+
+class TestRulesetExceptionHierarchy:
+    """Verify exception inheritance and message formatting."""
+
+    def test_base_is_exception(self) -> None:
+        assert issubclass(RulesetError, Exception)
+
+    def test_url_error_inherits(self) -> None:
+        assert issubclass(RulesetURLError, RulesetError)
+
+    def test_fetch_error_inherits(self) -> None:
+        assert issubclass(RulesetFetchError, RulesetError)
+
+    def test_validation_error_inherits(self) -> None:
+        assert issubclass(RulesetValidationError, RulesetError)
+
+
+class TestRulesetURLError:
+    """Test RulesetURLError message formatting."""
+
+    def test_message_without_detail(self) -> None:
+        err = RulesetURLError("bad-url")
+        assert "bad-url" in str(err)
+        assert err.raw == "bad-url"
+
+    def test_message_with_detail(self) -> None:
+        err = RulesetURLError("bad-url", "empty URL")
+        assert "empty URL" in str(err)
+
+
+class TestRulesetFetchError:
+    """Test RulesetFetchError message formatting."""
+
+    def test_message_without_stderr(self) -> None:
+        err = RulesetFetchError("https://example.com/repo.git")
+        assert "example.com" in str(err)
+        assert err.url == "https://example.com/repo.git"
+
+    def test_message_with_stderr(self) -> None:
+        err = RulesetFetchError("url", "fatal: not found")
+        assert "fatal: not found" in str(err)
+        assert err.stderr == "fatal: not found"
+
+
+class TestRulesetValidationError:
+    """Test RulesetValidationError message formatting."""
+
+    def test_message_without_detail(self) -> None:
+        err = RulesetValidationError("my-rules")
+        assert "my-rules" in str(err)
+        assert err.name == "my-rules"
+
+    def test_message_with_detail(self) -> None:
+        err = RulesetValidationError("my-rules", "guard.yaml not found")
+        assert "guard.yaml not found" in str(err)

--- a/tests/unit/test_ruleset/test_fetcher.py
+++ b/tests/unit/test_ruleset/test_fetcher.py
@@ -120,12 +120,15 @@ def _create_bare_repo(
             capture_output=True,
         )
 
-    return f"file://{bare}"
+    return bare.as_uri()
 
 
 def _get_head_sha(bare_path: str) -> str:
     """Get the HEAD commit SHA from a bare repo URL."""
-    path = bare_path.replace("file://", "")
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+
+    path = url2pathname(urlparse(bare_path).path)
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=path,

--- a/tests/unit/test_ruleset/test_fetcher.py
+++ b/tests/unit/test_ruleset/test_fetcher.py
@@ -1,0 +1,281 @@
+"""Tests for ruleset fetcher."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_guard.ruleset.exceptions import (
+    RulesetFetchError,
+    RulesetValidationError,
+)
+from ai_guard.ruleset.fetcher import (
+    _is_commit_sha,
+    fetch_ruleset,
+    validate_ruleset_dir,
+)
+from ai_guard.ruleset.models import RulesetRef
+
+# ---------------------------------------------------------------------------
+# Helpers — create local git repos for testing
+# ---------------------------------------------------------------------------
+
+
+def _create_bare_repo(
+    base: Path,
+    name: str = "test-rules",
+    *,
+    with_guard_yaml: bool = True,
+    guard_yaml_content: dict | None = None,
+    tag: str | None = None,
+) -> str:
+    """Create a local bare git repo and return a file:// URL.
+
+    Args:
+        base: Parent directory for the repo.
+        name: Repo directory name.
+        with_guard_yaml: Whether to include a guard.yaml.
+        guard_yaml_content: Custom guard.yaml content dict.
+        tag: Optional tag to create.
+
+    Returns:
+        file:// URL pointing to the bare repo.
+    """
+    work = base / f"{name}-work"
+    bare = base / f"{name}.git"
+
+    # Create a working repo, add files, push to bare
+    base.mkdir(parents=True, exist_ok=True)
+    work.mkdir()
+    bare.mkdir()
+
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "clone", str(bare), str(work)],
+        check=True,
+        capture_output=True,
+    )
+
+    # Configure git user for commits
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+
+    if with_guard_yaml:
+        content = guard_yaml_content or {
+            "behavior": {
+                "read": {"forbidden": [{"pattern": "file:secret/**"}]},
+            }
+        }
+        (work / "guard.yaml").write_text(yaml.dump(content), encoding="utf-8")
+
+    # Create files/ and checks/ directories
+    (work / "files").mkdir()
+    (work / "files" / ".clang-format").write_text(
+        "BasedOnStyle: LLVM\n", encoding="utf-8"
+    )
+    (work / "checks").mkdir()
+    (work / "checks" / "my_check.py").write_text("# check\n", encoding="utf-8")
+
+    subprocess.run(["git", "add", "."], cwd=work, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "push", "origin", "HEAD"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+    )
+
+    if tag:
+        subprocess.run(
+            ["git", "tag", tag],
+            cwd=work,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "push", "origin", tag],
+            cwd=work,
+            check=True,
+            capture_output=True,
+        )
+
+    return f"file://{bare}"
+
+
+def _get_head_sha(bare_path: str) -> str:
+    """Get the HEAD commit SHA from a bare repo URL."""
+    path = bare_path.replace("file://", "")
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsCommitSha:
+    """Test _is_commit_sha helper."""
+
+    def test_40_hex_chars(self) -> None:
+        assert _is_commit_sha("a" * 40) is True
+
+    def test_7_hex_chars(self) -> None:
+        assert _is_commit_sha("abc1234") is True
+
+    def test_short_hex_6_chars(self) -> None:
+        """6 chars is too short to be a reliable SHA."""
+        assert _is_commit_sha("abc123") is False
+
+    def test_tag_name(self) -> None:
+        assert _is_commit_sha("v1.0.0") is False
+
+    def test_branch_name(self) -> None:
+        assert _is_commit_sha("main") is False
+
+    def test_7_valid_hex(self) -> None:
+        assert _is_commit_sha("abcdef0") is True  # 7 hex chars
+
+    def test_contains_nonhex(self) -> None:
+        assert _is_commit_sha("abcdxyz") is False
+
+
+class TestValidateRulesetDir:
+    """Test validate_ruleset_dir."""
+
+    def test_valid_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "guard.yaml").write_text(
+            yaml.dump({"behavior": {}}), encoding="utf-8"
+        )
+        # Should not raise
+        validate_ruleset_dir(tmp_path)
+
+    def test_missing_guard_yaml(self, tmp_path: Path) -> None:
+        with pytest.raises(RulesetValidationError, match=r"guard\.yaml"):
+            validate_ruleset_dir(tmp_path)
+
+    def test_empty_guard_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "guard.yaml").write_text("", encoding="utf-8")
+        # Empty YAML is valid (parsed as None/empty) — should not raise
+        validate_ruleset_dir(tmp_path)
+
+
+class TestFetchRuleset:
+    """Test fetch_ruleset with local bare repos."""
+
+    def test_clone_creates_directory(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos")
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version=None, raw=url)
+        result = fetch_ruleset(ref, cache_root)
+
+        assert result.is_dir()
+        assert result.name == "test-rules"
+        assert (result / "guard.yaml").is_file()
+        assert (result / "files" / ".clang-format").is_file()
+        assert (result / "checks" / "my_check.py").is_file()
+
+    def test_clone_with_tag(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos", tag="v1.0")
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version="v1.0", raw=f"{url}#v1.0")
+        result = fetch_ruleset(ref, cache_root)
+
+        assert result.is_dir()
+        assert (result / "guard.yaml").is_file()
+
+    def test_clone_with_commit_sha(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos")
+        sha = _get_head_sha(url)
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version=sha, raw=f"{url}#{sha}")
+        result = fetch_ruleset(ref, cache_root)
+
+        assert result.is_dir()
+        assert (result / "guard.yaml").is_file()
+
+    def test_re_fetch_replaces_existing(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos")
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version=None, raw=url)
+
+        # First fetch
+        result1 = fetch_ruleset(ref, cache_root)
+        assert result1.is_dir()
+
+        # Second fetch should succeed (replace)
+        result2 = fetch_ruleset(ref, cache_root)
+        assert result2.is_dir()
+        assert (result2 / "guard.yaml").is_file()
+
+    def test_invalid_url_raises(self, tmp_path: Path) -> None:
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(
+            url="file:///nonexistent/repo.git",
+            name="bad",
+            version=None,
+            raw="file:///nonexistent/repo.git",
+        )
+        with pytest.raises(RulesetFetchError):
+            fetch_ruleset(ref, cache_root)
+
+    def test_missing_guard_yaml_raises(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos", with_guard_yaml=False)
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version=None, raw=url)
+        with pytest.raises(RulesetValidationError, match=r"guard\.yaml"):
+            fetch_ruleset(ref, cache_root)
+
+    def test_writes_meta_json(self, tmp_path: Path) -> None:
+        url = _create_bare_repo(tmp_path / "repos", tag="v1.0")
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+
+        ref = RulesetRef(url=url, name="test-rules", version="v1.0", raw=f"{url}#v1.0")
+        result = fetch_ruleset(ref, cache_root)
+
+        meta_path = result / ".ruleset-meta.json"
+        assert meta_path.is_file()
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["url"] == url
+        assert meta["version"] == "v1.0"
+        assert "fetched_at" in meta

--- a/tests/unit/test_ruleset/test_models.py
+++ b/tests/unit/test_ruleset/test_models.py
@@ -1,0 +1,35 @@
+"""Tests for ruleset data models."""
+
+from __future__ import annotations
+
+from ai_guard.ruleset.models import CACHE_DIR, RulesetRef
+
+
+class TestRulesetRef:
+    """Test RulesetRef dataclass."""
+
+    def test_basic_construction(self) -> None:
+        ref = RulesetRef(
+            url="https://github.com/org/rules.git",
+            name="rules",
+            version="v1.0",
+            raw="https://github.com/org/rules.git#v1.0",
+        )
+        assert ref.url == "https://github.com/org/rules.git"
+        assert ref.name == "rules"
+        assert ref.version == "v1.0"
+        assert ref.raw == "https://github.com/org/rules.git#v1.0"
+
+    def test_version_none(self) -> None:
+        ref = RulesetRef(url="url", name="name", version=None, raw="url")
+        assert ref.version is None
+
+
+class TestCacheDir:
+    """Test CACHE_DIR constant."""
+
+    def test_value(self) -> None:
+        assert CACHE_DIR == ".ai-guard/cache"
+
+    def test_is_string(self) -> None:
+        assert isinstance(CACHE_DIR, str)

--- a/tests/unit/test_ruleset/test_parser.py
+++ b/tests/unit/test_ruleset/test_parser.py
@@ -80,6 +80,16 @@ class TestParseRulesetUrl:
         assert ref.name == "my-rules"
         assert ref.version == "v1"
 
+    def test_file_url_windows_style(self) -> None:
+        """Regression: file:///C:/path (Windows as_uri format) must extract name correctly."""
+        ref = parse_ruleset_url("file:///C:/Users/runner/repos/test-rules.git")
+        assert ref.name == "test-rules"
+
+    def test_file_url_windows_backslash(self) -> None:
+        """Regression: backslash paths must not produce an absolute-path name."""
+        ref = parse_ruleset_url("file:///C:\\Users\\runner\\repos\\test-rules.git")
+        assert ref.name == "test-rules"
+
     # --- Name extraction edge cases ---
 
     def test_name_strips_dot_git(self) -> None:

--- a/tests/unit/test_ruleset/test_parser.py
+++ b/tests/unit/test_ruleset/test_parser.py
@@ -1,0 +1,121 @@
+"""Tests for ruleset URL parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_guard.ruleset.exceptions import RulesetURLError
+from ai_guard.ruleset.parser import parse_ruleset_url
+
+
+class TestParseRulesetUrl:
+    """Test parse_ruleset_url with various URL formats."""
+
+    # --- HTTPS URLs ---
+
+    def test_https_url_no_version(self) -> None:
+        ref = parse_ruleset_url("https://github.com/company/python-rules.git")
+        assert ref.url == "https://github.com/company/python-rules.git"
+        assert ref.name == "python-rules"
+        assert ref.version is None
+        assert ref.raw == "https://github.com/company/python-rules.git"
+
+    def test_https_url_with_tag(self) -> None:
+        ref = parse_ruleset_url("https://github.com/company/python-rules.git#v1.0.0")
+        assert ref.url == "https://github.com/company/python-rules.git"
+        assert ref.name == "python-rules"
+        assert ref.version == "v1.0.0"
+
+    def test_https_url_with_branch(self) -> None:
+        ref = parse_ruleset_url("https://github.com/company/rules.git#main")
+        assert ref.version == "main"
+        assert ref.name == "rules"
+
+    def test_https_url_without_git_suffix(self) -> None:
+        ref = parse_ruleset_url("https://github.com/company/python-rules")
+        assert ref.url == "https://github.com/company/python-rules"
+        assert ref.name == "python-rules"
+
+    # --- SSH URLs ---
+
+    def test_ssh_url_no_version(self) -> None:
+        ref = parse_ruleset_url("git@github.com:company/python-rules.git")
+        assert ref.url == "git@github.com:company/python-rules.git"
+        assert ref.name == "python-rules"
+        assert ref.version is None
+
+    def test_ssh_url_with_version(self) -> None:
+        ref = parse_ruleset_url("git@github.com:company/python-rules.git#v2.0")
+        assert ref.url == "git@github.com:company/python-rules.git"
+        assert ref.name == "python-rules"
+        assert ref.version == "v2.0"
+
+    def test_ssh_url_nested_path(self) -> None:
+        ref = parse_ruleset_url("git@gitlab.com:org/group/sub/my-rules.git#v1")
+        assert ref.name == "my-rules"
+        assert ref.version == "v1"
+
+    # --- Commit SHA ---
+
+    def test_full_commit_sha(self) -> None:
+        sha = "a" * 40
+        ref = parse_ruleset_url(f"https://github.com/org/rules.git#{sha}")
+        assert ref.version == sha
+
+    def test_short_commit_sha(self) -> None:
+        ref = parse_ruleset_url("https://github.com/org/rules.git#abc1234")
+        assert ref.version == "abc1234"
+
+    # --- file:// URLs (for testing) ---
+
+    def test_file_url(self) -> None:
+        ref = parse_ruleset_url("file:///tmp/repos/my-rules")
+        assert ref.url == "file:///tmp/repos/my-rules"
+        assert ref.name == "my-rules"
+        assert ref.version is None
+
+    def test_file_url_with_version(self) -> None:
+        ref = parse_ruleset_url("file:///tmp/repos/my-rules.git#v1")
+        assert ref.url == "file:///tmp/repos/my-rules.git"
+        assert ref.name == "my-rules"
+        assert ref.version == "v1"
+
+    # --- Name extraction edge cases ---
+
+    def test_name_strips_dot_git(self) -> None:
+        ref = parse_ruleset_url("https://host/org/repo.git")
+        assert ref.name == "repo"
+
+    def test_name_preserves_hyphens(self) -> None:
+        ref = parse_ruleset_url("https://host/org/my-cool-rules.git")
+        assert ref.name == "my-cool-rules"
+
+    def test_trailing_slash_ignored(self) -> None:
+        ref = parse_ruleset_url("https://host/org/repo.git/")
+        assert ref.name == "repo"
+
+    # --- Raw preservation ---
+
+    def test_raw_preserved(self) -> None:
+        raw = "git@github.com:co/rules.git#v1.0"
+        ref = parse_ruleset_url(raw)
+        assert ref.raw == raw
+
+    # --- Error cases ---
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(RulesetURLError):
+            parse_ruleset_url("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(RulesetURLError):
+            parse_ruleset_url("   ")
+
+    def test_bare_word_raises(self) -> None:
+        with pytest.raises(RulesetURLError):
+            parse_ruleset_url("just-a-name")
+
+    def test_hash_only_version_raises(self) -> None:
+        """URL with '#' but empty version should raise."""
+        with pytest.raises(RulesetURLError):
+            parse_ruleset_url("https://github.com/org/repo.git#")


### PR DESCRIPTION
## Summary

- Add `src/ai_guard/ruleset/` module: URL parser, git-based fetcher (with `#version` pinning for tag/branch/SHA), cache management, and validation
- Register CLI commands: `guard ruleset fetch <url>`, `guard ruleset list`, `guard ruleset cache clear`
- Integrate ruleset config loading into `install`/`update` flow — cached ruleset `guard.yaml` fragments are merged via `resolve_config(rulesets=...)`

## Test plan

- [x] Unit tests for parser (19), fetcher (17), cache (13), exceptions (10), models (3), CLI (4)
- [x] Integration tests: fetch→list→clear lifecycle, fetch with tag, install with cached ruleset, missing ruleset warning (5)
- [x] Full regression: 692 tests passed, 0 failed
- [x] All pre-commit hooks passed (ruff, coverage, docstring, type hints, import deps, security, naming, test structure, path integrity)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)