### PR TITLE
fix(adapters): stop double-wrapping managed block markers (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `execute.forbidden` as system rules, matching the README's "the agent
   cannot skip the gate" promise.
   ([#93](https://github.com/ikroal/ai-code-guard/issues/93))
+- Rule-document files (`CLAUDE.md`, `AGENTS.md`,
+  `.cursor/rules/behavior.mdc`, `.kilocode/rules/behavior.md`,
+  `.github/copilot-instructions.md`) no longer accumulate duplicate
+  `<!-- AI-GUARD:BEGIN -->` / `<!-- AI-GUARD:END -->` markers on each
+  `ac-guard update`. Adapters now return raw Markdown and the writer
+  layer owns wrapping. `.mdc` files are wrapped alongside `.md`.
+  ([#94](https://github.com/ikroal/ai-code-guard/issues/94))
 
 ### Changed
 

--- a/src/ac_guard/adapters/claude_code.py
+++ b/src/ac_guard/adapters/claude_code.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard.adapters._render import render_hook, render_rule_doc
 from ac_guard.adapters.base import AgentAdapter, AgentCapabilities
-from ac_guard.shared.types import FileSpec, wrap_with_managed_block
+from ac_guard.shared.types import FileSpec
 
 if TYPE_CHECKING:
     from ac_guard.config.models import BehaviorConfig
@@ -39,11 +39,12 @@ class ClaudeCodeAdapter(AgentAdapter):
     def render_rule_doc(self, behavior: BehaviorConfig) -> str:
         """Render behavior rules as Claude Code rule document.
 
-        Uses Jinja2 template (claude_code.md.j2) for formatting.
-        Output is wrapped with managed block markers.
+        Returns raw Markdown content without managed-block markers.
+        The writer layer (``write_artifacts`` / ``replace_managed_block``)
+        owns wrapping so we do not accumulate duplicate markers across
+        ``install`` / ``update`` cycles.
         """
-        content = render_rule_doc("claude_code", behavior)
-        return wrap_with_managed_block(content)
+        return render_rule_doc("claude_code", behavior)
 
     def hook_files(self, behavior: BehaviorConfig) -> list[FileSpec]:
         """Generate Claude Code Hook script.

--- a/src/ac_guard/adapters/copilot.py
+++ b/src/ac_guard/adapters/copilot.py
@@ -15,10 +15,10 @@ from typing import TYPE_CHECKING
 
 from ac_guard.adapters._render import render_rule_doc
 from ac_guard.adapters.base import AgentAdapter, AgentCapabilities
-from ac_guard.shared.types import FileSpec, wrap_with_managed_block
 
 if TYPE_CHECKING:
     from ac_guard.config.models import BehaviorConfig
+    from ac_guard.shared.types import FileSpec
 
 __all__ = ["CopilotAdapter"]
 
@@ -41,12 +41,10 @@ class CopilotAdapter(AgentAdapter):
     def render_rule_doc(self, behavior: BehaviorConfig) -> str:
         """Render behavior rules as Copilot instructions.
 
-        Uses Jinja2 template (copilot.md.j2) for formatting.
-        Copilot uses copilot-instructions.md format.
-        Output is wrapped with managed block markers.
+        Returns raw ``copilot-instructions.md`` content without managed
+        block markers; the writer layer owns marker wrapping.
         """
-        content = render_rule_doc("copilot", behavior)
-        return wrap_with_managed_block(content)
+        return render_rule_doc("copilot", behavior)
 
     def hook_files(self, behavior: BehaviorConfig) -> list[FileSpec]:
         """Copilot has no Hook capability — returns empty list."""

--- a/src/ac_guard/adapters/cursor.py
+++ b/src/ac_guard/adapters/cursor.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard.adapters._render import render_hook, render_rule_doc
 from ac_guard.adapters.base import AgentAdapter, AgentCapabilities
-from ac_guard.shared.types import FileSpec, wrap_with_managed_block
+from ac_guard.shared.types import FileSpec
 
 if TYPE_CHECKING:
     from ac_guard.config.models import BehaviorConfig
@@ -40,12 +40,10 @@ class CursorAdapter(AgentAdapter):
     def render_rule_doc(self, behavior: BehaviorConfig) -> str:
         """Render behavior rules as Cursor rule document.
 
-        Uses Jinja2 template (cursor.mdc.j2) for formatting.
-        Cursor uses .mdc format with frontmatter.
-        Output is wrapped with managed block markers.
+        Returns raw ``.mdc`` content (with frontmatter) without managed
+        block markers. The writer layer owns marker wrapping.
         """
-        content = render_rule_doc("cursor", behavior)
-        return wrap_with_managed_block(content)
+        return render_rule_doc("cursor", behavior)
 
     def hook_files(self, behavior: BehaviorConfig) -> list[FileSpec]:
         """Generate Cursor Hook script.

--- a/src/ac_guard/adapters/kilocode.py
+++ b/src/ac_guard/adapters/kilocode.py
@@ -15,10 +15,10 @@ from typing import TYPE_CHECKING
 
 from ac_guard.adapters._render import render_rule_doc
 from ac_guard.adapters.base import AgentAdapter, AgentCapabilities
-from ac_guard.shared.types import FileSpec, wrap_with_managed_block
 
 if TYPE_CHECKING:
     from ac_guard.config.models import BehaviorConfig
+    from ac_guard.shared.types import FileSpec
 
 __all__ = ["KiloCodeAdapter"]
 
@@ -41,12 +41,10 @@ class KiloCodeAdapter(AgentAdapter):
     def render_rule_doc(self, behavior: BehaviorConfig) -> str:
         """Render behavior rules as KiloCode rule document.
 
-        Uses Jinja2 template (kilocode.md.j2) for formatting.
-        KiloCode uses .kilocode/rules/ directory for rule documents.
-        Output is wrapped with managed block markers.
+        Returns raw Markdown content without managed block markers;
+        the writer layer owns marker wrapping.
         """
-        content = render_rule_doc("kilocode", behavior)
-        return wrap_with_managed_block(content)
+        return render_rule_doc("kilocode", behavior)
 
     def hook_files(self, behavior: BehaviorConfig) -> list[FileSpec]:
         """KiloCode has no Hook capability — returns empty list."""

--- a/src/ac_guard/adapters/opencode.py
+++ b/src/ac_guard/adapters/opencode.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard.adapters._render import render_hook, render_rule_doc
 from ac_guard.adapters.base import AgentAdapter, AgentCapabilities
-from ac_guard.shared.types import FileSpec, wrap_with_managed_block
+from ac_guard.shared.types import FileSpec
 
 if TYPE_CHECKING:
     from ac_guard.config.models import BehaviorConfig
@@ -39,11 +39,10 @@ class OpenCodeAdapter(AgentAdapter):
     def render_rule_doc(self, behavior: BehaviorConfig) -> str:
         """Render behavior rules as OpenCode rule document.
 
-        Uses Jinja2 template (opencode.md.j2) for formatting.
-        Output is wrapped with managed block markers.
+        Returns raw Markdown content without managed block markers;
+        the writer layer owns marker wrapping.
         """
-        content = render_rule_doc("opencode", behavior)
-        return wrap_with_managed_block(content)
+        return render_rule_doc("opencode", behavior)
 
     def hook_files(self, behavior: BehaviorConfig) -> list[FileSpec]:
         """Generate OpenCode TypeScript plugin.

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -306,7 +306,7 @@ def write_artifacts(  # noqa: C901
             else:
                 # New file — wrap with managed block for rule docs
                 # (hook scripts and configs don't need managed blocks)
-                if artifact.path.endswith(".md"):
+                if artifact.path.endswith((".md", ".mdc")):
                     content = wrap_with_managed_block(artifact.content)
                 else:
                     content = artifact.content

--- a/tests/integration/test_cli_lifecycle.py
+++ b/tests/integration/test_cli_lifecycle.py
@@ -302,3 +302,46 @@ class TestErrorRecovery:
         assert result.exit_code == 0
         assert "warning" in result.output.lower()
         assert (tmp_path / STATE_FILE).is_file()
+
+
+class TestRuleDocMarkers:
+    """Regression for #94: install/update must not accumulate markers."""
+
+    _BEGIN = "<!-- AI-GUARD:BEGIN -->"
+    _END = "<!-- AI-GUARD:END -->"
+
+    def _bump_config(self, config: Path) -> None:
+        """Mutate guard.yaml so `update` has something to regenerate."""
+        data = yaml.safe_load(config.read_text())
+        data.setdefault("behavior", {}).setdefault("write", {}).setdefault(
+            "forbidden", []
+        ).append({"pattern": "file:marker-bump/**", "reason": "test"})
+        config.write_text(yaml.dump(data, default_flow_style=False))
+
+    def test_install_and_update_keep_single_marker_pair(self, tmp_path: Path) -> None:
+        config = tmp_path / "guard.yaml"
+        (tmp_path / ".git").mkdir()
+        runner.invoke(app, ["init", "--language", "python", "--output", str(config)])
+        runner.invoke(
+            app, ["install", "--agent", "claude-code", "--config", str(config)]
+        )
+
+        claude = tmp_path / "CLAUDE.md"
+        assert claude.read_text().count(self._BEGIN) == 1
+        assert claude.read_text().count(self._END) == 1
+
+        # Add a user section outside the managed block
+        claude.write_text(
+            claude.read_text() + "\n\n## My Custom Section\nuser content\n"
+        )
+
+        # Two updates in a row — markers must stay at 1+1 each time
+        for _ in range(2):
+            self._bump_config(config)
+            r = runner.invoke(app, ["update", "--config", str(config)])
+            assert r.exit_code == 0, r.output
+            text = claude.read_text()
+            assert text.count(self._BEGIN) == 1, text
+            assert text.count(self._END) == 1, text
+            assert "My Custom Section" in text
+            assert "user content" in text

--- a/tests/unit/test_adapters/test_claude_code.py
+++ b/tests/unit/test_adapters/test_claude_code.py
@@ -33,12 +33,13 @@ class TestClaudeCodeAdapterProperties:
 
 
 class TestClaudeCodeAdapterRenderRuleDoc:
-    def test_output_has_managed_block_markers(self) -> None:
+    def test_output_is_raw_content_without_markers(self) -> None:
+        """Adapter returns plain Markdown; writer layer adds markers."""
         adapter = ClaudeCodeAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
     def test_output_structure_with_rules(self) -> None:
         adapter = ClaudeCodeAdapter()
@@ -61,10 +62,10 @@ class TestClaudeCodeAdapterRenderRuleDoc:
         adapter = ClaudeCodeAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        # Should still have markers and basic structure
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        # Should still render non-empty markdown (markers added by writer)
         assert len(result) > 0
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapters/test_copilot.py
+++ b/tests/unit/test_adapters/test_copilot.py
@@ -39,12 +39,13 @@ class TestCopilotAdapterProperties:
 
 
 class TestCopilotAdapterRenderRuleDoc:
-    def test_output_has_managed_block_markers(self) -> None:
+    def test_output_is_raw_content_without_markers(self) -> None:
+        """Adapter returns plain Markdown; writer layer adds markers."""
         adapter = CopilotAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
     def test_output_structure_with_rules(self) -> None:
         adapter = CopilotAdapter()

--- a/tests/unit/test_adapters/test_cursor.py
+++ b/tests/unit/test_adapters/test_cursor.py
@@ -40,12 +40,13 @@ class TestCursorAdapterProperties:
 
 
 class TestCursorAdapterRenderRuleDoc:
-    def test_output_has_managed_block_markers(self) -> None:
+    def test_output_is_raw_content_without_markers(self) -> None:
+        """Adapter returns plain .mdc content; writer layer adds markers."""
         adapter = CursorAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
     def test_output_structure_with_rules(self) -> None:
         adapter = CursorAdapter()
@@ -65,9 +66,9 @@ class TestCursorAdapterRenderRuleDoc:
         adapter = CursorAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
         assert len(result) > 0
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapters/test_kilocode.py
+++ b/tests/unit/test_adapters/test_kilocode.py
@@ -39,12 +39,13 @@ class TestKiloCodeAdapterProperties:
 
 
 class TestKiloCodeAdapterRenderRuleDoc:
-    def test_output_has_managed_block_markers(self) -> None:
+    def test_output_is_raw_content_without_markers(self) -> None:
+        """Adapter returns plain Markdown; writer layer adds markers."""
         adapter = KiloCodeAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
     def test_output_structure_with_rules(self) -> None:
         adapter = KiloCodeAdapter()

--- a/tests/unit/test_adapters/test_opencode.py
+++ b/tests/unit/test_adapters/test_opencode.py
@@ -33,12 +33,13 @@ class TestOpenCodeAdapterProperties:
 
 
 class TestOpenCodeAdapterRenderRuleDoc:
-    def test_output_has_managed_block_markers(self) -> None:
+    def test_output_is_raw_content_without_markers(self) -> None:
+        """Adapter returns plain Markdown; writer layer adds markers."""
         adapter = OpenCodeAdapter()
         behavior = BehaviorConfig.empty()
         result = adapter.render_rule_doc(behavior)
-        assert MARKER_BEGIN in result
-        assert MARKER_END in result
+        assert MARKER_BEGIN not in result
+        assert MARKER_END not in result
 
     def test_output_structure_with_rules(self) -> None:
         adapter = OpenCodeAdapter()

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -338,6 +338,58 @@ class TestWriteArtifacts:
             readonly_dir.chmod(0o755)
 
 
+class TestMarkerDuplication:
+    """Regression: install + repeated updates must not accumulate markers."""
+
+    @staticmethod
+    def _count(content: str, marker: str) -> int:
+        return content.count(marker)
+
+    def test_install_produces_single_marker_pair(self, tmp_path: Path) -> None:
+        """First-time write of a .md artifact yields exactly one BEGIN/END pair."""
+        artifact = FileSpec(path="CLAUDE.md", content="# Rules\n\nDo this.")
+        write_artifacts(tmp_path, [artifact])
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert self._count(content, MARKER_BEGIN) == 1
+        assert self._count(content, MARKER_END) == 1
+        assert "# Rules" in content
+
+    def test_update_preserves_single_marker_pair(self, tmp_path: Path) -> None:
+        """A second write (update) still leaves exactly one BEGIN/END pair."""
+        write_artifacts(tmp_path, [FileSpec(path="CLAUDE.md", content="v1")])
+        write_artifacts(tmp_path, [FileSpec(path="CLAUDE.md", content="v2")])
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert self._count(content, MARKER_BEGIN) == 1
+        assert self._count(content, MARKER_END) == 1
+        assert "v2" in content
+        assert "v1" not in content
+
+    def test_install_wraps_mdc_rule_docs_too(self, tmp_path: Path) -> None:
+        """Cursor uses .mdc; it must be wrapped like .md."""
+        write_artifacts(
+            tmp_path,
+            [FileSpec(path=".cursor/rules/behavior.mdc", content="raw")],
+        )
+        content = (tmp_path / ".cursor" / "rules" / "behavior.mdc").read_text()
+        assert self._count(content, MARKER_BEGIN) == 1
+        assert self._count(content, MARKER_END) == 1
+
+    def test_update_preserves_user_content_outside_markers(
+        self, tmp_path: Path
+    ) -> None:
+        """User content added outside markers survives the next update."""
+        write_artifacts(tmp_path, [FileSpec(path="CLAUDE.md", content="v1")])
+        md = tmp_path / "CLAUDE.md"
+        md.write_text(md.read_text() + "\n\n## My Custom Section\nuser notes\n")
+        write_artifacts(tmp_path, [FileSpec(path="CLAUDE.md", content="v2")])
+        content = md.read_text()
+        assert self._count(content, MARKER_BEGIN) == 1
+        assert self._count(content, MARKER_END) == 1
+        assert "My Custom Section" in content
+        assert "user notes" in content
+        assert "v2" in content
+
+
 class TestDeleteArtifacts:
     """delete_artifacts function tests."""
 


### PR DESCRIPTION
## Summary

Every rule-doc file shipped by ac-guard previously ended up with duplicate `<!-- AI-GUARD:BEGIN --> / <!-- AI-GUARD:END -->` marker pairs, and each subsequent `ac-guard update` accumulated one more `END` marker. Root cause: two layers of wrapping.

### Root cause

- Each of the 5 `AgentAdapter.render_rule_doc()` methods called `wrap_with_managed_block()` before returning.
- `write_artifacts()` then wrapped `.md` files **again** on first install.
- Result on install: `2 BEGIN + 2 END`. On each update, `replace_managed_block()` uses `.find()` which lands on the outer `BEGIN` and the first (**inner**) `END`, splicing a pre-wrapped payload in between — leaving the original outer `END` as a trailing leftover. Consecutive updates accumulate: `2 BEGIN + 3 END`, `2 BEGIN + 4 END`, …

### Fix

- 5 adapters (`claude_code`, `cursor`, `opencode`, `copilot`, `kilocode`) now return **raw** Markdown/`.mdc` content. The writer layer (`write_artifacts` + `replace_managed_block`) is the single owner of marker wrapping.
- `write_artifacts` extended to also wrap `.mdc` files (Cursor's rule doc extension). Without this, removing the adapter wrap would have regressed Cursor to 0 markers.

## Verified end-to-end (all 5 agents)

```
=== install counts ===
CLAUDE.md                          BEGIN=1 END=1
AGENTS.md                          BEGIN=1 END=1
.cursor/rules/behavior.mdc         BEGIN=1 END=1
.kilocode/rules/behavior.md        BEGIN=1 END=1
.github/copilot-instructions.md    BEGIN=1 END=1

=== after 2 consecutive updates ===
CLAUDE.md                          BEGIN=1 END=1
AGENTS.md                          BEGIN=1 END=1
.cursor/rules/behavior.mdc         BEGIN=1 END=1
.kilocode/rules/behavior.md        BEGIN=1 END=1
.github/copilot-instructions.md    BEGIN=1 END=1
```

User-authored content outside the managed block is preserved across updates (covered by new regression test).

## Test plan

- [x] `pytest tests/` — 835 passed (+4 regression tests: 3 in `TestMarkerDuplication` + 1 in `TestRuleDocMarkers` CLI lifecycle)
- [x] Adapter unit tests updated: every `test_output_has_managed_block_markers` became `test_output_is_raw_content_without_markers`
- [x] End-to-end walk-through on all 5 agents
- [x] `ruff check` clean; `pre-commit run --all-files` clean
- [x] CI

## Out of scope

- No change to `wrap_with_managed_block` or `replace_managed_block` — they are already correct single-wrap operations.
- No change to Jinja templates.

Closes #94