### PR TITLE
docs(changelog): add CHANGELOG.md for 0.1.0 (WP6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+本项目变更记录遵循 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-CN/1.1.0/) 格式与 [语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
+
+## [Unreleased]
+
+## [0.1.0] - 2026-0X-XX
+
+首个公开预览版本。核心能力覆盖 AI Agent 看护系统的两条主线：
+**运行时行为拦截**（`pre_tool_use` hook + Enforcer）
+与 **代码质量门禁**（`pre-commit` / `pre-push` Checker）。
+
+First public preview. Covers the two pillars of AI agent guardianship:
+**runtime behavior interception** (`pre_tool_use` hook + Enforcer)
+and **code-quality gates** (`pre-commit` / `pre-push` Checker).
+
+### Added
+
+**Config & Generator (M1)**
+
+- `guard.yaml` schema, loader, validator, and multi-source merger. (#2, #3, #4)
+- Generator core with six artifact primitives G1–G6: rule docs, hooks, tool configs, pre-commit manifests, scripts, and auxiliary files. (#5, #6, #7)
+- `AgentAdapter` ABC and five adapters: Claude Code, Cursor, Windsurf, GitHub Copilot, Gemini CLI. (#8)
+- CLI commands: `init`, `install`, `update`, `uninstall`, `status`, `doctor`, `agents`, `version`. (#9, #10, #11)
+
+**Enforcer & Hooks (M2)**
+
+- Pattern matching engine supporting glob + regex across paths and commands. (#13)
+- Core decision engine with `allow` / `deny` / `ask` three-state policy output. (#14)
+- Hook script templates integrated with Enforcer. (#15)
+- Audit logging infrastructure and `PolicyDecision` type. (#16)
+
+**Checker & Reporter (M3)**
+
+- Checker orchestration module coordinating `commit` and `push` stages. (#18)
+- Reporter with terminal output and Markdown rendering. (#19)
+- CLI commands: `check`, `verify`, `run`, `gate`. (#20)
+
+**Ruleset Management (M4)**
+
+- Ruleset `fetch` with local cache and checksum verification. (#45)
+- `checks/` script copying and `files/` skip semantics. (#46)
+- CLI commands: `ruleset list`, `ruleset show`. (#47)
+
+**PR Report & Polish (M5)**
+
+- `ReportChannel` abstract base and GitHub implementation. (#49)
+- GitLab, Gitea, and Bitbucket channels with smart PR detection. (#50)
+- Global `--format json` output mode for `check`, `verify`, and `status`. (#51)
+- `validation list` and `validation report` commands. (#52)
+
+**Release Pipeline (partial M6)**
+
+- PyPI packaging via hatchling with full project metadata and classifiers. (#68, PR #87)
+- GitHub Actions release workflow using PyPI Trusted Publisher. (#68, PR #87)
+
+### Changed
+
+- CLI executable renamed from `guard` to `ac-guard` for better discoverability and to avoid naming collisions. The `guard.yaml` config filename and the `ac_guard` Python package name are unchanged. (PR #87, PR #88)
+- Project branding unified as **ac-guard** (AI Code Guard). (PR #88, PR #89)
+
+### Known Limitations
+
+- Audit logging is not yet wired into every Enforcer call path. ([#75](https://github.com/ikroal/ai-code-guard/issues/75))
+- `output.locale` is not propagated to every formatter. ([#76](https://github.com/ikroal/ai-code-guard/issues/76))
+- Push-stage build failure does not fail-fast as aggressively as commit-stage. ([#77](https://github.com/ikroal/ai-code-guard/issues/77))
+- `post_pr_comment` is not yet invoked automatically by the CLI; call it manually from CI for now. ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
+- HTTP requests have no retry/backoff; transient network failures surface directly. ([#67](https://github.com/ikroal/ai-code-guard/issues/67))
+
+[Unreleased]: https://github.com/ikroal/ai-code-guard/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ikroal/ai-code-guard/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ pytest                    # 816 tests
 ruff check .
 ```
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes and known limitations.
+
 ## License
 
 [MIT](LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -134,6 +134,10 @@ pytest                    # 816 个测试
 ruff check .
 ```
 
+## 版本记录
+
+发布说明与已知限制见 [CHANGELOG.md](CHANGELOG.md)。
+
 ## 许可证
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

- 新增 `CHANGELOG.md`，遵循 [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) + SemVer
- 涵盖 M1–M5 全部能力（Config/Generator、Enforcer/Hook、Checker/Reporter、Ruleset、PR Report）
- 记录 M6 已合并部分（WP6.3 PyPI 发布链路）
- 诚实列出首发 0.1.0 的 5 项 Known Limitations，均链接到对应 Issue（#75 / #76 / #77 / #66 / #67）
- `README.md` 与 `README_zh.md` 添加 Changelog 链接入口

## Motivation

- 为即将发布的 `0.1.0` 准备用户可读的变更记录
- `pyproject.toml` 早已声明 Changelog URL，本次填上实际内容
- 让用户在安装 preview 之前就能评估能力范围与已知缺陷

## Out of scope (deferred to 0.2.0)

- 自动化生成工具（release-drafter / towncrier）
- release.yml 自动抽取 body（首发人工复制粘贴即可）
- 每个 PR 的细粒度改动回填

## Test plan

- [x] 本地 `pre-commit run --files CHANGELOG.md README.md README_zh.md` 通过
- [x] 对照 M1–M5 已合并 PR 核对条目无遗漏（#2–#64、#87/#88）
- [x] compare/tag links 语法正确（tag 创建后即生效）
- [x] CI 通过

Closes #72