### PR TITLE
feat(cli): add validation list and report commands (WP5.4)

### DIFF
--- a/src/ai_guard/cli/main.py
+++ b/src/ai_guard/cli/main.py
@@ -21,6 +21,7 @@ from ai_guard.cli.ruleset import (
     ruleset_show_command,
 )
 from ai_guard.cli.status import agents_command, doctor_command, status_command
+from ai_guard.cli.validation import validation_list_command, validation_report_command
 
 app = typer.Typer(
     name="guard",
@@ -394,3 +395,31 @@ def cache_clear(
 
 ruleset_app.add_typer(cache_app)
 app.add_typer(ruleset_app)
+
+# validation subcommand group
+validation_app = typer.Typer(name="validation", help="Inspect configured checks.")
+
+
+@validation_app.command(name="list")
+def validation_list(
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """List all configured checks by stage."""
+    validation_list_command(config_path=config)
+
+
+@validation_app.command(name="report")
+def validation_report(
+    config: Annotated[
+        Path,
+        typer.Option("--config", "-c", help="Path to guard.yaml"),
+    ] = Path("guard.yaml"),
+) -> None:
+    """Generate a formatted check configuration report."""
+    validation_report_command(config_path=config)
+
+
+app.add_typer(validation_app)

--- a/src/ai_guard/cli/validation.py
+++ b/src/ai_guard/cli/validation.py
@@ -1,0 +1,122 @@
+"""Validation list and report command implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai_guard.config.exceptions import ConfigError
+from ai_guard.config.merger import resolve_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ai_guard.config.models import CheckItem
+
+__all__ = ["validation_list_command", "validation_report_command"]
+
+
+def validation_list_command(config_path: Path) -> None:
+    """Execute ``guard validation list``.
+
+    Lists all configured checks grouped by stage (commit/push),
+    showing builtin checks and custom check commands.
+
+    Args:
+        config_path: Path to guard.yaml.
+    """
+    code = _load_code_config(config_path)
+
+    print("Commit stage:")
+    _print_builtin("format", code.commit_format)
+    _print_builtin("naming", code.commit_naming)
+    for name, item in sorted(code.commit_checks.items()):
+        _print_custom(name, item)
+
+    print("\nPush stage:")
+    _print_builtin("lint", code.push_lint)
+    for name, item in sorted(code.push_checks.items()):
+        _print_custom(name, item)
+
+
+def validation_report_command(config_path: Path) -> None:
+    """Execute ``guard validation report``.
+
+    Generates a formatted table showing all check configurations
+    with name, stage, type, command, timeout, and file types.
+
+    Args:
+        config_path: Path to guard.yaml.
+    """
+    code = _load_code_config(config_path)
+
+    rows: list[tuple[str, str, str, str, str, str]] = []
+
+    # Commit stage
+    if code.commit_format:
+        rows.append(("format", "commit", "builtin", "-", "-", "-"))
+    if code.commit_naming:
+        rows.append(("naming", "commit", "builtin", "-", "-", "-"))
+    for name, item in sorted(code.commit_checks.items()):
+        rows.append(_check_row(name, "commit", item))
+
+    # Push stage
+    if code.push_lint:
+        rows.append(("lint", "push", "builtin", "-", "-", "-"))
+    for name, item in sorted(code.push_checks.items()):
+        rows.append(_check_row(name, "push", item))
+
+    # Print table
+    header = ("Name", "Stage", "Type", "Command", "Timeout", "Types")
+    widths = [
+        max(len(header[i]), *(len(row[i]) for row in rows)) + 2
+        for i in range(len(header))
+    ]
+
+    print("Check Configuration Report")
+    print("-" * sum(widths))
+    print("".join(h.ljust(w) for h, w in zip(header, widths, strict=True)))
+    print("-" * sum(widths))
+    for row in rows:
+        print("".join(val.ljust(w) for val, w in zip(row, widths, strict=True)))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_code_config(config_path: Path):
+    """Load and return the CodeConfig from guard.yaml.
+
+    Args:
+        config_path: Path to guard.yaml.
+
+    Returns:
+        CodeConfig instance.
+    """
+    try:
+        resolved = resolve_config(config_path)
+        return resolved.code
+    except ConfigError as e:
+        print(f"Error: {e}")
+        raise SystemExit(1) from None
+
+
+def _print_builtin(name: str, enabled: bool) -> None:
+    """Print a builtin check entry for list output."""
+    status = "enabled" if enabled else "disabled"
+    print(f"  [builtin] {name:<15} ({status})")
+
+
+def _print_custom(name: str, item: CheckItem) -> None:
+    """Print a custom check entry for list output."""
+    print(f"  [custom]  {name:<15} {item.command}")
+
+
+def _check_row(
+    name: str, stage: str, item: CheckItem
+) -> tuple[str, str, str, str, str, str]:
+    """Build a table row for a custom check item."""
+    timeout = f"{item.timeout}s" if item.timeout else "-"
+    types = ", ".join(item.types) if item.types else "-"
+    return (name, stage, "custom", item.command, timeout, types)

--- a/tests/unit/test_cli/test_validation.py
+++ b/tests/unit/test_cli/test_validation.py
@@ -1,0 +1,116 @@
+"""Tests for validation list and report commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from ai_guard.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_config(tmp_path: Path, *, custom_checks: bool = False) -> Path:
+    """Create a guard.yaml with optional custom checks."""
+    config: dict = {
+        "version": 1,
+        "project": {"name": "test", "language": "python"},
+        "code": {
+            "commit": {
+                "format": True,
+                "naming": True,
+            },
+            "push": {
+                "lint": True,
+            },
+        },
+    }
+    if custom_checks:
+        config["code"]["commit"]["checks"] = {
+            "test": {"command": "pytest --cov", "timeout": 120},
+        }
+        config["code"]["push"]["checks"] = {
+            "typecheck": {
+                "command": "mypy src/",
+                "timeout": 60,
+                "types": ["python"],
+            },
+        }
+
+    path = tmp_path / "guard.yaml"
+    path.write_text(yaml.dump(config, default_flow_style=False), encoding="utf-8")
+    return path
+
+
+class TestValidationList:
+    """Tests for guard validation list."""
+
+    def test_lists_builtin_checks(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path)
+        result = runner.invoke(app, ["validation", "list", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "format" in result.output
+        assert "naming" in result.output
+        assert "lint" in result.output
+
+    def test_lists_custom_checks(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "list", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "test" in result.output
+        assert "typecheck" in result.output
+
+    def test_groups_by_stage(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "list", "--config", str(config)])
+        assert result.exit_code == 0
+        output = result.output.lower()
+        assert "commit" in output
+        assert "push" in output
+
+    def test_shows_builtin_tag(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path)
+        result = runner.invoke(app, ["validation", "list", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "builtin" in result.output.lower()
+
+    def test_shows_custom_tag(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "list", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "custom" in result.output.lower()
+
+
+class TestValidationReport:
+    """Tests for guard validation report."""
+
+    def test_report_table_format(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "report", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "Name" in result.output
+        assert "Stage" in result.output
+        assert "Command" in result.output
+
+    def test_report_includes_custom_details(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "report", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "pytest --cov" in result.output
+        assert "mypy src/" in result.output
+        assert "120" in result.output
+
+    def test_report_includes_types(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, custom_checks=True)
+        result = runner.invoke(app, ["validation", "report", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "python" in result.output.lower()
+
+    def test_report_builtin_only(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path)
+        result = runner.invoke(app, ["validation", "report", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "format" in result.output
+        assert "lint" in result.output


### PR DESCRIPTION
## Summary

- `guard validation list`: lists all configured checks grouped by commit/push stage, with `[builtin]`/`[custom]` tags and enable status
- `guard validation report`: formatted table with Name, Stage, Type, Command, Timeout, and Types columns

## Test plan

- [x] `TestValidationList`: 5 tests (builtin, custom, stage grouping, tags)
- [x] `TestValidationReport`: 4 tests (table format, custom details, types, builtin-only)
- [x] Full regression: 807 tests passed, 0 failed
- [x] All pre-commit hooks passed

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)