### PR TITLE
feat(ruleset): enhance list and add show command (WP4.3)

### DIFF
--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -18,6 +18,7 @@ from ai_guard.cli.ruleset import (
     ruleset_cache_clear_command,
     ruleset_fetch_command,
     ruleset_list_command,
+    ruleset_show_command,
 )
 from ai_guard.cli.status import agents_command, doctor_command, status_command
 
@@ -341,6 +342,21 @@ def ruleset_list(
 ) -> None:
     """List cached rulesets."""
     ruleset_list_command(project_root=project_root.resolve())
+
+
+@ruleset_app.command(name="show")
+def ruleset_show(
+    name: Annotated[
+        str,
+        typer.Argument(help="Ruleset name to display"),
+    ],
+    project_root: Annotated[
+        Path,
+        typer.Option("--project-root", "-p", help="Project root directory"),
+    ] = Path("."),
+) -> None:
+    """Show details of a cached ruleset."""
+    ruleset_show_command(name=name, project_root=project_root.resolve())
 
 
 @cache_app.command(name="clear")

--- a/src/ai_guard/cli/ruleset.py
+++ b/src/ai_guard/cli/ruleset.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached
+import yaml
+
+from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached, read_meta
 from ai_guard.ruleset.exceptions import (
     RulesetError,
 )
 from ai_guard.ruleset.fetcher import fetch_ruleset
+from ai_guard.ruleset.models import CACHE_DIR
 from ai_guard.ruleset.parser import parse_ruleset_url
 
 
@@ -78,7 +81,7 @@ def ruleset_cache_clear_command(project_root: Path | None = None) -> None:
 def ruleset_list_command(project_root: Path | None = None) -> None:
     """Execute ``guard ruleset list``.
 
-    Lists cached rulesets with basic info.
+    Lists cached rulesets with name, version, and cache path.
 
     Args:
         project_root: Project root directory. Defaults to cwd.
@@ -92,4 +95,82 @@ def ruleset_list_command(project_root: Path | None = None) -> None:
 
     print(f"Cached rulesets ({len(names)}):")
     for name in names:
-        print(f"  - {name}")
+        meta = read_meta(root, name)
+        version = (meta.get("version") if meta else None) or "(default branch)"
+        cache_path = f"{CACHE_DIR}/{name}"
+        print(f"  {name:<25} {version:<20} {cache_path}")
+
+
+def ruleset_show_command(
+    name: str,
+    project_root: Path | None = None,
+) -> None:
+    """Execute ``guard ruleset show <name>``.
+
+    Displays ruleset metadata, behavior rules, files, and checks.
+
+    Args:
+        name: Ruleset name (cache directory name).
+        project_root: Project root directory. Defaults to cwd.
+    """
+    root = project_root or Path.cwd()
+    ruleset_dir = root / CACHE_DIR / name
+
+    if not ruleset_dir.is_dir():
+        print(f"Error: Ruleset '{name}' not found in cache.")
+        print("Run 'guard ruleset fetch <url>' to download it.")
+        raise SystemExit(1)
+
+    _print_meta(root, name)
+    _print_behavior_rules(ruleset_dir)
+    _print_dir_listing(ruleset_dir / "files", "Files")
+    _print_dir_listing(ruleset_dir / "checks", "Checks")
+
+
+def _print_meta(root: Path, name: str) -> None:
+    """Print ruleset metadata header."""
+    meta = read_meta(root, name)
+    print(f"Ruleset: {name}")
+    if meta:
+        version = meta.get("version") or "(default branch)"
+        print(f"  URL:     {meta.get('url', 'unknown')}")
+        print(f"  Version: {version}")
+        print(f"  Fetched: {meta.get('fetched_at', 'unknown')}")
+    print()
+
+
+def _print_behavior_rules(ruleset_dir: Path) -> None:
+    """Print behavior rules from the ruleset's guard.yaml."""
+    guard_yaml = ruleset_dir / "guard.yaml"
+    if not guard_yaml.is_file():
+        return
+
+    data = yaml.safe_load(guard_yaml.read_text(encoding="utf-8"))
+    behavior = data.get("behavior", {}) if isinstance(data, dict) else {}
+    if not behavior:
+        return
+
+    print("Behavior rules:")
+    for operation, tiers in sorted(behavior.items()):
+        if not isinstance(tiers, dict):
+            continue
+        for tier, rules in sorted(tiers.items()):
+            if not isinstance(rules, list):
+                continue
+            for rule in rules:
+                pattern = rule.get("pattern", "") if isinstance(rule, dict) else ""
+                if pattern:
+                    print(f"  {operation}.{tier}: {pattern}")
+    print()
+
+
+def _print_dir_listing(directory: Path, label: str) -> None:
+    """Print a directory's file listing."""
+    if not directory.is_dir():
+        return
+    items = sorted(f.name for f in directory.iterdir() if f.is_file())
+    if not items:
+        return
+    print(f"{label} ({len(items)}):")
+    for item in items:
+        print(f"  {item}")

--- a/src/ai_guard/ruleset/cache.py
+++ b/src/ai_guard/ruleset/cache.py
@@ -6,16 +6,17 @@ cache stored under ``.ai-guard/cache/``.
 
 from __future__ import annotations
 
+import json
 import shutil
 import stat
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ai_guard.ruleset.models import CACHE_DIR
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-__all__ = ["clear_cache", "get_cache_dir", "list_cached"]
+__all__ = ["clear_cache", "get_cache_dir", "list_cached", "read_meta"]
 
 
 def get_cache_dir(project_root: Path) -> Path:
@@ -46,6 +47,22 @@ def list_cached(project_root: Path) -> list[str]:
     if not cache.is_dir():
         return []
     return sorted(p.name for p in cache.iterdir() if p.is_dir())
+
+
+def read_meta(project_root: Path, name: str) -> dict[str, Any] | None:
+    """Read ``.ruleset-meta.json`` for a cached ruleset.
+
+    Args:
+        project_root: Path to the project root.
+        name: Ruleset directory name.
+
+    Returns:
+        Parsed metadata dict, or None if the file does not exist.
+    """
+    meta_path = project_root / CACHE_DIR / name / ".ruleset-meta.json"
+    if not meta_path.is_file():
+        return None
+    return json.loads(meta_path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
 
 
 def clear_cache(project_root: Path) -> int:

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -130,6 +130,22 @@ class TestRulesetFetchAndCacheClear:
         assert result.exit_code == 0
         assert "No cached rulesets" in result.output
 
+    def test_show_after_fetch(self, tmp_path: Path) -> None:
+        """Fetch a ruleset and show its details."""
+        url = _create_bare_repo(tmp_path / "repos")
+        pr = str(tmp_path)
+
+        runner.invoke(app, ["ruleset", "fetch", url, "--project-root", pr])
+
+        result = runner.invoke(
+            app, ["ruleset", "show", "test-rules", "--project-root", pr]
+        )
+        assert result.exit_code == 0, f"show failed: {result.output}"
+        assert "test-rules" in result.output
+        assert "file:secret/**" in result.output
+        assert ".editorconfig" in result.output
+        assert "check_headers.py" in result.output
+
     def test_fetch_with_tag(self, tmp_path: Path) -> None:
         """Fetch a specific version using #tag."""
         url = _create_bare_repo(tmp_path / "repos", tag="v1.0")

--- a/tests/unit/test_cli/test_ruleset.py
+++ b/tests/unit/test_cli/test_ruleset.py
@@ -2,14 +2,56 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ai_guard.cli.ruleset import (
     ruleset_cache_clear_command,
     ruleset_list_command,
+    ruleset_show_command,
 )
+
+
+def _create_cached_ruleset(
+    tmp_path: Path,
+    name: str = "my-rules",
+    *,
+    version: str | None = "v1.0",
+    url: str = "https://github.com/org/rules.git",
+    guard_yaml: dict | None = None,
+    files: list[str] | None = None,
+    checks: list[str] | None = None,
+) -> Path:
+    """Create a mock cached ruleset directory."""
+    cache = tmp_path / ".ai-guard" / "cache" / name
+    cache.mkdir(parents=True, exist_ok=True)
+
+    # Write meta
+    meta = {"url": url, "version": version, "fetched_at": "2026-04-17T00:00:00+00:00"}
+    (cache / ".ruleset-meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    # Write guard.yaml
+    content = guard_yaml or {
+        "behavior": {"read": {"forbidden": [{"pattern": "file:secret/**"}]}}
+    }
+    (cache / "guard.yaml").write_text(yaml.dump(content), encoding="utf-8")
+
+    # Write files
+    if files:
+        (cache / "files").mkdir(exist_ok=True)
+        for f in files:
+            (cache / "files" / f).write_text(f"# {f}", encoding="utf-8")
+
+    # Write checks
+    if checks:
+        (cache / "checks").mkdir(exist_ok=True)
+        for c in checks:
+            (cache / "checks" / c).write_text(f"# {c}", encoding="utf-8")
+
+    return cache
 
 
 class TestRulesetListCommand:
@@ -25,13 +67,99 @@ class TestRulesetListCommand:
     def test_lists_cached_rulesets(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        cache = tmp_path / ".ai-guard" / "cache"
-        cache.mkdir(parents=True)
-        (cache / "my-rules").mkdir()
+        _create_cached_ruleset(tmp_path, "my-rules", version="v1.0")
 
         ruleset_list_command(project_root=tmp_path)
         captured = capsys.readouterr()
         assert "my-rules" in captured.out
+
+    def test_list_shows_version(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _create_cached_ruleset(tmp_path, "rules", version="v2.0")
+
+        ruleset_list_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "v2.0" in captured.out
+
+    def test_list_shows_default_branch_when_no_version(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _create_cached_ruleset(tmp_path, "rules", version=None)
+
+        ruleset_list_command(project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "default" in captured.out.lower()
+
+
+class TestRulesetShowCommand:
+    """Test ruleset_show_command."""
+
+    def test_show_nonexistent_ruleset(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            ruleset_show_command("nonexistent", project_root=tmp_path)
+
+    def test_show_displays_meta(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _create_cached_ruleset(
+            tmp_path,
+            "company-rules",
+            version="v1.0",
+            url="https://github.com/org/rules.git",
+        )
+
+        ruleset_show_command("company-rules", project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "company-rules" in captured.out
+        assert "v1.0" in captured.out
+        assert "github.com" in captured.out
+
+    def test_show_displays_behavior_rules(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = {
+            "behavior": {
+                "read": {"forbidden": [{"pattern": "file:.env*"}]},
+                "execute": {"forbidden": [{"pattern": "shell:rm -rf*"}]},
+            }
+        }
+        _create_cached_ruleset(tmp_path, "rules", guard_yaml=config)
+
+        ruleset_show_command("rules", project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "file:.env*" in captured.out
+        assert "shell:rm -rf*" in captured.out
+
+    def test_show_displays_files_list(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _create_cached_ruleset(
+            tmp_path,
+            "rules",
+            files=[".editorconfig", ".clang-format"],
+        )
+
+        ruleset_show_command("rules", project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert ".editorconfig" in captured.out
+        assert ".clang-format" in captured.out
+
+    def test_show_displays_checks_list(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _create_cached_ruleset(
+            tmp_path,
+            "rules",
+            checks=["encoding_check.py", "header_check.py"],
+        )
+
+        ruleset_show_command("rules", project_root=tmp_path)
+        captured = capsys.readouterr()
+        assert "encoding_check.py" in captured.out
+        assert "header_check.py" in captured.out
 
 
 class TestRulesetCacheClearCommand:

--- a/tests/unit/test_ruleset/test_cache.py
+++ b/tests/unit/test_ruleset/test_cache.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached
+from ai_guard.ruleset.cache import clear_cache, get_cache_dir, list_cached, read_meta
 
 
 class TestGetCacheDir:
@@ -118,3 +119,30 @@ class TestClearCache:
         (cache / "rules").mkdir()
         clear_cache(tmp_path)
         assert (ai_guard / "state.json").is_file()
+
+
+class TestReadMeta:
+    """Test read_meta."""
+
+    def test_reads_meta_json(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache" / "my-rules"
+        cache.mkdir(parents=True)
+        meta = {
+            "url": "https://example.com/repo.git",
+            "version": "v1.0",
+            "fetched_at": "2026-04-17T00:00:00",
+        }
+        (cache / ".ruleset-meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+        result = read_meta(tmp_path, "my-rules")
+        assert result is not None
+        assert result["url"] == "https://example.com/repo.git"
+        assert result["version"] == "v1.0"
+
+    def test_returns_none_when_no_meta(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".ai-guard" / "cache" / "my-rules"
+        cache.mkdir(parents=True)
+        assert read_meta(tmp_path, "my-rules") is None
+
+    def test_returns_none_when_no_ruleset(self, tmp_path: Path) -> None:
+        assert read_meta(tmp_path, "nonexistent") is None


### PR DESCRIPTION
## Summary

- Enhanced `guard ruleset list`: displays name, version, and cache path (reads `.ruleset-meta.json`)
- New `guard ruleset show <name>`: displays metadata, behavior rules, files/ listing, and checks/ listing
- New `read_meta()` utility in cache module

## Test plan

- [x] Unit tests: `TestReadMeta` (3), enhanced `TestRulesetListCommand` (4), `TestRulesetShowCommand` (5)
- [x] Integration test: `test_show_after_fetch` — fetch → show e2e
- [x] Full regression: 724 tests passed, 0 failed
- [x] All pre-commit hooks passed

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)