### PR TITLE
feat(ruleset): add checks/ copying and files/ skip logic (WP4.2)

### DIFF
--- a/src/ai_guard/cli/install.py
+++ b/src/ai_guard/cli/install.py
@@ -20,6 +20,7 @@ from ai_guard.config.merger import resolve_config
 from ai_guard.generator.core import (
     create_state,
     delete_artifacts,
+    generate_check_scripts,
     generate_git_hooks,
     generate_hook_files,
     generate_policy_cache,
@@ -69,6 +70,8 @@ def _run_generator_pipeline(
     adapters: list[AgentAdapter],
     project_root: Path,
     rulesets: list[str],
+    *,
+    force: bool = False,
 ) -> list[str]:
     """Run G1-G7 generator primitives and write artifacts.
 
@@ -77,6 +80,7 @@ def _run_generator_pipeline(
         adapters: List of agent adapters to generate for.
         project_root: Path to project root directory.
         rulesets: List of ruleset names for tool config generation.
+        force: If True, overwrite existing tool config files.
 
     Returns:
         List of written artifact paths (relative to project root).
@@ -93,8 +97,11 @@ def _run_generator_pipeline(
     # G2: Hook files
     artifacts.extend(generate_hook_files(adapters, resolved_config.behavior))
 
-    # G3: Tool configs from rulesets
-    artifacts.extend(generate_tool_configs(project_root, rulesets))
+    # G3: Tool configs from rulesets (skip existing unless --force)
+    artifacts.extend(generate_tool_configs(project_root, rulesets, force=force))
+
+    # G3b: Check scripts from rulesets (always overwrite)
+    artifacts.extend(generate_check_scripts(project_root, rulesets))
 
     # G4: Pre-commit config
     artifacts.append(
@@ -220,6 +227,8 @@ def install_command(
     agents: list[str],
     project_root: Path,
     config_path: Path,
+    *,
+    force: bool = False,
 ) -> None:
     """Execute the install command.
 
@@ -230,6 +239,7 @@ def install_command(
         agents: Agent names to install (empty to list available).
         project_root: Path to project root directory.
         config_path: Path to guard.yaml.
+        force: If True, overwrite existing tool config files.
     """
     if not agents:
         _print_available_agents()
@@ -269,7 +279,7 @@ def install_command(
     # Run generator pipeline
     try:
         written_paths = _run_generator_pipeline(
-            resolved, adapters, project_root, rulesets
+            resolved, adapters, project_root, rulesets, force=force
         )
     except ArtifactWriteError as e:
         print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")
@@ -285,6 +295,8 @@ def install_command(
 def update_command(
     project_root: Path,
     config_path: Path,
+    *,
+    force: bool = False,
 ) -> None:
     """Execute the update command.
 
@@ -293,6 +305,7 @@ def update_command(
     Args:
         project_root: Path to project root directory.
         config_path: Path to guard.yaml.
+        force: If True, overwrite existing tool config files.
     """
     existing_state = read_state(project_root)
     if existing_state is None:
@@ -320,7 +333,7 @@ def update_command(
     # Run generator pipeline
     try:
         written_paths = _run_generator_pipeline(
-            resolved, adapters, project_root, rulesets
+            resolved, adapters, project_root, rulesets, force=force
         )
     except ArtifactWriteError as e:
         print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -124,6 +124,14 @@ def install(
             help="Path to guard.yaml",
         ),
     ] = Path("guard.yaml"),
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Overwrite existing tool config files from rulesets",
+        ),
+    ] = False,
 ) -> None:
     """Install AI Guard artifacts for specified agents.
 
@@ -132,7 +140,9 @@ def install(
     """
     agents = [a.strip() for a in agent.split(",") if a.strip()] if agent else []
     project_root = config.parent.resolve()
-    install_command(agents=agents, project_root=project_root, config_path=config)
+    install_command(
+        agents=agents, project_root=project_root, config_path=config, force=force
+    )
 
 
 @app.command()
@@ -145,6 +155,14 @@ def update(
             help="Path to guard.yaml",
         ),
     ] = Path("guard.yaml"),
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Overwrite existing tool config files from rulesets",
+        ),
+    ] = False,
 ) -> None:
     """Re-generate all artifacts for installed agents.
 
@@ -152,7 +170,7 @@ def update(
     artifacts based on the latest guard.yaml configuration.
     """
     project_root = config.parent.resolve()
-    update_command(project_root=project_root, config_path=config)
+    update_command(project_root=project_root, config_path=config, force=force)
 
 
 @app.command()

--- a/src/ai_guard/generator/core.py
+++ b/src/ai_guard/generator/core.py
@@ -481,16 +481,23 @@ def generate_git_hooks(project_root: Path) -> list[FileSpec]:
 def generate_tool_configs(
     project_root: Path,
     rulesets: list[str],
+    *,
+    force: bool = False,
 ) -> list[FileSpec]:
     """Copy tool config files from ruleset cache (G3).
 
-    Rulesets are cloned to .ai-guard/cache/<ruleset-name>/.
-    Tool config files (like .clang-format, pyproject.toml) are
-    stored in the ruleset's 'files/' subdirectory.
+    Rulesets are cloned to ``.ai-guard/cache/<ruleset-name>/``.
+    Tool config files (like ``.clang-format``, ``pyproject.toml``)
+    are stored in the ruleset's ``files/`` subdirectory.
+
+    When ``force`` is False, files that already exist in the project
+    root are skipped with a warning. When True, all files are
+    included regardless of existing content.
 
     Args:
         project_root: Path to project root.
         rulesets: List of ruleset names installed.
+        force: If True, overwrite existing files.
 
     Returns:
         List of FileSpec for tool config files to be copied
@@ -506,11 +513,62 @@ def generate_tool_configs(
 
         for file_path in files_dir.iterdir():
             if file_path.is_file():
+                # Skip existing user files unless forced
+                if not force and (project_root / file_path.name).is_file():
+                    print(
+                        f"Skipping {file_path.name}: already exists "
+                        f"(use --force to overwrite)"
+                    )
+                    continue
+
                 try:
                     content = file_path.read_text(encoding="utf-8")
                     artifacts.append(
                         FileSpec(
                             path=file_path.name,  # Copy to project root
+                            content=content,
+                        )
+                    )
+                except UnicodeDecodeError:
+                    # Skip binary files
+                    continue
+    return artifacts
+
+
+def generate_check_scripts(
+    project_root: Path,
+    rulesets: list[str],
+) -> list[FileSpec]:
+    """Copy check scripts from ruleset cache (G3b).
+
+    Rulesets may include a ``checks/`` subdirectory with custom
+    check scripts. These are copied to ``.ai-guard/checks/`` in
+    the project directory. Unlike tool configs, check scripts are
+    always overwritten (managed by AI Guard).
+
+    Args:
+        project_root: Path to project root.
+        rulesets: List of ruleset names installed.
+
+    Returns:
+        List of FileSpec for check scripts to be copied
+        to ``.ai-guard/checks/``.
+    """
+    artifacts: list[FileSpec] = []
+    cache_dir = project_root / ".ai-guard" / "cache"
+
+    for ruleset in rulesets:
+        checks_dir = cache_dir / ruleset / "checks"
+        if not checks_dir.is_dir():
+            continue
+
+        for file_path in checks_dir.iterdir():
+            if file_path.is_file():
+                try:
+                    content = file_path.read_text(encoding="utf-8")
+                    artifacts.append(
+                        FileSpec(
+                            path=f".ai-guard/checks/{file_path.name}",
                             content=content,
                         )
                     )

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -229,3 +229,94 @@ class TestInstallWithRuleset:
         assert result.exit_code == 0
         assert "Warning" in result.output
         assert "nonexistent-rules" in result.output
+
+
+class TestRulesetFileCopy:
+    """Test ruleset files/ and checks/ copying (WP4.2)."""
+
+    def _init_and_install_with_ruleset(
+        self,
+        tmp_path: Path,
+        ruleset_url: str,
+        ruleset_name: str,
+        extra_args: list[str] | None = None,
+    ) -> object:
+        """Helper: fetch ruleset, init config, install."""
+        pr = str(tmp_path)
+        (tmp_path / ".git").mkdir(exist_ok=True)
+
+        # Fetch
+        result = runner.invoke(
+            app, ["ruleset", "fetch", ruleset_url, "--project-root", pr]
+        )
+        assert result.exit_code == 0, f"fetch failed: {result.output}"
+
+        # Init config
+        config_path = tmp_path / "guard.yaml"
+        if not config_path.is_file():
+            result = runner.invoke(
+                app, ["init", "--language", "python", "--output", str(config_path)]
+            )
+            assert result.exit_code == 0
+
+        # Add rulesets
+        text = config_path.read_text(encoding="utf-8")
+        if "rulesets:" not in text:
+            text += f'\nrulesets:\n  - "{ruleset_name}"\n'
+            config_path.write_text(text, encoding="utf-8")
+
+        # Install
+        cmd = ["install", "--agent", "claude-code", "--config", str(config_path)]
+        if extra_args:
+            cmd.extend(extra_args)
+        return runner.invoke(app, cmd)
+
+    def test_install_copies_checks_to_ai_guard(self, tmp_path: Path) -> None:
+        """Check scripts from ruleset should appear in .ai-guard/checks/."""
+        url = _create_bare_repo(tmp_path / "repos")
+        result = self._init_and_install_with_ruleset(tmp_path, url, "test-rules")
+        assert result.exit_code == 0, f"install failed: {result.output}"
+        assert (tmp_path / ".ai-guard" / "checks" / "check_headers.py").is_file()
+
+    def test_install_copies_files_to_root(self, tmp_path: Path) -> None:
+        """Tool config files from ruleset should appear at project root."""
+        url = _create_bare_repo(tmp_path / "repos")
+        result = self._init_and_install_with_ruleset(tmp_path, url, "test-rules")
+        assert result.exit_code == 0, f"install failed: {result.output}"
+        assert (tmp_path / ".editorconfig").is_file()
+        assert (tmp_path / ".editorconfig").read_text(
+            encoding="utf-8"
+        ) == "root = true\n"
+
+    def test_install_skips_existing_files(self, tmp_path: Path) -> None:
+        """Existing user files should not be overwritten without --force."""
+        url = _create_bare_repo(tmp_path / "repos")
+
+        # Create user file BEFORE install
+        (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
+
+        result = self._init_and_install_with_ruleset(tmp_path, url, "test-rules")
+        assert result.exit_code == 0
+        assert "Skipping" in result.output or "skip" in result.output.lower()
+
+        # User file should be preserved
+        assert (tmp_path / ".editorconfig").read_text(
+            encoding="utf-8"
+        ) == "user content"
+
+    def test_install_force_overwrites_existing_files(self, tmp_path: Path) -> None:
+        """--force should overwrite existing user files."""
+        url = _create_bare_repo(tmp_path / "repos")
+
+        # Create user file BEFORE install
+        (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
+
+        result = self._init_and_install_with_ruleset(
+            tmp_path, url, "test-rules", extra_args=["--force"]
+        )
+        assert result.exit_code == 0
+
+        # Ruleset file should have replaced user file
+        assert (tmp_path / ".editorconfig").read_text(
+            encoding="utf-8"
+        ) == "root = true\n"

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -581,6 +581,133 @@ class TestGenerateToolConfigs:
         assert result[0].path == "text.txt"
 
 
+class TestGenerateToolConfigsForce:
+    """generate_tool_configs force/skip behavior tests."""
+
+    def test_skips_existing_file_by_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Existing user file should be skipped with warning when force=False."""
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "files"
+        cache.mkdir(parents=True)
+        (cache / ".editorconfig").write_text("ruleset content", encoding="utf-8")
+
+        # User already has this file
+        (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
+
+        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        assert len(result) == 0
+
+        captured = capsys.readouterr()
+        assert ".editorconfig" in captured.out
+        assert "skip" in captured.out.lower() or "exists" in captured.out.lower()
+
+    def test_overwrites_existing_file_when_forced(self, tmp_path: Path) -> None:
+        """Existing file should be included when force=True."""
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "files"
+        cache.mkdir(parents=True)
+        (cache / ".editorconfig").write_text("ruleset content", encoding="utf-8")
+
+        (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
+
+        result = generate_tool_configs(tmp_path, ["rules"], force=True)
+        assert len(result) == 1
+        assert result[0].content == "ruleset content"
+
+    def test_copies_new_file_regardless_of_force(self, tmp_path: Path) -> None:
+        """New files should always be copied, even with force=False."""
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "files"
+        cache.mkdir(parents=True)
+        (cache / "new-config.yml").write_text("new", encoding="utf-8")
+
+        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        assert len(result) == 1
+        assert result[0].path == "new-config.yml"
+
+    def test_mixed_existing_and_new(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Only existing files should be skipped; new files still copied."""
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "files"
+        cache.mkdir(parents=True)
+        (cache / "existing.cfg").write_text("from ruleset", encoding="utf-8")
+        (cache / "new.cfg").write_text("new config", encoding="utf-8")
+
+        (tmp_path / "existing.cfg").write_text("user version", encoding="utf-8")
+
+        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        assert len(result) == 1
+        assert result[0].path == "new.cfg"
+
+
+class TestGenerateCheckScripts:
+    """generate_check_scripts function tests."""
+
+    def test_returns_empty_list_when_no_rulesets(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        result = generate_check_scripts(tmp_path, [])
+        assert result == []
+
+    def test_returns_empty_list_when_cache_missing(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        result = generate_check_scripts(tmp_path, ["company-rules"])
+        assert result == []
+
+    def test_copies_scripts_to_ai_guard_checks(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "checks"
+        cache.mkdir(parents=True)
+        (cache / "encoding_check.py").write_text("# check", encoding="utf-8")
+
+        result = generate_check_scripts(tmp_path, ["rules"])
+        assert len(result) == 1
+        assert result[0].path == ".ai-guard/checks/encoding_check.py"
+        assert result[0].content == "# check"
+
+    def test_copies_from_multiple_rulesets(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        cache1 = tmp_path / ".ai-guard" / "cache" / "a" / "checks"
+        cache1.mkdir(parents=True)
+        (cache1 / "check_a.py").write_text("a", encoding="utf-8")
+
+        cache2 = tmp_path / ".ai-guard" / "cache" / "b" / "checks"
+        cache2.mkdir(parents=True)
+        (cache2 / "check_b.py").write_text("b", encoding="utf-8")
+
+        result = generate_check_scripts(tmp_path, ["a", "b"])
+        assert len(result) == 2
+        paths = [r.path for r in result]
+        assert ".ai-guard/checks/check_a.py" in paths
+        assert ".ai-guard/checks/check_b.py" in paths
+
+    def test_skips_binary_files(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        cache = tmp_path / ".ai-guard" / "cache" / "rules" / "checks"
+        cache.mkdir(parents=True)
+        (cache / "check.py").write_text("# ok", encoding="utf-8")
+        (cache / "binary.bin").write_bytes(b"\x00\xff\xfe")
+
+        result = generate_check_scripts(tmp_path, ["rules"])
+        assert len(result) == 1
+        assert result[0].path == ".ai-guard/checks/check.py"
+
+    def test_skips_missing_checks_dir(self, tmp_path: Path) -> None:
+        from ai_guard.generator.core import generate_check_scripts
+
+        # Ruleset exists in cache but has no checks/ dir
+        cache = tmp_path / ".ai-guard" / "cache" / "rules"
+        cache.mkdir(parents=True)
+        (cache / "guard.yaml").write_text("version: 1", encoding="utf-8")
+
+        result = generate_check_scripts(tmp_path, ["rules"])
+        assert result == []
+
+
 # ---------------------------------------------------------------------------
 # G4: Pre-commit Config Tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New `generate_check_scripts()` (G3b): copies ruleset `checks/` scripts to `.ai-guard/checks/`, always overwrites (AI Guard managed)
- Modified `generate_tool_configs()` (G3): skip existing user files with warning when `force=False`, overwrite when `force=True`
- Added `--force` flag to `guard install` and `guard update` commands
- Integrated G3b into the generator pipeline alongside G3

## Test plan

- [x] Unit tests: `TestGenerateCheckScripts` (6 tests), `TestGenerateToolConfigsForce` (4 tests)
- [x] Integration tests: files+checks copying, skip existing, force overwrite (4 tests)
- [x] Full regression: 713 tests passed, 0 failed
- [x] All pre-commit hooks passed

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)