### PR TITLE
feat(cli): add --format json output for check, verify, and status (WP5.3)

### DIFF
--- a/src/ai_guard/cli/check.py
+++ b/src/ai_guard/cli/check.py
@@ -17,7 +17,7 @@ from ai_guard.checker.core import (
 from ai_guard.checker.models import CheckReport
 from ai_guard.config.exceptions import ConfigError
 from ai_guard.config.merger import resolve_config
-from ai_guard.reporter.formatting import format_gate, format_terminal
+from ai_guard.reporter.formatting import format_gate, format_json, format_terminal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,12 +35,15 @@ _BUILTIN_CHECKS = frozenset({"format", "naming", "lint"})
 def check_command(
     files: list[str],
     config_path: Path,
+    *,
+    output_format: str = "text",
 ) -> None:
     """Execute the check command (commit-stage checks).
 
     Args:
         files: Explicit file list, or empty for auto-detect.
         config_path: Path to guard.yaml.
+        output_format: Output format (``"text"`` or ``"json"``).
     """
     resolved = _load_config(config_path)
     project_root = config_path.parent.resolve()
@@ -48,20 +51,22 @@ def check_command(
 
     report = run_stage("commit", resolved.code, project_root, files=file_list)
 
-    output = format_terminal(report, verbosity=resolved.output.verbosity)
-    print(output)
+    print(_format_report(report, output_format, resolved.output.verbosity))
     raise SystemExit(0 if report.passed else 1)
 
 
 def verify_command(
     skip_build: bool,
     config_path: Path,
+    *,
+    output_format: str = "text",
 ) -> None:
     """Execute the verify command (push-stage validation).
 
     Args:
         skip_build: Whether to skip the build step.
         config_path: Path to guard.yaml.
+        output_format: Output format (``"text"`` or ``"json"``).
     """
     resolved = _load_config(config_path)
     project_root = config_path.parent.resolve()
@@ -69,8 +74,7 @@ def verify_command(
 
     report = run_stage("push", resolved.code, project_root, build_command=build_cmd)
 
-    output = format_terminal(report, verbosity=resolved.output.verbosity)
-    print(output)
+    print(_format_report(report, output_format, resolved.output.verbosity))
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -117,8 +121,7 @@ def run_command(
         duration_ms=result.duration_ms,
     )
 
-    output = format_terminal(report, verbosity=resolved.output.verbosity)
-    print(output)
+    print(_format_report(report, "text", resolved.output.verbosity))
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -141,6 +144,22 @@ def gate_run_command(
     message, exit_code = format_gate(report)
     print(message)
     raise SystemExit(exit_code)
+
+
+def _format_report(report: CheckReport, output_format: str, verbosity: str) -> str:
+    """Format a CheckReport for output.
+
+    Args:
+        report: The check report to format.
+        output_format: ``"text"`` or ``"json"``.
+        verbosity: Verbosity level for text output.
+
+    Returns:
+        Formatted string.
+    """
+    if output_format == "json":
+        return format_json(report)
+    return format_terminal(report, verbosity=verbosity)
 
 
 def _load_config(config_path: Path):

--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -210,10 +210,22 @@ def status(
             help="Path to guard.yaml",
         ),
     ] = Path("guard.yaml"),
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            help="Output format: text or json",
+        ),
+    ] = "text",
 ) -> None:
     """Show installation status, drift detection, and artifact integrity."""
     project_root = config.parent.resolve()
-    status_command(project_root=project_root, config_path=config, show_rules=rules)
+    status_command(
+        project_root=project_root,
+        config_path=config,
+        show_rules=rules,
+        output_format=output_format,
+    )
 
 
 @app.command()
@@ -252,9 +264,13 @@ def check(
         Path,
         typer.Option("--config", "-c", help="Path to guard.yaml"),
     ] = Path("guard.yaml"),
+    output_format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: text or json"),
+    ] = "text",
 ) -> None:
     """Run commit-stage quality checks."""
-    check_command(files=files or [], config_path=config)
+    check_command(files=files or [], config_path=config, output_format=output_format)
 
 
 @app.command()
@@ -267,9 +283,15 @@ def verify(
         Path,
         typer.Option("--config", "-c", help="Path to guard.yaml"),
     ] = Path("guard.yaml"),
+    output_format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: text or json"),
+    ] = "text",
 ) -> None:
     """Run full push-stage validation (includes commit checks)."""
-    verify_command(skip_build=skip_build, config_path=config)
+    verify_command(
+        skip_build=skip_build, config_path=config, output_format=output_format
+    )
 
 
 @app.command(name="run")

--- a/src/ai_guard/cli/status.py
+++ b/src/ai_guard/cli/status.py
@@ -7,6 +7,7 @@ AI Guard installation state, environment health, and agent capabilities.
 from __future__ import annotations
 
 import hashlib
+import json
 import shutil
 import sys
 from typing import TYPE_CHECKING
@@ -43,6 +44,8 @@ def status_command(
     project_root: Path,
     config_path: Path,
     show_rules: bool,
+    *,
+    output_format: str = "text",
 ) -> None:
     """Execute the status command.
 
@@ -52,8 +55,31 @@ def status_command(
         project_root: Path to project root directory.
         config_path: Path to guard.yaml.
         show_rules: Whether to display the active rule list.
+        output_format: Output format (``"text"`` or ``"json"``).
     """
     state = read_state(project_root)
+
+    if output_format == "json":
+        _status_json(state, project_root, config_path)
+    else:
+        _status_text(state, project_root, config_path, show_rules=show_rules)
+
+
+def _status_text(
+    state: object,
+    project_root: Path,
+    config_path: Path,
+    *,
+    show_rules: bool,
+) -> None:
+    """Output status as text.
+
+    Args:
+        state: GeneratedState or None.
+        project_root: Path to project root.
+        config_path: Path to guard.yaml.
+        show_rules: Whether to display active rules.
+    """
     if state is None:
         print("AI Guard is not installed.")
         print("Run 'guard install --agent <name>' to install.")
@@ -87,11 +113,7 @@ def status_command(
         print("\nWarning: guard.yaml not found.")
 
     # Artifact integrity check
-    missing = []
-    for artifact_path in state.artifacts:
-        full_path = project_root / artifact_path
-        if not full_path.is_file():
-            missing.append(artifact_path)
+    missing = [p for p in state.artifacts if not (project_root / p).is_file()]
 
     if missing:
         print(f"\nMissing artifacts ({len(missing)}):")
@@ -104,6 +126,41 @@ def status_command(
     # Rules display
     if show_rules:
         _print_rules(config_path)
+
+
+def _status_json(state: object, project_root: Path, config_path: Path) -> None:
+    """Output status as JSON.
+
+    Args:
+        state: GeneratedState or None.
+        project_root: Path to project root.
+        config_path: Path to guard.yaml.
+    """
+    if state is None:
+        print(json.dumps({"installed": False}))
+        return
+
+    # Compute drift
+    drift = False
+    if config_path.is_file():
+        current_hash = _compute_config_hash(config_path)
+        drift = current_hash != state.config_hash
+
+    # Check missing artifacts
+    missing = [p for p in state.artifacts if not (project_root / p).is_file()]
+
+    data = {
+        "installed": True,
+        "installed_agents": state.installed_agents,
+        "ai_guard_version": state.ai_guard_version,
+        "current_version": __version__,
+        "installed_at": state.installed_at.isoformat(),
+        "config_hash": state.config_hash,
+        "config_drift": drift,
+        "artifacts": state.artifacts,
+        "missing_artifacts": missing,
+    }
+    print(json.dumps(data, indent=2))
 
 
 def _print_rules(config_path: Path) -> None:

--- a/src/ai_guard/reporter/__init__.py
+++ b/src/ai_guard/reporter/__init__.py
@@ -2,13 +2,19 @@
 
 from ai_guard.reporter.audit import append_audit_log, apply_retention
 from ai_guard.reporter.channel_base import ChannelError, post_pr_comment
-from ai_guard.reporter.formatting import format_gate, format_markdown, format_terminal
+from ai_guard.reporter.formatting import (
+    format_gate,
+    format_json,
+    format_markdown,
+    format_terminal,
+)
 
 __all__ = [
     "ChannelError",
     "append_audit_log",
     "apply_retention",
     "format_gate",
+    "format_json",
     "format_markdown",
     "format_terminal",
     "post_pr_comment",

--- a/src/ai_guard/reporter/formatting.py
+++ b/src/ai_guard/reporter/formatting.py
@@ -1,11 +1,14 @@
-"""Reporter formatting — terminal, gate, and Markdown output.
+"""Reporter formatting — terminal, gate, Markdown, and JSON output.
 
 Converts CheckReport into human-readable formats for terminal
-display, Git Hook output, and PR comment rendering.
+display, Git Hook output, PR comment rendering, and machine-readable
+JSON for CI/CD pipelines.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -183,3 +186,23 @@ def format_markdown(
         passed=passed,
         total=total,
     )
+
+
+# ---------------------------------------------------------------------------
+# JSON Output
+# ---------------------------------------------------------------------------
+
+
+def format_json(report: Any) -> str:
+    """Serialize a CheckReport to JSON for CI/CD pipelines.
+
+    Uses ``dataclasses.asdict()`` to convert the entire report tree
+    (CheckReport → CheckResult → Violation) into a JSON string.
+
+    Args:
+        report: A CheckReport instance.
+
+    Returns:
+        Pretty-printed JSON string parseable by ``jq``.
+    """
+    return json.dumps(dataclasses.asdict(report), indent=2)

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -233,3 +233,44 @@ class TestGateRunCommand:
             )
         assert result.exit_code == 0
         assert "passed" in result.output
+
+
+class TestJsonOutput:
+    """Tests for --format json output."""
+
+    def test_check_json_output(self, tmp_path: Path) -> None:
+        """check --format json outputs valid JSON."""
+        import json
+
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["check", "--config", str(config), "--format", "json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["stage"] == "commit"
+        assert data["passed"] is True
+        assert "results" in data
+
+    def test_verify_json_output(self, tmp_path: Path) -> None:
+        """verify --format json outputs valid JSON."""
+        import json
+
+        config = _write_config(tmp_path)
+        with patch("ai_guard.checker.core.get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app,
+                [
+                    "verify",
+                    "--skip-build",
+                    "--config",
+                    str(config),
+                    "--format",
+                    "json",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["stage"] == "push"
+        assert "results" in data

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -256,3 +256,31 @@ class TestAgentsCommand:
         result = runner.invoke(app, ["agents"])
         assert result.exit_code == 0
         assert "claude.md" in result.output.lower()
+
+
+class TestStatusJsonOutput:
+    """Tests for status --format json."""
+
+    def test_status_json_installed(self, installed_project: Path) -> None:
+        """JSON output includes installation details."""
+        config = installed_project / "guard.yaml"
+        result = runner.invoke(
+            app, ["status", "--config", str(config), "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["installed"] is True
+        assert "claude-code" in data["installed_agents"]
+        assert "config_hash" in data
+        assert "artifacts" in data
+
+    def test_status_json_not_installed(self, tmp_path: Path) -> None:
+        """JSON output when not installed."""
+        config = tmp_path / "guard.yaml"
+        config.write_text("version: 1\n")
+        result = runner.invoke(
+            app, ["status", "--config", str(config), "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["installed"] is False

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from ai_guard.checker.models import CheckReport, CheckResult, Violation
-from ai_guard.reporter.formatting import format_gate, format_markdown, format_terminal
+from ai_guard.reporter.formatting import (
+    format_gate,
+    format_json,
+    format_markdown,
+    format_terminal,
+)
 
 
 def _passed_report() -> CheckReport:
@@ -183,3 +188,46 @@ class TestFormatMarkdown:
         """Report without violations omits details block."""
         md = format_markdown(_passed_report())
         assert "<details>" not in md
+
+
+class TestFormatJson:
+    """format_json function tests."""
+
+    def test_output_is_valid_json(self) -> None:
+        import json
+
+        output = format_json(_passed_report())
+        data = json.loads(output)
+        assert isinstance(data, dict)
+
+    def test_contains_stage_and_passed(self) -> None:
+        import json
+
+        data = json.loads(format_json(_passed_report()))
+        assert data["stage"] == "commit"
+        assert data["passed"] is True
+
+    def test_contains_results(self) -> None:
+        import json
+
+        data = json.loads(format_json(_passed_report()))
+        assert "results" in data
+        assert len(data["results"]) == 2
+        assert data["results"][0]["name"] == "format"
+
+    def test_violations_serialized(self) -> None:
+        import json
+
+        data = json.loads(format_json(_failed_report()))
+        failed_results = [r for r in data["results"] if not r["passed"]]
+        assert len(failed_results) == 1
+        violations = failed_results[0]["violations"]
+        assert len(violations) == 2
+        assert violations[0]["file"] == "src/main.py"
+        assert violations[0]["line"] == 10
+
+    def test_duration_included(self) -> None:
+        import json
+
+        data = json.loads(format_json(_passed_report()))
+        assert data["duration_ms"] == 38


### PR DESCRIPTION
## Summary

- New `format_json()` in reporter using `dataclasses.asdict()` for CheckReport serialization
- `guard check --format json`: outputs commit-stage report as JSON
- `guard verify --format json`: outputs push-stage report as JSON
- `guard status --format json`: outputs installation state (agents, version, drift, artifacts) as JSON
- Default `--format text` preserves all existing behavior
- All JSON outputs are valid and parseable by `jq`

## Test plan

- [x] `TestFormatJson`: 5 tests (valid JSON, fields, violations, duration)
- [x] `TestJsonOutput` in check tests: 2 tests (check + verify JSON)
- [x] `TestStatusJsonOutput`: 2 tests (installed + not installed)
- [x] Full regression: 798 tests passed, 0 failed
- [x] All pre-commit hooks passed

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)