### PR TITLE
feat(reporter): add ReportChannel ABC and GitHub implementation (WP5.1)

### DIFF
--- a/src/ai_guard/reporter/__init__.py
+++ b/src/ai_guard/reporter/__init__.py
@@ -1,12 +1,15 @@
-"""Reporter module — audit logging and report formatting."""
+"""Reporter module — audit logging, report formatting, and PR posting."""
 
 from ai_guard.reporter.audit import append_audit_log, apply_retention
+from ai_guard.reporter.channel_base import ChannelError, post_pr_comment
 from ai_guard.reporter.formatting import format_gate, format_markdown, format_terminal
 
 __all__ = [
+    "ChannelError",
     "append_audit_log",
     "apply_retention",
     "format_gate",
     "format_markdown",
     "format_terminal",
+    "post_pr_comment",
 ]

--- a/src/ai_guard/reporter/channel_base.py
+++ b/src/ai_guard/reporter/channel_base.py
@@ -1,0 +1,155 @@
+"""ReportChannel ABC, registration, and R4 post_pr_comment API.
+
+Defines the interface for posting check reports to code hosting
+platforms (GitHub, GitLab, etc.) as PR comments. Each platform
+is implemented as a separate channel file and auto-registered.
+"""
+
+from __future__ import annotations
+
+import sys
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from ai_guard.reporter.formatting import format_markdown
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ai_guard.config.models import PrReportConfig
+
+__all__ = [
+    "ChannelError",
+    "ReportChannel",
+    "get_channel",
+    "post_pr_comment",
+    "register_channel",
+]
+
+
+class ChannelError(Exception):
+    """Raised when a report channel operation fails.
+
+    This is caught by ``post_pr_comment`` to avoid affecting
+    the main exit code — failures are logged as warnings.
+    """
+
+
+class ReportChannel(ABC):
+    """Abstract base for PR comment posting channels.
+
+    Each subclass handles one platform (GitHub, GitLab, etc.).
+    Subclasses must be decorated with :func:`register_channel`
+    to be discoverable via :func:`get_channel`.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Platform identifier matching ``output.pr_report.platform``."""
+
+    @abstractmethod
+    def send(self, markdown: str, config: PrReportConfig) -> None:
+        """Post a Markdown report as a PR comment.
+
+        Args:
+            markdown: Rendered Markdown report string.
+            config: PR report configuration with platform
+                credentials and API endpoint.
+
+        Raises:
+            ChannelError: If posting fails (HTTP error,
+                missing credentials, no PR detected, etc.).
+        """
+
+
+# ---------------------------------------------------------------------------
+# Channel registry
+# ---------------------------------------------------------------------------
+
+_CHANNELS: dict[str, type[ReportChannel]] = {}
+
+
+def register_channel(cls: type[ReportChannel]) -> type[ReportChannel]:
+    """Register a ReportChannel subclass by its ``name``.
+
+    Intended as a class decorator::
+
+        @register_channel
+        class GitHubChannel(ReportChannel):
+            ...
+
+    Args:
+        cls: A concrete ReportChannel subclass.
+
+    Returns:
+        The same class, unmodified.
+    """
+    instance = cls()
+    _CHANNELS[instance.name] = cls
+    return cls
+
+
+def get_channel(platform: str) -> ReportChannel:
+    """Look up a registered channel by platform name.
+
+    Args:
+        platform: Platform identifier (e.g. ``"github"``).
+
+    Returns:
+        A new instance of the matching channel.
+
+    Raises:
+        ChannelError: If no channel is registered for the platform.
+    """
+    cls = _CHANNELS.get(platform)
+    if cls is None:
+        available = ", ".join(sorted(_CHANNELS)) or "(none)"
+        raise ChannelError(f"Unknown platform '{platform}'. Available: {available}")
+    return cls()
+
+
+# ---------------------------------------------------------------------------
+# R4: Public API
+# ---------------------------------------------------------------------------
+
+
+def post_pr_comment(
+    report: Any,
+    config: PrReportConfig,
+    locale: str = "en",
+) -> None:
+    """Post a check report as a PR comment (R4 primitive).
+
+    Renders the report to Markdown, looks up the appropriate
+    channel for the configured platform, and sends the comment.
+
+    **Non-blocking:** If sending fails for any reason (missing
+    credentials, no PR detected, HTTP error), a warning is printed
+    to stderr but no exception is raised — the main exit code
+    is not affected.
+
+    Args:
+        report: Aggregated check report to post.
+        config: PR report configuration. If ``enabled`` is False,
+            this function returns immediately.
+        locale: Locale for Markdown template (``"en"`` or ``"zh-CN"``).
+    """
+    if not config.enabled:
+        return
+
+    try:
+        markdown = format_markdown(report, locale)
+        channel = get_channel(config.platform)
+        channel.send(markdown, config)
+    except (ChannelError, Exception) as exc:
+        print(f"Warning: PR comment not posted: {exc}", file=sys.stderr)
+
+
+# Ensure built-in channels are registered on import
+def _auto_register() -> None:
+    """Import built-in channel modules to trigger registration."""
+    import ai_guard.reporter.channel_github  # noqa: F401
+
+
+_auto_register()

--- a/src/ai_guard/reporter/channel_github.py
+++ b/src/ai_guard/reporter/channel_github.py
@@ -1,0 +1,150 @@
+"""GitHub ReportChannel — posts check reports as PR comments.
+
+Uses the GitHub REST API to create issue comments on pull requests.
+Supports both github.com and self-hosted GitHub Enterprise instances
+via the ``api_url`` configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.request
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+
+from ai_guard.reporter.channel_base import ChannelError, ReportChannel, register_channel
+
+if TYPE_CHECKING:
+    from ai_guard.config.models import PrReportConfig
+
+__all__ = ["GitHubChannel"]
+
+_PR_REF_PATTERN = re.compile(r"^refs/pull/(\d+)/")
+"""Pattern to extract PR number from GITHUB_REF."""
+
+
+@register_channel
+class GitHubChannel(ReportChannel):
+    """Post check reports to GitHub PR comments.
+
+    Requires environment variables:
+        - Token: from ``config.token_env`` (default ``GITHUB_TOKEN``)
+        - Repository: ``GITHUB_REPOSITORY`` (format ``owner/repo``)
+        - PR number: parsed from ``GITHUB_REF`` (``refs/pull/<n>/merge``)
+          or ``AI_GUARD_PR_NUMBER`` as fallback
+
+    Attributes:
+        DEFAULT_API_URL: Default GitHub API base URL.
+    """
+
+    DEFAULT_API_URL = "https://api.github.com"
+
+    @property
+    def name(self) -> str:
+        """Platform identifier."""
+        return "github"
+
+    def send(self, markdown: str, config: PrReportConfig) -> None:
+        """Post markdown as a comment on the associated PR.
+
+        Args:
+            markdown: Rendered Markdown report string.
+            config: PR report configuration.
+
+        Raises:
+            ChannelError: If token is missing, PR cannot be
+                identified, or the API request fails.
+        """
+        token = self._get_token(config)
+        repo = self._get_repository()
+        pr_number = self._get_pr_number()
+        api_url = (config.api_url or self.DEFAULT_API_URL).rstrip("/")
+
+        url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
+        data = json.dumps({"body": markdown}).encode("utf-8")
+
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(req) as resp:
+                resp.read()
+        except HTTPError as exc:
+            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+        except URLError as exc:
+            raise ChannelError(
+                f"Failed to connect to GitHub API: {exc.reason}"
+            ) from exc
+
+    @staticmethod
+    def _get_token(config: PrReportConfig) -> str:
+        """Read the API token from the environment.
+
+        Args:
+            config: PR report config with ``token_env`` field.
+
+        Returns:
+            The token string.
+
+        Raises:
+            ChannelError: If the environment variable is not set.
+        """
+        token = os.environ.get(config.token_env)
+        if not token:
+            raise ChannelError(
+                f"GitHub token not found: set the {config.token_env} "
+                f"environment variable"
+            )
+        return token
+
+    @staticmethod
+    def _get_repository() -> str:
+        """Read the repository from ``GITHUB_REPOSITORY``.
+
+        Returns:
+            Repository in ``owner/repo`` format.
+
+        Raises:
+            ChannelError: If the environment variable is not set.
+        """
+        repo = os.environ.get("GITHUB_REPOSITORY")
+        if not repo:
+            raise ChannelError("GITHUB_REPOSITORY environment variable not set")
+        return repo
+
+    @staticmethod
+    def _get_pr_number() -> str:
+        """Determine the PR number from environment variables.
+
+        Checks ``GITHUB_REF`` first (``refs/pull/<n>/merge``),
+        then falls back to ``AI_GUARD_PR_NUMBER``.
+
+        Returns:
+            PR number as string.
+
+        Raises:
+            ChannelError: If PR number cannot be determined.
+        """
+        github_ref = os.environ.get("GITHUB_REF", "")
+        match = _PR_REF_PATTERN.match(github_ref)
+        if match:
+            return match.group(1)
+
+        pr_number = os.environ.get("AI_GUARD_PR_NUMBER")
+        if pr_number:
+            return pr_number
+
+        raise ChannelError(
+            "Cannot determine PR number. Set GITHUB_REF "
+            "(refs/pull/<n>/merge) or AI_GUARD_PR_NUMBER"
+        )

--- a/tests/unit/test_reporter/test_channel_base.py
+++ b/tests/unit/test_reporter/test_channel_base.py
@@ -1,0 +1,93 @@
+"""Tests for ReportChannel ABC, registration, and post_pr_comment."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_guard.config.models import PrReportConfig
+from ai_guard.reporter.channel_base import (
+    ChannelError,
+    ReportChannel,
+    get_channel,
+    post_pr_comment,
+    register_channel,
+)
+
+
+class TestReportChannelABC:
+    """ReportChannel cannot be instantiated directly."""
+
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            ReportChannel()  # type: ignore[abstract]
+
+    def test_subclass_must_implement_name_and_send(self) -> None:
+        class Incomplete(ReportChannel):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_valid_subclass(self) -> None:
+        class Valid(ReportChannel):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            def send(self, markdown: str, config: PrReportConfig) -> None:
+                pass
+
+        ch = Valid()
+        assert ch.name == "test"
+
+
+class TestRegisterAndGetChannel:
+    """Channel registration and lookup."""
+
+    def test_register_and_get(self) -> None:
+        class FakeChannel(ReportChannel):
+            @property
+            def name(self) -> str:
+                return "fake"
+
+            def send(self, markdown: str, config: PrReportConfig) -> None:
+                pass
+
+        register_channel(FakeChannel)
+        ch = get_channel("fake")
+        assert ch.name == "fake"
+
+    def test_get_unknown_platform_raises(self) -> None:
+        with pytest.raises(ChannelError, match="unknown-platform"):
+            get_channel("unknown-platform")
+
+    def test_get_github_returns_github_channel(self) -> None:
+        """GitHubChannel should be auto-registered on import."""
+        ch = get_channel("github")
+        assert ch.name == "github"
+
+
+class TestPostPrComment:
+    """post_pr_comment is non-blocking (catches errors)."""
+
+    def test_disabled_config_does_nothing(self) -> None:
+        """When pr_report.enabled=False, should not attempt to send."""
+        config = PrReportConfig(enabled=False)
+        # Should not raise regardless of missing env vars
+        post_pr_comment(report=None, config=config, locale="en")  # type: ignore[arg-type]
+
+    def test_send_failure_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If channel.send() raises, post_pr_comment catches and warns."""
+        from ai_guard.checker.models import CheckReport
+
+        config = PrReportConfig(enabled=True, platform="github")
+        report = CheckReport(stage="commit", passed=True)
+
+        # Ensure send will fail (no env vars set)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        # Should not raise — catches internally
+        post_pr_comment(report=report, config=config, locale="en")

--- a/tests/unit/test_reporter/test_channel_github.py
+++ b/tests/unit/test_reporter/test_channel_github.py
@@ -1,0 +1,191 @@
+"""Tests for GitHubChannel — mock HTTP."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_guard.config.models import PrReportConfig
+from ai_guard.reporter.channel_base import ChannelError
+from ai_guard.reporter.channel_github import GitHubChannel
+
+
+class TestGitHubChannel:
+    """GitHubChannel send() with mocked HTTP."""
+
+    def _make_config(
+        self,
+        *,
+        api_url: str | None = None,
+        token_env: str = "GITHUB_TOKEN",
+    ) -> PrReportConfig:
+        return PrReportConfig(
+            enabled=True,
+            platform="github",
+            api_url=api_url,
+            token_env=token_env,
+        )
+
+    def test_name_is_github(self) -> None:
+        ch = GitHubChannel()
+        assert ch.name == "github"
+
+    def test_send_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful POST returns 201."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        mock_response = MagicMock()
+        mock_response.status = 201
+        mock_response.read.return_value = b'{"id": 1}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "urllib.request.urlopen", return_value=mock_response
+        ) as mock_urlopen:
+            ch = GitHubChannel()
+            ch.send("## Report\n- all passed", self._make_config())
+
+            mock_urlopen.assert_called_once()
+            req = mock_urlopen.call_args[0][0]
+            assert "/repos/owner/repo/issues/42/comments" in req.full_url
+            body = json.loads(req.data)
+            assert "Report" in body["body"]
+
+    def test_send_failure_raises_channel_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HTTP error raises ChannelError."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        from urllib.error import HTTPError
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=HTTPError(
+                url="",
+                code=403,
+                msg="Forbidden",
+                hdrs=None,
+                fp=None,  # type: ignore[arg-type]
+            ),
+        ):
+            ch = GitHubChannel()
+            with pytest.raises(ChannelError, match="403"):
+                ch.send("report", self._make_config())
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Missing token raises ChannelError."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
+
+        ch = GitHubChannel()
+        with pytest.raises(ChannelError, match="token"):
+            ch.send("report", self._make_config())
+
+    def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Custom api_url is used instead of default."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/5/merge")
+
+        mock_response = MagicMock()
+        mock_response.status = 201
+        mock_response.read.return_value = b'{"id": 1}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "urllib.request.urlopen", return_value=mock_response
+        ) as mock_urlopen:
+            ch = GitHubChannel()
+            ch.send("report", self._make_config(api_url="https://git.corp.com/api/v3"))
+
+            req = mock_urlopen.call_args[0][0]
+            assert req.full_url.startswith("https://git.corp.com/api/v3/")
+
+    def test_pr_number_from_ai_guard_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AI_GUARD_PR_NUMBER fallback."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "99")
+
+        mock_response = MagicMock()
+        mock_response.status = 201
+        mock_response.read.return_value = b'{"id": 1}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "urllib.request.urlopen", return_value=mock_response
+        ) as mock_urlopen:
+            ch = GitHubChannel()
+            ch.send("report", self._make_config())
+
+            req = mock_urlopen.call_args[0][0]
+            assert "/issues/99/comments" in req.full_url
+
+    def test_missing_pr_number_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No PR number available raises ChannelError."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        ch = GitHubChannel()
+        with pytest.raises(ChannelError, match="PR number"):
+            ch.send("report", self._make_config())
+
+    def test_missing_repository_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Missing GITHUB_REPOSITORY raises ChannelError."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
+
+        ch = GitHubChannel()
+        with pytest.raises(ChannelError, match="GITHUB_REPOSITORY"):
+            ch.send("report", self._make_config())
+
+    def test_parse_pr_number_from_github_ref(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """refs/pull/<n>/merge format is parsed correctly."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/123/merge")
+
+        mock_response = MagicMock()
+        mock_response.status = 201
+        mock_response.read.return_value = b'{"id": 1}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "urllib.request.urlopen", return_value=mock_response
+        ) as mock_urlopen:
+            ch = GitHubChannel()
+            ch.send("report", self._make_config())
+
+            req = mock_urlopen.call_args[0][0]
+            assert "/issues/123/comments" in req.full_url
+
+    def test_non_pr_github_ref_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """refs/heads/main does not contain PR number → raises."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        ch = GitHubChannel()
+        with pytest.raises(ChannelError, match="PR number"):
+            ch.send("report", self._make_config())


### PR DESCRIPTION
## Summary

- `ReportChannel` ABC with `register_channel` decorator and `get_channel()` lookup (`channel_base.py`)
- `GitHubChannel` implementation: POST PR comments via GitHub REST API using stdlib `urllib` (`channel_github.py`)
  - Token from configurable env var (`token_env`), PR number from `GITHUB_REF` or `AI_GUARD_PR_NUMBER`
  - Custom `api_url` support for self-hosted GitHub Enterprise
- `post_pr_comment()` R4 public API: non-blocking, catches all errors as stderr warnings
- Each platform gets its own file, auto-registered on import

## Test plan

- [x] Unit tests: `TestReportChannelABC` (3), `TestRegisterAndGetChannel` (3), `TestPostPrComment` (2), `TestGitHubChannel` (10) — all with mock HTTP
- [x] Full regression: 751 tests passed, 0 failed
- [x] All pre-commit hooks passed (including import dependency check)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)