### PR TITLE
feat(reporter): add GitLab/Gitea/Bitbucket channels and smart PR detection (WP5.2)

### DIFF
--- a/src/ai_guard/reporter/_git_info.py
+++ b/src/ai_guard/reporter/_git_info.py
@@ -1,0 +1,95 @@
+"""Git repository info helper for ReportChannel.
+
+Provides functions to extract repository owner/name and current
+branch from the local git repo, used as fallback when CI
+environment variables are not available.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+__all__ = ["get_current_branch", "get_remote_repo", "parse_repo_url"]
+
+_HTTPS_REPO_PATTERN = re.compile(r"https?://[^/]+/(.+?)(?:\.git)?$")
+"""Match HTTPS remote: https://host/owner/repo.git → owner/repo"""
+
+_SSH_REPO_PATTERN = re.compile(r"git@[^:]+:(.+?)(?:\.git)?$")
+"""Match SSH remote: git@host:owner/repo.git → owner/repo"""
+
+
+def parse_repo_url(url: str) -> str | None:
+    """Extract ``owner/repo`` from a git remote URL.
+
+    Handles HTTPS and SSH formats. For paths with more than two
+    segments (e.g. GitLab nested groups), returns the last two.
+
+    Args:
+        url: Git remote URL string.
+
+    Returns:
+        ``"owner/repo"`` string, or None if unparseable.
+    """
+    for pattern in (_HTTPS_REPO_PATTERN, _SSH_REPO_PATTERN):
+        match = pattern.match(url.strip())
+        if match:
+            path = match.group(1)
+            # For nested groups (a/b/c/repo), take last two segments
+            parts = path.split("/")
+            if len(parts) >= 2:
+                return f"{parts[-2]}/{parts[-1]}"
+            return path
+    return None
+
+
+def get_remote_repo() -> str | None:
+    """Get ``owner/repo`` from ``git remote get-url origin``.
+
+    Returns:
+        Parsed ``"owner/repo"`` string, or None if git command
+        fails or URL is unparseable.
+    """
+    output = _run_git("remote", "get-url", "origin")
+    if output is None:
+        return None
+    return parse_repo_url(output)
+
+
+def get_current_branch() -> str | None:
+    """Get the current git branch name.
+
+    Returns:
+        Branch name string, or None if not on a branch
+        or git command fails.
+    """
+    output = _run_git("branch", "--show-current")
+    if output is None:
+        return None
+    return output.strip() or None
+
+
+def _run_git(*args: str) -> str | None:
+    """Run a git command and return stdout, or None on failure.
+
+    Args:
+        args: Git subcommand and arguments.
+
+    Returns:
+        Stripped stdout string, or None if the command fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return None

--- a/src/ai_guard/reporter/channel_base.py
+++ b/src/ai_guard/reporter/channel_base.py
@@ -149,7 +149,10 @@ def post_pr_comment(
 # Ensure built-in channels are registered on import
 def _auto_register() -> None:
     """Import built-in channel modules to trigger registration."""
-    import ai_guard.reporter.channel_github  # noqa: F401
+    import ai_guard.reporter.channel_bitbucket
+    import ai_guard.reporter.channel_gitea
+    import ai_guard.reporter.channel_github
+    import ai_guard.reporter.channel_gitlab  # noqa: F401
 
 
 _auto_register()

--- a/src/ai_guard/reporter/channel_bitbucket.py
+++ b/src/ai_guard/reporter/channel_bitbucket.py
@@ -1,7 +1,7 @@
-"""GitHub ReportChannel — posts check reports as PR comments.
+"""Bitbucket ReportChannel — posts check reports as PR comments.
 
-Uses the GitHub REST API to create issue comments on pull requests.
-Supports both github.com and self-hosted GitHub Enterprise instances
+Uses the Bitbucket REST API to create comments on pull requests.
+Supports both bitbucket.org and self-hosted Bitbucket instances
 via the ``api_url`` configuration.
 """
 
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import urllib.request
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
@@ -20,37 +19,34 @@ from ai_guard.reporter.channel_base import ChannelError, ReportChannel, register
 if TYPE_CHECKING:
     from ai_guard.config.models import PrReportConfig
 
-__all__ = ["GitHubChannel"]
-
-_PR_REF_PATTERN = re.compile(r"^refs/pull/(\d+)/")
-"""Pattern to extract PR number from GITHUB_REF."""
+__all__ = ["BitbucketChannel"]
 
 
 @register_channel
-class GitHubChannel(ReportChannel):
-    """Post check reports to GitHub PR comments.
+class BitbucketChannel(ReportChannel):
+    """Post check reports to Bitbucket PR comments.
 
     Repository and PR number are resolved automatically:
 
     **Repository** (in priority order):
-        1. ``GITHUB_REPOSITORY`` environment variable
+        1. ``BITBUCKET_REPO_FULL_NAME`` environment variable
         2. ``git remote get-url origin`` parsed
 
     **PR number** (in priority order):
         1. ``AI_GUARD_PR_NUMBER`` environment variable
-        2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
-        3. GitHub API query by current branch name
+        2. ``BITBUCKET_PR_ID`` environment variable
+        3. Bitbucket API query by current branch name
 
     Attributes:
-        DEFAULT_API_URL: Default GitHub API base URL.
+        DEFAULT_API_URL: Default Bitbucket API base URL.
     """
 
-    DEFAULT_API_URL = "https://api.github.com"
+    DEFAULT_API_URL = "https://api.bitbucket.org"
 
     @property
     def name(self) -> str:
         """Platform identifier."""
-        return "github"
+        return "bitbucket"
 
     def send(self, markdown: str, config: PrReportConfig) -> None:
         """Post markdown as a comment on the associated PR.
@@ -66,60 +62,58 @@ class GitHubChannel(ReportChannel):
         token = self._get_token(config)
         repo = self._get_repository()
         api_url = (config.api_url or self.DEFAULT_API_URL).rstrip("/")
-        pr_number = self._get_pr_number(token, repo, api_url)
+        pr_id = self._get_pr_id(token, repo, api_url)
 
-        url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
-        self._post_json(url, {"body": markdown}, token)
+        url = f"{api_url}/2.0/repositories/{repo}/pullrequests/{pr_id}/comments"
+        self._post_json(url, {"content": {"raw": markdown}}, token)
 
-    def _get_pr_number(self, token: str, repo: str, api_url: str) -> str:
-        """Determine the PR number.
+    def _get_pr_id(self, token: str, repo: str, api_url: str) -> str:
+        """Determine the PR ID.
 
         Priority:
             1. ``AI_GUARD_PR_NUMBER`` env var
-            2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
+            2. ``BITBUCKET_PR_ID`` env var
             3. API query by current branch
 
         Args:
-            token: GitHub API token for API query fallback.
-            repo: Repository in ``owner/repo`` format.
-            api_url: GitHub API base URL.
+            token: Bitbucket API token for API query fallback.
+            repo: Repository in ``workspace/repo`` format.
+            api_url: Bitbucket API base URL.
 
         Returns:
-            PR number as string.
+            PR ID as string.
 
         Raises:
-            ChannelError: If PR number cannot be determined.
+            ChannelError: If PR ID cannot be determined.
         """
         # 1. Explicit env var
-        pr_number = os.environ.get("AI_GUARD_PR_NUMBER")
-        if pr_number:
-            return pr_number
+        pr_id = os.environ.get("AI_GUARD_PR_NUMBER")
+        if pr_id:
+            return pr_id
 
-        # 2. GITHUB_REF
-        github_ref = os.environ.get("GITHUB_REF", "")
-        match = _PR_REF_PATTERN.match(github_ref)
-        if match:
-            return match.group(1)
+        # 2. BITBUCKET_PR_ID
+        pr_id = os.environ.get("BITBUCKET_PR_ID")
+        if pr_id:
+            return pr_id
 
         # 3. API query by branch
         branch = get_current_branch()
         if branch:
-            owner = repo.split("/")[0] if "/" in repo else repo
-            query_url = (
-                f"{api_url}/repos/{repo}/pulls"
-                f"?head={owner}:{branch}&state=open&per_page=1"
-            )
+            query_url = f"{api_url}/2.0/repositories/{repo}/pullrequests?state=OPEN"
             try:
                 data = self._get_json(query_url, token)
-                if data and isinstance(data, list) and len(data) > 0:
-                    return str(data[0]["number"])
+                if data and isinstance(data, dict):
+                    for pr in data.get("values", []):
+                        source = pr.get("source", {})
+                        source_branch = source.get("branch", {})
+                        if source_branch.get("name") == branch:
+                            return str(pr["id"])
             except ChannelError:
                 pass  # Fall through to error
 
         raise ChannelError(
-            "Cannot determine PR number. Set AI_GUARD_PR_NUMBER, "
-            "GITHUB_REF (refs/pull/<n>/merge), or push your branch "
-            "and open a PR"
+            "Cannot determine PR ID. Set AI_GUARD_PR_NUMBER, "
+            "BITBUCKET_PR_ID, or push your branch and open a PR"
         )
 
     @staticmethod
@@ -138,7 +132,7 @@ class GitHubChannel(ReportChannel):
         token = os.environ.get(config.token_env)
         if not token:
             raise ChannelError(
-                f"GitHub token not found: set the {config.token_env} "
+                f"Bitbucket token not found: set the {config.token_env} "
                 f"environment variable"
             )
         return token
@@ -148,16 +142,16 @@ class GitHubChannel(ReportChannel):
         """Determine the repository.
 
         Priority:
-            1. ``GITHUB_REPOSITORY`` env var
+            1. ``BITBUCKET_REPO_FULL_NAME`` env var
             2. ``git remote get-url origin``
 
         Returns:
-            Repository in ``owner/repo`` format.
+            Repository in ``workspace/repo`` format.
 
         Raises:
             ChannelError: If repository cannot be determined.
         """
-        repo = os.environ.get("GITHUB_REPOSITORY")
+        repo = os.environ.get("BITBUCKET_REPO_FULL_NAME")
         if repo:
             return repo
 
@@ -166,7 +160,7 @@ class GitHubChannel(ReportChannel):
             return repo
 
         raise ChannelError(
-            "Cannot determine repository. Set GITHUB_REPOSITORY or "
+            "Cannot determine repository. Set BITBUCKET_REPO_FULL_NAME or "
             "ensure git remote 'origin' is configured"
         )
 
@@ -189,7 +183,6 @@ class GitHubChannel(ReportChannel):
             method="POST",
             headers={
                 "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
                 "Content-Type": "application/json",
             },
         )
@@ -197,10 +190,12 @@ class GitHubChannel(ReportChannel):
             with urllib.request.urlopen(req) as resp:
                 resp.read()
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(
+                f"Bitbucket API returned {exc.code}: {exc.reason}"
+            ) from exc
         except URLError as exc:
             raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
+                f"Failed to connect to Bitbucket API: {exc.reason}"
             ) from exc
 
     @staticmethod
@@ -222,15 +217,16 @@ class GitHubChannel(ReportChannel):
             method="GET",
             headers={
                 "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
             },
         )
         try:
             with urllib.request.urlopen(req) as resp:
                 return json.loads(resp.read())
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(
+                f"Bitbucket API returned {exc.code}: {exc.reason}"
+            ) from exc
         except URLError as exc:
             raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
+                f"Failed to connect to Bitbucket API: {exc.reason}"
             ) from exc

--- a/src/ai_guard/reporter/channel_gitea.py
+++ b/src/ai_guard/reporter/channel_gitea.py
@@ -1,7 +1,7 @@
-"""GitHub ReportChannel — posts check reports as PR comments.
+"""Gitea ReportChannel — posts check reports as PR comments.
 
-Uses the GitHub REST API to create issue comments on pull requests.
-Supports both github.com and self-hosted GitHub Enterprise instances
+Uses the Gitea REST API to create issue comments on pull requests.
+Supports both gitea.com and self-hosted Gitea instances
 via the ``api_url`` configuration.
 """
 
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import urllib.request
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
@@ -20,37 +19,33 @@ from ai_guard.reporter.channel_base import ChannelError, ReportChannel, register
 if TYPE_CHECKING:
     from ai_guard.config.models import PrReportConfig
 
-__all__ = ["GitHubChannel"]
-
-_PR_REF_PATTERN = re.compile(r"^refs/pull/(\d+)/")
-"""Pattern to extract PR number from GITHUB_REF."""
+__all__ = ["GiteaChannel"]
 
 
 @register_channel
-class GitHubChannel(ReportChannel):
-    """Post check reports to GitHub PR comments.
+class GiteaChannel(ReportChannel):
+    """Post check reports to Gitea PR comments.
 
     Repository and PR number are resolved automatically:
 
     **Repository** (in priority order):
-        1. ``GITHUB_REPOSITORY`` environment variable
+        1. ``GITEA_REPOSITORY`` environment variable
         2. ``git remote get-url origin`` parsed
 
     **PR number** (in priority order):
         1. ``AI_GUARD_PR_NUMBER`` environment variable
-        2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
-        3. GitHub API query by current branch name
+        2. Gitea API query by current branch name
 
     Attributes:
-        DEFAULT_API_URL: Default GitHub API base URL.
+        DEFAULT_API_URL: Default Gitea API base URL.
     """
 
-    DEFAULT_API_URL = "https://api.github.com"
+    DEFAULT_API_URL = "https://gitea.com"
 
     @property
     def name(self) -> str:
         """Platform identifier."""
-        return "github"
+        return "gitea"
 
     def send(self, markdown: str, config: PrReportConfig) -> None:
         """Post markdown as a comment on the associated PR.
@@ -68,7 +63,7 @@ class GitHubChannel(ReportChannel):
         api_url = (config.api_url or self.DEFAULT_API_URL).rstrip("/")
         pr_number = self._get_pr_number(token, repo, api_url)
 
-        url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
+        url = f"{api_url}/api/v1/repos/{repo}/issues/{pr_number}/comments"
         self._post_json(url, {"body": markdown}, token)
 
     def _get_pr_number(self, token: str, repo: str, api_url: str) -> str:
@@ -76,13 +71,12 @@ class GitHubChannel(ReportChannel):
 
         Priority:
             1. ``AI_GUARD_PR_NUMBER`` env var
-            2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
-            3. API query by current branch
+            2. API query by current branch
 
         Args:
-            token: GitHub API token for API query fallback.
+            token: Gitea API token for API query fallback.
             repo: Repository in ``owner/repo`` format.
-            api_url: GitHub API base URL.
+            api_url: Gitea API base URL.
 
         Returns:
             PR number as string.
@@ -95,31 +89,23 @@ class GitHubChannel(ReportChannel):
         if pr_number:
             return pr_number
 
-        # 2. GITHUB_REF
-        github_ref = os.environ.get("GITHUB_REF", "")
-        match = _PR_REF_PATTERN.match(github_ref)
-        if match:
-            return match.group(1)
-
-        # 3. API query by branch
+        # 2. API query by branch
         branch = get_current_branch()
         if branch:
-            owner = repo.split("/")[0] if "/" in repo else repo
-            query_url = (
-                f"{api_url}/repos/{repo}/pulls"
-                f"?head={owner}:{branch}&state=open&per_page=1"
-            )
+            query_url = f"{api_url}/api/v1/repos/{repo}/pulls?state=open&limit=50"
             try:
                 data = self._get_json(query_url, token)
-                if data and isinstance(data, list) and len(data) > 0:
-                    return str(data[0]["number"])
+                if data and isinstance(data, list):
+                    for pr in data:
+                        head = pr.get("head", {})
+                        if head.get("label") == branch:
+                            return str(pr["number"])
             except ChannelError:
                 pass  # Fall through to error
 
         raise ChannelError(
             "Cannot determine PR number. Set AI_GUARD_PR_NUMBER, "
-            "GITHUB_REF (refs/pull/<n>/merge), or push your branch "
-            "and open a PR"
+            "or push your branch and open a PR"
         )
 
     @staticmethod
@@ -138,7 +124,7 @@ class GitHubChannel(ReportChannel):
         token = os.environ.get(config.token_env)
         if not token:
             raise ChannelError(
-                f"GitHub token not found: set the {config.token_env} "
+                f"Gitea token not found: set the {config.token_env} "
                 f"environment variable"
             )
         return token
@@ -148,7 +134,7 @@ class GitHubChannel(ReportChannel):
         """Determine the repository.
 
         Priority:
-            1. ``GITHUB_REPOSITORY`` env var
+            1. ``GITEA_REPOSITORY`` env var
             2. ``git remote get-url origin``
 
         Returns:
@@ -157,7 +143,7 @@ class GitHubChannel(ReportChannel):
         Raises:
             ChannelError: If repository cannot be determined.
         """
-        repo = os.environ.get("GITHUB_REPOSITORY")
+        repo = os.environ.get("GITEA_REPOSITORY")
         if repo:
             return repo
 
@@ -166,18 +152,18 @@ class GitHubChannel(ReportChannel):
             return repo
 
         raise ChannelError(
-            "Cannot determine repository. Set GITHUB_REPOSITORY or "
+            "Cannot determine repository. Set GITEA_REPOSITORY or "
             "ensure git remote 'origin' is configured"
         )
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with Bearer auth.
+        """POST JSON to a URL with token auth.
 
         Args:
             url: API endpoint URL.
             body: JSON body dict.
-            token: Bearer token.
+            token: API token.
 
         Raises:
             ChannelError: On HTTP or connection error.
@@ -188,8 +174,7 @@ class GitHubChannel(ReportChannel):
             data=data,
             method="POST",
             headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
+                "Authorization": f"token {token}",
                 "Content-Type": "application/json",
             },
         )
@@ -197,19 +182,17 @@ class GitHubChannel(ReportChannel):
             with urllib.request.urlopen(req) as resp:
                 resp.read()
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(f"Gitea API returned {exc.code}: {exc.reason}") from exc
         except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
-            ) from exc
+            raise ChannelError(f"Failed to connect to Gitea API: {exc.reason}") from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with Bearer auth.
+        """GET JSON from a URL with token auth.
 
         Args:
             url: API endpoint URL.
-            token: Bearer token.
+            token: API token.
 
         Returns:
             Parsed JSON response.
@@ -221,16 +204,13 @@ class GitHubChannel(ReportChannel):
             url,
             method="GET",
             headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
+                "Authorization": f"token {token}",
             },
         )
         try:
             with urllib.request.urlopen(req) as resp:
                 return json.loads(resp.read())
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(f"Gitea API returned {exc.code}: {exc.reason}") from exc
         except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
-            ) from exc
+            raise ChannelError(f"Failed to connect to Gitea API: {exc.reason}") from exc

--- a/src/ai_guard/reporter/channel_gitlab.py
+++ b/src/ai_guard/reporter/channel_gitlab.py
@@ -1,7 +1,7 @@
-"""GitHub ReportChannel — posts check reports as PR comments.
+"""GitLab ReportChannel — posts check reports as MR comments.
 
-Uses the GitHub REST API to create issue comments on pull requests.
-Supports both github.com and self-hosted GitHub Enterprise instances
+Uses the GitLab REST API to create note comments on merge requests.
+Supports both gitlab.com and self-hosted GitLab instances
 via the ``api_url`` configuration.
 """
 
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import os
-import re
+import urllib.parse
 import urllib.request
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
@@ -20,106 +20,101 @@ from ai_guard.reporter.channel_base import ChannelError, ReportChannel, register
 if TYPE_CHECKING:
     from ai_guard.config.models import PrReportConfig
 
-__all__ = ["GitHubChannel"]
-
-_PR_REF_PATTERN = re.compile(r"^refs/pull/(\d+)/")
-"""Pattern to extract PR number from GITHUB_REF."""
+__all__ = ["GitLabChannel"]
 
 
 @register_channel
-class GitHubChannel(ReportChannel):
-    """Post check reports to GitHub PR comments.
+class GitLabChannel(ReportChannel):
+    """Post check reports to GitLab MR comments.
 
-    Repository and PR number are resolved automatically:
+    Repository and MR number are resolved automatically:
 
     **Repository** (in priority order):
-        1. ``GITHUB_REPOSITORY`` environment variable
-        2. ``git remote get-url origin`` parsed
+        1. ``CI_PROJECT_ID`` environment variable
+        2. ``git remote get-url origin`` parsed and URL-encoded
 
-    **PR number** (in priority order):
+    **MR number** (in priority order):
         1. ``AI_GUARD_PR_NUMBER`` environment variable
-        2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
-        3. GitHub API query by current branch name
+        2. ``CI_MERGE_REQUEST_IID`` environment variable
+        3. GitLab API query by current branch name
 
     Attributes:
-        DEFAULT_API_URL: Default GitHub API base URL.
+        DEFAULT_API_URL: Default GitLab API base URL.
     """
 
-    DEFAULT_API_URL = "https://api.github.com"
+    DEFAULT_API_URL = "https://gitlab.com"
 
     @property
     def name(self) -> str:
         """Platform identifier."""
-        return "github"
+        return "gitlab"
 
     def send(self, markdown: str, config: PrReportConfig) -> None:
-        """Post markdown as a comment on the associated PR.
+        """Post markdown as a comment on the associated MR.
 
         Args:
             markdown: Rendered Markdown report string.
             config: PR report configuration.
 
         Raises:
-            ChannelError: If token is missing, PR cannot be
+            ChannelError: If token is missing, MR cannot be
                 identified, or the API request fails.
         """
         token = self._get_token(config)
-        repo = self._get_repository()
+        project_id = self._get_project_id()
         api_url = (config.api_url or self.DEFAULT_API_URL).rstrip("/")
-        pr_number = self._get_pr_number(token, repo, api_url)
+        mr_iid = self._get_mr_iid(token, project_id, api_url)
 
-        url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
+        url = f"{api_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes"
         self._post_json(url, {"body": markdown}, token)
 
-    def _get_pr_number(self, token: str, repo: str, api_url: str) -> str:
-        """Determine the PR number.
+    def _get_mr_iid(self, token: str, project_id: str, api_url: str) -> str:
+        """Determine the MR IID.
 
         Priority:
             1. ``AI_GUARD_PR_NUMBER`` env var
-            2. ``GITHUB_REF`` (``refs/pull/<n>/merge``)
+            2. ``CI_MERGE_REQUEST_IID`` env var
             3. API query by current branch
 
         Args:
-            token: GitHub API token for API query fallback.
-            repo: Repository in ``owner/repo`` format.
-            api_url: GitHub API base URL.
+            token: GitLab API token for API query fallback.
+            project_id: Project ID or URL-encoded path.
+            api_url: GitLab API base URL.
 
         Returns:
-            PR number as string.
+            MR IID as string.
 
         Raises:
-            ChannelError: If PR number cannot be determined.
+            ChannelError: If MR IID cannot be determined.
         """
         # 1. Explicit env var
-        pr_number = os.environ.get("AI_GUARD_PR_NUMBER")
-        if pr_number:
-            return pr_number
+        mr_iid = os.environ.get("AI_GUARD_PR_NUMBER")
+        if mr_iid:
+            return mr_iid
 
-        # 2. GITHUB_REF
-        github_ref = os.environ.get("GITHUB_REF", "")
-        match = _PR_REF_PATTERN.match(github_ref)
-        if match:
-            return match.group(1)
+        # 2. CI_MERGE_REQUEST_IID
+        mr_iid = os.environ.get("CI_MERGE_REQUEST_IID")
+        if mr_iid:
+            return mr_iid
 
         # 3. API query by branch
         branch = get_current_branch()
         if branch:
-            owner = repo.split("/")[0] if "/" in repo else repo
             query_url = (
-                f"{api_url}/repos/{repo}/pulls"
-                f"?head={owner}:{branch}&state=open&per_page=1"
+                f"{api_url}/api/v4/projects/{project_id}/merge_requests"
+                f"?source_branch={urllib.parse.quote(branch, safe='')}"
+                f"&state=opened"
             )
             try:
                 data = self._get_json(query_url, token)
                 if data and isinstance(data, list) and len(data) > 0:
-                    return str(data[0]["number"])
+                    return str(data[0]["iid"])
             except ChannelError:
                 pass  # Fall through to error
 
         raise ChannelError(
-            "Cannot determine PR number. Set AI_GUARD_PR_NUMBER, "
-            "GITHUB_REF (refs/pull/<n>/merge), or push your branch "
-            "and open a PR"
+            "Cannot determine MR IID. Set AI_GUARD_PR_NUMBER, "
+            "CI_MERGE_REQUEST_IID, or push your branch and open a MR"
         )
 
     @staticmethod
@@ -138,46 +133,46 @@ class GitHubChannel(ReportChannel):
         token = os.environ.get(config.token_env)
         if not token:
             raise ChannelError(
-                f"GitHub token not found: set the {config.token_env} "
+                f"GitLab token not found: set the {config.token_env} "
                 f"environment variable"
             )
         return token
 
     @staticmethod
-    def _get_repository() -> str:
-        """Determine the repository.
+    def _get_project_id() -> str:
+        """Determine the project ID.
 
         Priority:
-            1. ``GITHUB_REPOSITORY`` env var
-            2. ``git remote get-url origin``
+            1. ``CI_PROJECT_ID`` env var
+            2. ``git remote get-url origin`` URL-encoded
 
         Returns:
-            Repository in ``owner/repo`` format.
+            Project ID or URL-encoded ``owner/repo`` path.
 
         Raises:
-            ChannelError: If repository cannot be determined.
+            ChannelError: If project ID cannot be determined.
         """
-        repo = os.environ.get("GITHUB_REPOSITORY")
-        if repo:
-            return repo
+        project_id = os.environ.get("CI_PROJECT_ID")
+        if project_id:
+            return project_id
 
         repo = get_remote_repo()
         if repo:
-            return repo
+            return urllib.parse.quote(repo, safe="")
 
         raise ChannelError(
-            "Cannot determine repository. Set GITHUB_REPOSITORY or "
+            "Cannot determine project. Set CI_PROJECT_ID or "
             "ensure git remote 'origin' is configured"
         )
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with Bearer auth.
+        """POST JSON to a URL with PRIVATE-TOKEN auth.
 
         Args:
             url: API endpoint URL.
             body: JSON body dict.
-            token: Bearer token.
+            token: Private token.
 
         Raises:
             ChannelError: On HTTP or connection error.
@@ -188,8 +183,7 @@ class GitHubChannel(ReportChannel):
             data=data,
             method="POST",
             headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
+                "PRIVATE-TOKEN": token,
                 "Content-Type": "application/json",
             },
         )
@@ -197,19 +191,19 @@ class GitHubChannel(ReportChannel):
             with urllib.request.urlopen(req) as resp:
                 resp.read()
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(f"GitLab API returned {exc.code}: {exc.reason}") from exc
         except URLError as exc:
             raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
+                f"Failed to connect to GitLab API: {exc.reason}"
             ) from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with Bearer auth.
+        """GET JSON from a URL with PRIVATE-TOKEN auth.
 
         Args:
             url: API endpoint URL.
-            token: Bearer token.
+            token: Private token.
 
         Returns:
             Parsed JSON response.
@@ -221,16 +215,15 @@ class GitHubChannel(ReportChannel):
             url,
             method="GET",
             headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
+                "PRIVATE-TOKEN": token,
             },
         )
         try:
             with urllib.request.urlopen(req) as resp:
                 return json.loads(resp.read())
         except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
+            raise ChannelError(f"GitLab API returned {exc.code}: {exc.reason}") from exc
         except URLError as exc:
             raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
+                f"Failed to connect to GitLab API: {exc.reason}"
             ) from exc

--- a/tests/unit/test_reporter/test__git_info.py
+++ b/tests/unit/test_reporter/test__git_info.py
@@ -1,0 +1,80 @@
+"""Tests for reporter git info helper."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ai_guard.reporter._git_info import (
+    get_current_branch,
+    get_remote_repo,
+    parse_repo_url,
+)
+
+
+class TestParseRepoUrl:
+    """Test parse_repo_url with various remote URL formats."""
+
+    def test_https_url(self) -> None:
+        assert parse_repo_url("https://github.com/owner/repo.git") == "owner/repo"
+
+    def test_https_url_no_git_suffix(self) -> None:
+        assert parse_repo_url("https://github.com/owner/repo") == "owner/repo"
+
+    def test_ssh_url(self) -> None:
+        assert parse_repo_url("git@github.com:owner/repo.git") == "owner/repo"
+
+    def test_ssh_url_no_git_suffix(self) -> None:
+        assert parse_repo_url("git@gitlab.com:org/project") == "org/project"
+
+    def test_nested_group_gitlab(self) -> None:
+        """GitLab nested groups — take last two segments."""
+        assert parse_repo_url("git@gitlab.com:org/group/sub/repo.git") == "sub/repo"
+
+    def test_invalid_url_returns_none(self) -> None:
+        assert parse_repo_url("not-a-url") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert parse_repo_url("") is None
+
+
+class TestGetRemoteRepo:
+    """Test get_remote_repo with mocked subprocess."""
+
+    def test_returns_parsed_repo(self) -> None:
+        with patch(
+            "ai_guard.reporter._git_info._run_git",
+            return_value="https://github.com/owner/repo.git",
+        ):
+            assert get_remote_repo() == "owner/repo"
+
+    def test_returns_none_on_failure(self) -> None:
+        with patch(
+            "ai_guard.reporter._git_info._run_git",
+            return_value=None,
+        ):
+            assert get_remote_repo() is None
+
+
+class TestGetCurrentBranch:
+    """Test get_current_branch with mocked subprocess."""
+
+    def test_returns_branch_name(self) -> None:
+        with patch(
+            "ai_guard.reporter._git_info._run_git",
+            return_value="feat/my-feature",
+        ):
+            assert get_current_branch() == "feat/my-feature"
+
+    def test_returns_none_on_failure(self) -> None:
+        with patch(
+            "ai_guard.reporter._git_info._run_git",
+            return_value=None,
+        ):
+            assert get_current_branch() is None
+
+    def test_strips_whitespace(self) -> None:
+        with patch(
+            "ai_guard.reporter._git_info._run_git",
+            return_value="  main\n",
+        ):
+            assert get_current_branch() == "main"

--- a/tests/unit/test_reporter/test_channel_bitbucket.py
+++ b/tests/unit/test_reporter/test_channel_bitbucket.py
@@ -1,0 +1,164 @@
+"""Tests for BitbucketChannel — mock HTTP."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_guard.config.models import PrReportConfig
+from ai_guard.reporter.channel_base import ChannelError
+from ai_guard.reporter.channel_bitbucket import BitbucketChannel
+
+
+class TestBitbucketChannel:
+    """BitbucketChannel send() with mocked HTTP."""
+
+    def _make_config(
+        self,
+        *,
+        api_url: str | None = None,
+        token_env: str = "BITBUCKET_TOKEN",
+    ) -> PrReportConfig:
+        return PrReportConfig(
+            enabled=True,
+            platform="bitbucket",
+            api_url=api_url,
+            token_env=token_env,
+        )
+
+    @staticmethod
+    def _mock_urlopen(status: int = 201, body: bytes = b'{"id": 1}') -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = status
+        mock_response.read.return_value = body
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    def test_name(self) -> None:
+        assert BitbucketChannel().name == "bitbucket"
+
+    def test_send_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful POST with env vars."""
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.setenv("BITBUCKET_PR_ID", "42")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            BitbucketChannel().send("## Report", self._make_config())
+            req = m.call_args[0][0]
+            assert (
+                "/repositories/workspace/repo/pullrequests/42/comments" in req.full_url
+            )
+            body = json.loads(req.data)
+            assert "Report" in body["content"]["raw"]
+
+    def test_send_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.setenv("BITBUCKET_PR_ID", "42")
+
+        from urllib.error import HTTPError
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=HTTPError("", 403, "Forbidden", None, None),  # type: ignore[arg-type]
+            ),
+            pytest.raises(ChannelError, match="403"),
+        ):
+            BitbucketChannel().send("report", self._make_config())
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BITBUCKET_TOKEN", raising=False)
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.setenv("BITBUCKET_PR_ID", "1")
+
+        with pytest.raises(ChannelError, match="token"):
+            BitbucketChannel().send("report", self._make_config())
+
+    def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.setenv("BITBUCKET_PR_ID", "5")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            BitbucketChannel().send(
+                "r", self._make_config(api_url="https://bb.corp.com")
+            )
+            assert m.call_args[0][0].full_url.startswith("https://bb.corp.com/")
+
+    def test_repo_from_git_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: get repo from git remote when env var missing."""
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.delenv("BITBUCKET_REPO_FULL_NAME", raising=False)
+        monkeypatch.setenv("BITBUCKET_PR_ID", "1")
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_bitbucket.get_remote_repo",
+                return_value="org/my-repo",
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            BitbucketChannel().send("r", self._make_config())
+            assert "/repositories/org/my-repo/" in m.call_args[0][0].full_url
+
+    def test_pr_from_api_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: query Bitbucket API for PR by branch name."""
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.delenv("BITBUCKET_PR_ID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET /pullrequests?state=OPEN → return PR list
+                return self._mock_urlopen(
+                    body=json.dumps(
+                        {
+                            "values": [
+                                {
+                                    "id": 77,
+                                    "source": {"branch": {"name": "feat/test"}},
+                                },
+                            ],
+                        }
+                    ).encode(),
+                )
+            # POST comment
+            return self._mock_urlopen()
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_bitbucket.get_current_branch",
+                return_value="feat/test",
+            ),
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m,
+        ):
+            BitbucketChannel().send("r", self._make_config())
+            # Second call (POST) should use PR 77
+            post_req = m.call_args_list[-1][0][0]
+            assert "/pullrequests/77/comments" in post_req.full_url
+
+    def test_missing_pr_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All PR detection methods fail."""
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.delenv("BITBUCKET_PR_ID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_bitbucket.get_current_branch",
+                return_value=None,
+            ),
+            pytest.raises(ChannelError, match="PR ID"),
+        ):
+            BitbucketChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_gitea.py
+++ b/tests/unit/test_reporter/test_channel_gitea.py
@@ -1,0 +1,151 @@
+"""Tests for GiteaChannel — mock HTTP."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_guard.config.models import PrReportConfig
+from ai_guard.reporter.channel_base import ChannelError
+from ai_guard.reporter.channel_gitea import GiteaChannel
+
+
+class TestGiteaChannel:
+    """GiteaChannel send() with mocked HTTP."""
+
+    def _make_config(
+        self,
+        *,
+        api_url: str | None = None,
+        token_env: str = "GITEA_TOKEN",
+    ) -> PrReportConfig:
+        return PrReportConfig(
+            enabled=True,
+            platform="gitea",
+            api_url=api_url,
+            token_env=token_env,
+        )
+
+    @staticmethod
+    def _mock_urlopen(status: int = 201, body: bytes = b'{"id": 1}') -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = status
+        mock_response.read.return_value = body
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    def test_name(self) -> None:
+        assert GiteaChannel().name == "gitea"
+
+    def test_send_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful POST with env vars."""
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "42")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GiteaChannel().send("## Report", self._make_config())
+            req = m.call_args[0][0]
+            assert "/repos/owner/repo/issues/42/comments" in req.full_url
+            assert "Report" in json.loads(req.data)["body"]
+
+    def test_send_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "42")
+
+        from urllib.error import HTTPError
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=HTTPError("", 403, "Forbidden", None, None),  # type: ignore[arg-type]
+            ),
+            pytest.raises(ChannelError, match="403"),
+        ):
+            GiteaChannel().send("report", self._make_config())
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITEA_TOKEN", raising=False)
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "1")
+
+        with pytest.raises(ChannelError, match="token"):
+            GiteaChannel().send("report", self._make_config())
+
+    def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "5")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GiteaChannel().send("r", self._make_config(api_url="https://git.corp.com"))
+            assert m.call_args[0][0].full_url.startswith("https://git.corp.com/")
+
+    def test_repo_from_git_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: get repo from git remote when env var missing."""
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.delenv("GITEA_REPOSITORY", raising=False)
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "1")
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitea.get_remote_repo",
+                return_value="org/my-repo",
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            GiteaChannel().send("r", self._make_config())
+            assert "/repos/org/my-repo/" in m.call_args[0][0].full_url
+
+    def test_pr_from_api_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: query Gitea API for PR by branch name."""
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET /pulls?state=open → return PR list with head.label
+                return self._mock_urlopen(
+                    body=json.dumps(
+                        [
+                            {"number": 77, "head": {"label": "feat/test"}},
+                        ]
+                    ).encode(),
+                )
+            # POST comment
+            return self._mock_urlopen()
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitea.get_current_branch",
+                return_value="feat/test",
+            ),
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m,
+        ):
+            GiteaChannel().send("r", self._make_config())
+            # Second call (POST) should use PR 77
+            post_req = m.call_args_list[-1][0][0]
+            assert "/issues/77/comments" in post_req.full_url
+
+    def test_missing_pr_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All PR detection methods fail."""
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitea.get_current_branch", return_value=None
+            ),
+            pytest.raises(ChannelError, match="PR number"),
+        ):
+            GiteaChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_github.py
+++ b/tests/unit/test_reporter/test_channel_github.py
@@ -28,164 +28,172 @@ class TestGitHubChannel:
             token_env=token_env,
         )
 
+    @staticmethod
+    def _mock_urlopen(status: int = 201, body: bytes = b'{"id": 1}') -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = status
+        mock_response.read.return_value = body
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
     def test_name_is_github(self) -> None:
-        ch = GitHubChannel()
-        assert ch.name == "github"
+        assert GitHubChannel().name == "github"
 
     def test_send_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Successful POST returns 201."""
+        """Successful POST with env vars."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
 
-        mock_response = MagicMock()
-        mock_response.status = 201
-        mock_response.read.return_value = b'{"id": 1}'
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            ch = GitHubChannel()
-            ch.send("## Report\n- all passed", self._make_config())
-
-            mock_urlopen.assert_called_once()
-            req = mock_urlopen.call_args[0][0]
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitHubChannel().send("## Report", self._make_config())
+            req = m.call_args[0][0]
             assert "/repos/owner/repo/issues/42/comments" in req.full_url
-            body = json.loads(req.data)
-            assert "Report" in body["body"]
+            assert "Report" in json.loads(req.data)["body"]
 
-    def test_send_failure_raises_channel_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """HTTP error raises ChannelError."""
+    def test_send_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
 
         from urllib.error import HTTPError
 
-        with patch(
-            "urllib.request.urlopen",
-            side_effect=HTTPError(
-                url="",
-                code=403,
-                msg="Forbidden",
-                hdrs=None,
-                fp=None,  # type: ignore[arg-type]
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=HTTPError("", 403, "Forbidden", None, None),  # type: ignore[arg-type]
             ),
+            pytest.raises(ChannelError, match="403"),
         ):
-            ch = GitHubChannel()
-            with pytest.raises(ChannelError, match="403"):
-                ch.send("report", self._make_config())
+            GitHubChannel().send("report", self._make_config())
 
     def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Missing token raises ChannelError."""
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
 
-        ch = GitHubChannel()
         with pytest.raises(ChannelError, match="token"):
-            ch.send("report", self._make_config())
+            GitHubChannel().send("report", self._make_config())
 
     def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Custom api_url is used instead of default."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/5/merge")
 
-        mock_response = MagicMock()
-        mock_response.status = 201
-        mock_response.read.return_value = b'{"id": 1}'
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            ch = GitHubChannel()
-            ch.send("report", self._make_config(api_url="https://git.corp.com/api/v3"))
-
-            req = mock_urlopen.call_args[0][0]
-            assert req.full_url.startswith("https://git.corp.com/api/v3/")
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitHubChannel().send(
+                "r", self._make_config(api_url="https://git.corp.com/api/v3")
+            )
+            assert m.call_args[0][0].full_url.startswith("https://git.corp.com/api/v3/")
 
     def test_pr_number_from_ai_guard_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AI_GUARD_PR_NUMBER fallback."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.delenv("GITHUB_REF", raising=False)
         monkeypatch.setenv("AI_GUARD_PR_NUMBER", "99")
 
-        mock_response = MagicMock()
-        mock_response.status = 201
-        mock_response.read.return_value = b'{"id": 1}'
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitHubChannel().send("r", self._make_config())
+            assert "/issues/99/comments" in m.call_args[0][0].full_url
 
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            ch = GitHubChannel()
-            ch.send("report", self._make_config())
+    def test_pr_number_from_github_ref(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/123/merge")
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
 
-            req = mock_urlopen.call_args[0][0]
-            assert "/issues/99/comments" in req.full_url
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitHubChannel().send("r", self._make_config())
+            assert "/issues/123/comments" in m.call_args[0][0].full_url
 
-    def test_missing_pr_number_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No PR number available raises ChannelError."""
+    def test_pr_number_from_api_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: query GitHub API for PR by branch name."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.delenv("GITHUB_REF", raising=False)
         monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
 
-        ch = GitHubChannel()
-        with pytest.raises(ChannelError, match="PR number"):
-            ch.send("report", self._make_config())
+        call_count = 0
 
-    def test_missing_repository_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Missing GITHUB_REPOSITORY raises ChannelError."""
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET /pulls?head=... → return PR list
+                return self._mock_urlopen(body=json.dumps([{"number": 77}]).encode())
+            # POST comment
+            return self._mock_urlopen()
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_github.get_current_branch",
+                return_value="feat/test",
+            ),
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m,
+        ):
+            GitHubChannel().send("r", self._make_config())
+            # Second call (POST) should use PR 77
+            post_req = m.call_args_list[-1][0][0]
+            assert "/issues/77/comments" in post_req.full_url
+
+    def test_repo_from_git_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: get repo from git remote when env var missing."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
         monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
 
-        ch = GitHubChannel()
-        with pytest.raises(ChannelError, match="GITHUB_REPOSITORY"):
-            ch.send("report", self._make_config())
+        with (
+            patch(
+                "ai_guard.reporter.channel_github.get_remote_repo",
+                return_value="org/my-repo",
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            GitHubChannel().send("r", self._make_config())
+            assert "/repos/org/my-repo/" in m.call_args[0][0].full_url
 
-    def test_parse_pr_number_from_github_ref(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """refs/pull/<n>/merge format is parsed correctly."""
+    def test_missing_repo_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_github.get_remote_repo", return_value=None
+            ),
+            pytest.raises(ChannelError, match="repository"),
+        ):
+            GitHubChannel().send("r", self._make_config())
+
+    def test_missing_pr_number_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All PR detection methods fail."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
-        monkeypatch.setenv("GITHUB_REF", "refs/pull/123/merge")
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
 
-        mock_response = MagicMock()
-        mock_response.status = 201
-        mock_response.read.return_value = b'{"id": 1}'
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
+        with (
+            patch(
+                "ai_guard.reporter.channel_github.get_current_branch", return_value=None
+            ),
+            pytest.raises(ChannelError, match="PR number"),
+        ):
+            GitHubChannel().send("r", self._make_config())
 
-        with patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ) as mock_urlopen:
-            ch = GitHubChannel()
-            ch.send("report", self._make_config())
-
-            req = mock_urlopen.call_args[0][0]
-            assert "/issues/123/comments" in req.full_url
-
-    def test_non_pr_github_ref_falls_back(
+    def test_non_pr_github_ref_falls_to_api(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """refs/heads/main does not contain PR number → raises."""
+        """refs/heads/main triggers API query fallback."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
         monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
 
-        ch = GitHubChannel()
-        with pytest.raises(ChannelError, match="PR number"):
-            ch.send("report", self._make_config())
+        with (
+            patch(
+                "ai_guard.reporter.channel_github.get_current_branch", return_value=None
+            ),
+            pytest.raises(ChannelError, match="PR number"),
+        ):
+            GitHubChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_gitlab.py
+++ b/tests/unit/test_reporter/test_channel_gitlab.py
@@ -1,0 +1,150 @@
+"""Tests for GitLabChannel — mock HTTP."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_guard.config.models import PrReportConfig
+from ai_guard.reporter.channel_base import ChannelError
+from ai_guard.reporter.channel_gitlab import GitLabChannel
+
+
+class TestGitLabChannel:
+    """GitLabChannel send() with mocked HTTP."""
+
+    def _make_config(
+        self,
+        *,
+        api_url: str | None = None,
+        token_env: str = "GITLAB_TOKEN",
+    ) -> PrReportConfig:
+        return PrReportConfig(
+            enabled=True,
+            platform="gitlab",
+            api_url=api_url,
+            token_env=token_env,
+        )
+
+    @staticmethod
+    def _mock_urlopen(status: int = 201, body: bytes = b'{"id": 1}') -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = status
+        mock_response.read.return_value = body
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    def test_name(self) -> None:
+        assert GitLabChannel().name == "gitlab"
+
+    def test_send_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful POST with env vars."""
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "42")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitLabChannel().send("## Report", self._make_config())
+            req = m.call_args[0][0]
+            assert "/projects/12345/merge_requests/42/notes" in req.full_url
+            assert "Report" in json.loads(req.data)["body"]
+
+    def test_send_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "42")
+
+        from urllib.error import HTTPError
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=HTTPError("", 403, "Forbidden", None, None),  # type: ignore[arg-type]
+            ),
+            pytest.raises(ChannelError, match="403"),
+        ):
+            GitLabChannel().send("report", self._make_config())
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "1")
+
+        with pytest.raises(ChannelError, match="token"):
+            GitLabChannel().send("report", self._make_config())
+
+    def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "5")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m:
+            GitLabChannel().send(
+                "r", self._make_config(api_url="https://gitlab.corp.com")
+            )
+            assert m.call_args[0][0].full_url.startswith("https://gitlab.corp.com/")
+
+    def test_repo_from_git_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: get project ID from git remote when env var missing."""
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.delenv("CI_PROJECT_ID", raising=False)
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "1")
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitlab.get_remote_repo",
+                return_value="org/my-repo",
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            GitLabChannel().send("r", self._make_config())
+            # URL-encoded owner/repo: org%2Fmy-repo
+            assert "/projects/org%2Fmy-repo/" in m.call_args[0][0].full_url
+
+    def test_pr_from_api_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: query GitLab API for MR by branch name."""
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.delenv("CI_MERGE_REQUEST_IID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET /merge_requests?source_branch=... → return MR list
+                return self._mock_urlopen(body=json.dumps([{"iid": 77}]).encode())
+            # POST note
+            return self._mock_urlopen()
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitlab.get_current_branch",
+                return_value="feat/test",
+            ),
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m,
+        ):
+            GitLabChannel().send("r", self._make_config())
+            # Second call (POST) should use MR 77
+            post_req = m.call_args_list[-1][0][0]
+            assert "/merge_requests/77/notes" in post_req.full_url
+
+    def test_missing_pr_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All MR detection methods fail."""
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.delenv("CI_MERGE_REQUEST_IID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ai_guard.reporter.channel_gitlab.get_current_branch", return_value=None
+            ),
+            pytest.raises(ChannelError, match="MR IID"),
+        ):
+            GitLabChannel().send("r", self._make_config())


### PR DESCRIPTION
## Summary

- Three new ReportChannel implementations: `GitLabChannel`, `GiteaChannel`, `BitbucketChannel`
- New `_git_info` module: `get_remote_repo()` (parse git remote origin) and `get_current_branch()` as shared helpers
- Refactored all 4 channels with smart PR detection:
  - **Repository**: env var override → `git remote get-url origin` fallback
  - **PR number**: `AI_GUARD_PR_NUMBER` → platform CI env → API query by current branch
- GitHubChannel refactored to use the same pattern (breaking change from env-var-only)

## Test plan

- [x] `test__git_info.py`: 12 tests (URL parsing, git remote, branch)
- [x] `test_channel_github.py`: 12 tests (refactored + API query + git remote fallback)
- [x] `test_channel_gitlab.py`: 8 tests
- [x] `test_channel_gitea.py`: 8 tests
- [x] `test_channel_bitbucket.py`: 8 tests
- [x] Full regression: 789 tests passed, 0 failed
- [x] All pre-commit hooks passed

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)