### PR TITLE
fix(checker): skip downstream push checks when build fails (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ac-guard update`. Adapters now return raw Markdown and the writer
   layer owns wrapping. `.mdc` files are wrapped alongside `.md`.
   ([#94](https://github.com/ikroal/ai-code-guard/issues/94))
+- Push-stage build is now a precondition: when `build` fails, `lint`
+  and `push.checks` are no longer executed — they are reported as
+  `skipped` with `Skipped: build failed`. Prevents wasted CI time and
+  matches the design doc §6.5.3 intent.
+  ([#77](https://github.com/ikroal/ai-code-guard/issues/77))
 
 ### Changed
 
@@ -100,7 +105,6 @@ and **code-quality gates** (`pre-commit` / `pre-push` Checker).
 
 - Audit logging is not yet wired into every Enforcer call path. ([#75](https://github.com/ikroal/ai-code-guard/issues/75))
 - `output.locale` is not propagated to every formatter. ([#76](https://github.com/ikroal/ai-code-guard/issues/76))
-- Push-stage build failure does not fail-fast as aggressively as commit-stage. ([#77](https://github.com/ikroal/ai-code-guard/issues/77))
 - `post_pr_comment` is not yet invoked automatically by the CLI; call it manually from CI for now. ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
 - HTTP requests have no retry/backoff; transient network failures surface directly. ([#67](https://github.com/ikroal/ai-code-guard/issues/67))
 - `code.commit.naming: true` is accepted but produces a `[SKIP]` result — a concrete naming check implementation is planned in a follow-up. ([#95](https://github.com/ikroal/ai-code-guard/issues/95))

--- a/src/ac_guard/checker/core.py
+++ b/src/ac_guard/checker/core.py
@@ -407,6 +407,9 @@ def _run_commit_checks(
     return results
 
 
+_BUILD_FAILED_SKIP_REASON = "Skipped: build failed"
+
+
 def _run_push_checks(
     config: CodeConfig,
     files: list[str],
@@ -414,11 +417,21 @@ def _run_push_checks(
     build_command: str | None,
     languages: list[str],
 ) -> list[CheckResult]:
-    """Run push-stage checks."""
+    """Run push-stage checks.
+
+    Build is a precondition: if it fails, lint and custom push checks
+    are not executed and are instead appended as ``skipped`` results
+    with a ``Skipped: build failed`` marker. This mirrors the existing
+    commit→push fail-fast pattern in :func:`run_stage`.
+    """
     results: list[CheckResult] = []
 
     if build_command:
-        results.append(run_build(build_command, project_root))
+        build_result = run_build(build_command, project_root)
+        results.append(build_result)
+        if not build_result.passed:
+            _append_skipped_downstream(results, config, languages)
+            return results
 
     if config.push_lint:
         results.extend(
@@ -429,3 +442,30 @@ def _run_push_checks(
         results.append(run_check(name, check_item, files, project_root))
 
     return results
+
+
+def _append_skipped_downstream(
+    results: list[CheckResult],
+    config: CodeConfig,
+    languages: list[str],
+) -> None:
+    """Mark lint + push.checks as skipped when build has already failed."""
+    if config.push_lint:
+        results.extend(
+            CheckResult(
+                name=f"pre-commit:lint-{lang}",
+                passed=True,
+                skipped=True,
+                output=_BUILD_FAILED_SKIP_REASON,
+            )
+            for lang in languages
+        )
+    results.extend(
+        CheckResult(
+            name=name,
+            passed=True,
+            skipped=True,
+            output=_BUILD_FAILED_SKIP_REASON,
+        )
+        for name in config.push_checks
+    )

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -219,6 +219,44 @@ class TestVerifyCommand:
         assert r.exit_code == 0
         assert "build" in r.output.lower()
 
+    def test_build_failure_skips_lint_and_custom_push_checks(
+        self, tmp_path: Path
+    ) -> None:
+        """#77: a failing build must short-circuit push stage with skips."""
+        import json as json_mod
+
+        config = _write_config(
+            tmp_path,
+            {
+                "build": {"command": "false"},  # always fails
+                "languages": {
+                    "python": {"tools": {"format": "black", "lint": "ruff"}},
+                },
+                "code": {
+                    "commit": {"format": False, "naming": False},
+                    "push": {
+                        "lint": True,
+                        "checks": {
+                            "custom": {
+                                "command": "echo should-not-run",
+                                "pass_filenames": False,
+                            }
+                        },
+                    },
+                },
+            },
+        )
+        with patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]):
+            r = runner.invoke(app, ["verify", "-c", str(config), "--format", "json"])
+        assert r.exit_code == 1
+        data = json_mod.loads(r.output)
+        names = {item["name"]: item for item in data["results"]}
+        assert names["build"]["passed"] is False
+        assert names["pre-commit:lint-python"]["skipped"] is True
+        assert "build failed" in names["pre-commit:lint-python"]["output"].lower()
+        assert names["custom"]["skipped"] is True
+        assert "build failed" in names["custom"]["output"].lower()
+
 
 # ===========================================================================
 # D. run Command

--- a/tests/unit/test_checker/test_core.py
+++ b/tests/unit/test_checker/test_core.py
@@ -244,3 +244,79 @@ class TestRunStage:
         ):
             run_stage("push", config, tmp_path, languages=[])
         mock_run.assert_not_called()
+
+    def test_push_build_failure_skips_lint_and_checks(self, tmp_path: Path) -> None:
+        """#77: a failing build must mark lint + push.checks as skipped."""
+        from ac_guard.checker.models import CheckResult
+
+        config = CodeConfig(
+            commit_format=False,
+            commit_naming=False,
+            push_lint=True,
+            push_checks={"custom": CheckItem(command="echo should-not-run")},
+        )
+        failing_build = CheckResult(
+            name="build", passed=False, duration_ms=10, output="build broke"
+        )
+        with (
+            patch(
+                "ac_guard.checker.core.run_build", return_value=failing_build
+            ) as build_mock,
+            patch("ac_guard.checker.core.run_precommit") as precommit_mock,
+            patch("ac_guard.checker.core.run_check") as check_mock,
+            patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
+        ):
+            report = run_stage(
+                "push",
+                config,
+                tmp_path,
+                build_command="make build",
+                languages=["python"],
+            )
+
+        # Build ran once, downstream checkers never invoked
+        assert build_mock.call_count == 1
+        precommit_mock.assert_not_called()
+        check_mock.assert_not_called()
+
+        # Report is failed because build failed
+        assert report.passed is False
+        names = {r.name: r for r in report.results}
+        assert names["build"].passed is False
+        assert names["pre-commit:lint-python"].skipped is True
+        assert "build failed" in names["pre-commit:lint-python"].output.lower()
+        assert names["custom"].skipped is True
+        assert "build failed" in names["custom"].output.lower()
+
+    def test_push_build_success_runs_downstream(self, tmp_path: Path) -> None:
+        """Build success preserves the existing downstream execution path."""
+        from ac_guard.checker.models import CheckResult
+
+        config = CodeConfig(
+            commit_format=False,
+            commit_naming=False,
+            push_lint=True,
+            push_checks={"custom": CheckItem(command="echo ok")},
+        )
+        passing_build = CheckResult(name="build", passed=True, duration_ms=10)
+        with (
+            patch("ac_guard.checker.core.run_build", return_value=passing_build),
+            patch("ac_guard.checker.core.run_precommit") as precommit_mock,
+            patch("ac_guard.checker.core.run_check") as check_mock,
+            patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
+        ):
+            precommit_mock.return_value = CheckResult(
+                name="pre-commit:lint-python", passed=True, duration_ms=1
+            )
+            check_mock.return_value = CheckResult(
+                name="custom", passed=True, duration_ms=1
+            )
+            run_stage(
+                "push",
+                config,
+                tmp_path,
+                build_command="make build",
+                languages=["python"],
+            )
+        precommit_mock.assert_called()
+        check_mock.assert_called()


### PR DESCRIPTION
## Summary

When `build` fails at push stage, ac-guard should not waste time running `lint` and custom `push.checks` on a broken tree. Design doc §6.5.3 called build a precondition, but `_run_push_checks` appended the build result and kept going.

This PR makes `_run_push_checks` short-circuit on build failure: it appends one `CheckResult(passed=True, skipped=True, output="Skipped: build failed")` per downstream check and returns early. The overall report still fails (build's own `passed=False`), but users see the real reason immediately and no bogus lint output.

Mirrors the existing commit→push fail-fast pattern in `run_stage` (`src/ac_guard/checker/core.py:336-348`).

## Verified end-to-end

```bash
# guard.yaml with build.command = "false", push.lint=true, 2 custom checks
ac-guard verify --format json
```

```json
{
  "stage": "push",
  "passed": false,
  "results": [
    { "name": "build",                    "passed": false, "skipped": false },
    { "name": "pre-commit:lint-python",   "passed": true,  "skipped": true,  "output": "Skipped: build failed" },
    { "name": "custom",                   "passed": true,  "skipped": true,  "output": "Skipped: build failed" },
    { "name": "test",                     "passed": true,  "skipped": true,  "output": "Skipped: build failed" }
  ]
}
```

## Test plan

- [x] `pytest tests/` — 838 passed (+3 regression tests)
  - `test_push_build_failure_skips_lint_and_checks` — mocked build fail → lint/custom never invoked, results carry the skip reason
  - `test_push_build_success_runs_downstream` — mocked build pass → lint and custom still run (no regression)
  - `test_build_failure_skips_lint_and_custom_push_checks` — CLI-level E2E with `ac-guard verify --format json`
- [x] `ruff check` clean; `pre-commit run` clean
- [x] Manual E2E walk-through on a clean project (see above)
- [ ] CI

## Out of scope

- No change to `run_build` / `run_stage` signatures
- No `lint → custom` fail-fast (they remain independent)
- `apply_retention`, audit wiring, locale propagation all stay in their own PRs (#75, #76)

Closes #77