### PR TITLE
fix(reporter): propagate output.locale to terminal formatter (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `skipped` with `Skipped: build failed`. Prevents wasted CI time and
   matches the design doc §6.5.3 intent.
   ([#77](https://github.com/ikroal/ai-code-guard/issues/77))
+- `output.locale` is now honored by the terminal formatter. Setting
+  `output.locale: zh-CN` in `guard.yaml` switches the stage heading,
+  summary line, and total-time label to Chinese; `[PASS]` / `[FAIL]`
+  / `[SKIP]` indicators stay ASCII for alignment. Unknown locales
+  fall back to English.
+  ([#76](https://github.com/ikroal/ai-code-guard/issues/76))
 
 ### Changed
 
@@ -104,7 +110,6 @@ and **code-quality gates** (`pre-commit` / `pre-push` Checker).
 ### Known Limitations
 
 - Audit logging is not yet wired into every Enforcer call path. ([#75](https://github.com/ikroal/ai-code-guard/issues/75))
-- `output.locale` is not propagated to every formatter. ([#76](https://github.com/ikroal/ai-code-guard/issues/76))
 - `post_pr_comment` is not yet invoked automatically by the CLI; call it manually from CI for now. ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
 - HTTP requests have no retry/backoff; transient network failures surface directly. ([#67](https://github.com/ikroal/ai-code-guard/issues/67))
 - `code.commit.naming: true` is accepted but produces a `[SKIP]` result — a concrete naming check implementation is planned in a follow-up. ([#95](https://github.com/ikroal/ai-code-guard/issues/95))

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -61,7 +61,14 @@ def check_command(
         languages=list(resolved.languages),
     )
 
-    print(_format_report(report, output_format, resolved.output.verbosity))
+    print(
+        _format_report(
+            report,
+            output_format,
+            resolved.output.verbosity,
+            resolved.output.locale,
+        )
+    )
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -90,7 +97,14 @@ def verify_command(
         languages=list(resolved.languages),
     )
 
-    print(_format_report(report, output_format, resolved.output.verbosity))
+    print(
+        _format_report(
+            report,
+            output_format,
+            resolved.output.verbosity,
+            resolved.output.locale,
+        )
+    )
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -163,7 +177,11 @@ def run_command(
         duration_ms=duration,
     )
 
-    print(_format_report(report, "text", resolved.output.verbosity))
+    print(
+        _format_report(
+            report, "text", resolved.output.verbosity, resolved.output.locale
+        )
+    )
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -194,20 +212,27 @@ def gate_run_command(
     raise SystemExit(exit_code)
 
 
-def _format_report(report: CheckReport, output_format: str, verbosity: str) -> str:
+def _format_report(
+    report: CheckReport,
+    output_format: str,
+    verbosity: str,
+    locale: str = "en",
+) -> str:
     """Format a CheckReport for output.
 
     Args:
         report: The check report to format.
         output_format: ``"text"`` or ``"json"``.
         verbosity: Verbosity level for text output.
+        locale: Label locale for terminal output (``"en"`` or
+            ``"zh-CN"``). Ignored for JSON.
 
     Returns:
         Formatted string.
     """
     if output_format == "json":
         return format_json(report)
-    return format_terminal(report, verbosity=verbosity)
+    return format_terminal(report, verbosity=verbosity, locale=locale)
 
 
 def _load_config(config_path: Path):

--- a/src/ac_guard/reporter/formatting.py
+++ b/src/ac_guard/reporter/formatting.py
@@ -29,6 +29,30 @@ _LOCALE_TEMPLATES = {
     "zh-CN": "report_zh_cn.md.j2",
 }
 
+# Terminal-facing labels. See format_terminal() docstring for the scope
+# of what is localized versus left as stable ASCII tokens.
+_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "stage": "Stage",
+        "passed": "PASSED",
+        "failed": "FAILED",
+        "summary": "{passed}/{total} checks passed, {failed} failed",
+        "total_time": "Total time",
+    },
+    "zh-CN": {
+        "stage": "阶段",
+        "passed": "通过",
+        "failed": "失败",
+        "summary": "{passed}/{total} 项检查通过, {failed} 项失败",
+        "total_time": "总耗时",
+    },
+}
+
+
+def _labels_for(locale: str) -> dict[str, str]:
+    """Return the label set for *locale*, falling back to English."""
+    return _LABELS.get(locale, _LABELS["en"])
+
 
 def _get_env() -> Environment:
     """Get or create Jinja2 environment."""
@@ -51,23 +75,29 @@ def _get_env() -> Environment:
 def format_terminal(
     report: Any,
     verbosity: str = "normal",
+    locale: str = "en",
 ) -> str:
     """Format a CheckReport for terminal display.
 
     Args:
         report: Any to format.
         verbosity: Output detail level ("quiet", "normal", "verbose").
+        locale: Label locale ("en" or "zh-CN"). Unknown locales fall
+            back to English. Only full-line headings are localized;
+            the ``[PASS] / [FAIL] / [SKIP]`` indicators and check
+            names stay as stable ASCII tokens to preserve alignment.
 
     Returns:
         Formatted string for terminal output.
     """
-    status = "PASSED" if report.passed else "FAILED"
+    labels = _labels_for(locale)
+    status = labels["passed"] if report.passed else labels["failed"]
 
     if verbosity == "quiet":
         return f"{report.stage}: {status}"
 
     lines: list[str] = []
-    lines.append(f"Stage: {report.stage} — {status}")
+    lines.append(f"{labels['stage']}: {report.stage} — {status}")
     lines.append("")
 
     for result in report.results:
@@ -87,10 +117,10 @@ def format_terminal(
     passed = sum(1 for r in report.results if r.passed)
     total = len(report.results)
     failed = total - passed
-    lines.append(f"{passed}/{total} checks passed, {failed} failed")
+    lines.append(labels["summary"].format(passed=passed, total=total, failed=failed))
 
     if report.duration_ms:
-        lines.append(f"Total time: {report.duration_ms}ms")
+        lines.append(f"{labels['total_time']}: {report.duration_ms}ms")
 
     return "\n".join(lines)
 

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -411,6 +411,49 @@ class TestSystemExecuteRulesE2E:
         assert "shell:git push --no-verify*" in patterns
 
 
+class TestLocalePropagation:
+    """#76: output.locale reaches the terminal formatter."""
+
+    def test_zh_cn_locale_propagates_to_check_output(self, tmp_path: Path) -> None:
+        config = _write_config(
+            tmp_path,
+            {
+                "output": {"locale": "zh-CN"},
+                "languages": {
+                    "python": {"tools": {"format": "black", "lint": "ruff"}},
+                },
+                "code": {
+                    "commit": {
+                        "format": False,
+                        "naming": False,
+                        "checks": {
+                            "demo": {
+                                "command": "echo ok",
+                                "pass_filenames": False,
+                            }
+                        },
+                    },
+                    "push": {"lint": False},
+                },
+            },
+        )
+        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["check", "-c", str(config)])
+        assert r.exit_code == 0
+        assert "阶段: commit — 通过" in r.output
+        assert "项检查通过" in r.output
+        assert "PASSED" not in r.output
+
+    def test_default_locale_keeps_english_output(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path)  # no locale → defaults to en
+        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["check", "-c", str(config)])
+        assert r.exit_code == 0
+        assert "PASSED" in r.output
+        assert "checks passed" in r.output
+        assert "阶段" not in r.output
+
+
 class TestReportFormats:
     """F1-F2: Report formatting integration."""
 

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -126,6 +126,37 @@ class TestFormatTerminal:
         output = format_terminal(_failed_report())
         assert "1/2" in output
 
+    def test_default_locale_uses_english_labels(self) -> None:
+        """Default locale keeps existing English output verbatim."""
+        output = format_terminal(_passed_report())
+        assert "Stage: commit — PASSED" in output
+        assert "2/2 checks passed, 0 failed" in output
+        assert "Total time" in output
+
+    def test_zh_cn_locale_localizes_headings(self) -> None:
+        """zh-CN localizes stage / summary / total_time labels and status."""
+        output = format_terminal(_passed_report(), locale="zh-CN")
+        assert "阶段: commit — 通过" in output
+        assert "2/2 项检查通过, 0 项失败" in output
+        assert "总耗时" in output
+        # PASS / FAIL / SKIP indicators remain ASCII for alignment
+        assert "[PASS]" in output
+        # English labels must not leak into zh-CN output
+        assert "PASSED" not in output
+        assert "Stage:" not in output
+
+    def test_zh_cn_locale_failure_heading(self) -> None:
+        """zh-CN locale shows 失败 when the report fails."""
+        output = format_terminal(_failed_report(), locale="zh-CN")
+        assert "阶段: push — 失败" in output
+        assert "1/2 项检查通过, 1 项失败" in output
+
+    def test_unknown_locale_falls_back_to_english(self) -> None:
+        """Unknown locale behaves like the default English labels."""
+        output = format_terminal(_passed_report(), locale="fr-FR")
+        assert "Stage: commit — PASSED" in output
+        assert "2/2 checks passed, 0 failed" in output
+
 
 # ---------------------------------------------------------------------------
 # TestFormatGate


### PR DESCRIPTION
## Summary

`ResolvedConfig.output.locale` existed, and `format_markdown` already honored it via Jinja templates, but `format_terminal` was English-only and the CLI never forwarded the locale anyway. `guard.yaml` → `output.locale: zh-CN` did nothing.

This PR wires the terminal path end-to-end.

## What is (and isn't) localized

**Localized — full-line headings:**

| English | 中文 |
|---|---|
| `Stage: commit — PASSED` | `阶段: commit — 通过` |
| `Stage: commit — FAILED` | `阶段: commit — 失败` |
| `2/3 checks passed, 1 failed` | `2/3 项检查通过, 1 项失败` |
| `Total time: 123ms` | `总耗时: 123ms` |

**Intentionally NOT localized** (stability / alignment):

- `[PASS]` / `[FAIL]` / `[SKIP]` per-check indicators
- `format_gate` output (shell hook consumes these as stable English tokens)
- Check names, durations, violation text (data, not labels)

Unknown locales fall back to English, matching `format_markdown`'s existing behavior.

## Changes

- `src/ac_guard/reporter/formatting.py` — new `_LABELS` table + `_labels_for()` helper; `format_terminal` grows a `locale="en"` parameter and pulls 5 label strings through the table.
- `src/ac_guard/cli/check.py` — `_format_report` grows a `locale` argument; `check_command` / `verify_command` / `run_command` all pass `resolved.output.locale`. `gate_run_command` untouched.

## Verified end-to-end

```
$ cat guard.yaml | grep locale
    locale: zh-CN

$ ac-guard check
阶段: commit — 通过

  [PASS] pre-commit:format-python (554ms)

1/1 项检查通过, 0 项失败
总耗时: 569ms
```

Default locale (no `output.locale`) is byte-for-byte identical to the pre-PR output:

```
Stage: commit — PASSED

  [PASS] pre-commit:format-python (432ms)

1/1 checks passed, 0 failed
Total time: 450ms
```

## Test plan

- [x] `pytest tests/` — 844 passed (+6 regression tests)
  - Unit: `test_default_locale_uses_english_labels`, `test_zh_cn_locale_localizes_headings`, `test_zh_cn_locale_failure_heading`, `test_unknown_locale_falls_back_to_english`
  - Integration: `TestLocalePropagation::test_zh_cn_locale_propagates_to_check_output`, `test_default_locale_keeps_english_output`
- [x] `pre-commit run` / `ruff check` clean
- [x] Manual E2E on clean project (see above)
- [ ] CI

## Out of scope

- No new locales (only the existing `en` / `zh-CN`).
- `format_gate` stays English — it feeds shell hooks that rely on stable tokens.
- `[PASS]` / `[FAIL]` / `[SKIP]` stay ASCII for alignment.
- Typer help / exception messages — separate concern.
- `post_pr_comment` caller wiring — tracked under [#66](https://github.com/ikroal/ai-code-guard/issues/66).

Closes #76