### PR TITLE
fix(audit): wire append_audit_log + rename policy.json → runtime.json (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / `[SKIP]` indicators stay ASCII for alignment. Unknown locales
   fall back to English.
   ([#76](https://github.com/ikroal/ai-code-guard/issues/76))
+- Audit logging is now actually written. Enforcer `evaluate()`
+  appends a JSON record to `.ac-guard/audit.jsonl` per policy
+  decision when `output.audit.enabled: true`, capturing timestamp /
+  agent / tool / operation / scheme / target / decision / reason /
+  matched_rule / policy_hash. `apply_retention()` is called at the
+  end of `ac-guard install` / `ac-guard update` so the
+  `output.audit.retention` field takes effect.
+  ([#75](https://github.com/ikroal/ai-code-guard/issues/75))
 
 ### Changed
 
+- **Breaking**: the Enforcer runtime cache file has been renamed from
+  `.ac-guard/policy.json` to `.ac-guard/runtime.json`. The file now
+  carries both behavior rules and audit config, so the new name
+  reflects that. `ac-guard install` / `update` delete the legacy
+  `policy.json` automatically on first run.
 - `code.commit.naming` is now a no-op that the checker surfaces as a
   `[SKIP]` result — the shortcut is reserved for a follow-up release
   ([#95](https://github.com/ikroal/ai-code-guard/issues/95)). The
@@ -109,7 +122,6 @@ and **code-quality gates** (`pre-commit` / `pre-push` Checker).
 
 ### Known Limitations
 
-- Audit logging is not yet wired into every Enforcer call path. ([#75](https://github.com/ikroal/ai-code-guard/issues/75))
 - `post_pr_comment` is not yet invoked automatically by the CLI; call it manually from CI for now. ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
 - HTTP requests have no retry/backoff; transient network failures surface directly. ([#67](https://github.com/ikroal/ai-code-guard/issues/67))
 - `code.commit.naming: true` is accepted but produces a `[SKIP]` result — a concrete naming check implementation is planned in a follow-up. ([#95](https://github.com/ikroal/ai-code-guard/issues/95))

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All check commands (`check`, `verify`, `status`) support `--format json` for mac
 
 ## How It Works
 
-`ac-guard install` reads `guard.yaml` and generates all artifacts at once — rule documents, hook scripts, `.pre-commit-config.yaml`, and `.ac-guard/policy.json`. No config parsing happens at runtime.
+`ac-guard install` reads `guard.yaml` and generates all artifacts at once — rule documents, hook scripts, `.pre-commit-config.yaml`, and `.ac-guard/runtime.json`. No config parsing happens at runtime.
 
 When the agent runs, its hook script loads the pre-built policy and matches each operation against the rules. Forbidden operations are blocked. Operations requiring approval prompt the user. Everything else is allowed. Every decision is logged to `.ac-guard/audit.jsonl`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -102,7 +102,7 @@ code:
 
 ## 工作原理
 
-`ac-guard install` 读取 `guard.yaml` 并一次性生成所有产物 — 规则文档、Hook 脚本、`.pre-commit-config.yaml` 和 `.ac-guard/policy.json`。运行时不做配置解析。
+`ac-guard install` 读取 `guard.yaml` 并一次性生成所有产物 — 规则文档、Hook 脚本、`.pre-commit-config.yaml` 和 `.ac-guard/runtime.json`。运行时不做配置解析。
 
 Agent 工作时，Hook 脚本加载预构建的策略文件，将每个操作与规则匹配。禁止的操作被阻止，需要审批的操作提示用户确认，其余放行。每次决策记录到 `.ac-guard/audit.jsonl`。
 

--- a/design/AI_GUARD_SYSTEM_DESIGN.md
+++ b/design/AI_GUARD_SYSTEM_DESIGN.md
@@ -371,7 +371,7 @@ AI Agent 工具调用
   Hook 脚本：协议转换（Agent 格式 → 统一 ToolCall）
   │
   Enforcer.evaluate():
-    E1 load_policy (从 policy.json)
+    E1 load_policy (从 runtime.json)
     E2 classify (确定操作类型和目标)
     E3 match (规则匹配)
     E4 decide (产出 PolicyDecision)
@@ -589,7 +589,7 @@ write:
 
 #### 5.3.4 规则来源追踪
 
-合并过程中，每条规则标记其来源，用于 `guard status --rules` 的展示和 policy.json 的存储：
+合并过程中，每条规则标记其来源，用于 `guard status --rules` 的展示和 runtime.json 的存储：
 
 | 来源标记 | 含义 |
 |---|---|
@@ -728,7 +728,7 @@ C1 内部流程：加载内置默认 → 逐个加载规则集并合并 → 加�
 | G2 | generate_hook_files | ResolvedConfig + AgentAdapter | list[FileSpec]（Hook 脚本 + 配置） |
 | G3 | generate_tool_configs | ResolvedConfig + ruleset files | list[FileSpec]（工具配置） |
 | G4 | generate_precommit_config | ResolvedConfig.code + languages | FileSpec（.pre-commit-config.yaml） |
-| G5 | generate_policy_cache | ResolvedConfig | FileSpec（policy.json） |
+| G5 | generate_policy_cache | ResolvedConfig | FileSpec（runtime.json） |
 | G6 | generate_git_hooks | — | list[FileSpec]（.git/hooks/*） |
 | G7 | write_artifacts | list[FileSpec] | 文件写入磁盘 |
 
@@ -803,19 +803,19 @@ install 为增量操作：新增 Agent 追加至已有列表，为全部 Agent �
 
 #### 6.4.1 职责与边界
 
-运行时规则匹配引擎。接收统一格式的 ToolCall，基于策略缓存（policy.json）执行判定，返回 PolicyDecision。Enforcer 不经过 CLI 入口，由安装时生成的 Hook 脚本直接调用。
+运行时规则匹配引擎。接收统一格式的 ToolCall，基于策略缓存（runtime.json）执行判定，返回 PolicyDecision。Enforcer 不经过 CLI 入口，由安装时生成的 Hook 脚本直接调用。
 
 #### 6.4.2 策略缓存机制
 
-install/update 时生成 `.ai-guard/policy.json`，包含合并后的最终行为策略（JSON 格式）及 config_hash。Enforcer 运行时直接加载此文件，无需解析 YAML。
+install/update 时生成 `.ai-guard/runtime.json`，包含合并后的最终行为策略（JSON 格式）及 config_hash。Enforcer 运行时直接加载此文件，无需解析 YAML。
 
-漂移检测：Enforcer 启动时比对当前 guard.yaml 的 hash 与 policy.json 中的 config_hash，不一致时向 stderr 输出警告，但不阻止执行（使用旧策略继续判定）。
+漂移检测：Enforcer 启动时比对当前 guard.yaml 的 hash 与 runtime.json 中的 config_hash，不一致时向 stderr 输出警告，但不阻止执行（使用旧策略继续判定）。
 
 #### 6.4.3 原语操作
 
 | 编号 | 原语 | 输入 | 输出 |
 |---|---|---|---|
-| E1 | load_policy | policy.json 路径 | Policy 对象 |
+| E1 | load_policy | runtime.json 路径 | Policy 对象 |
 | E2 | classify | tool_name, tool_args | (operation, scheme, target) |
 | E3 | match | target, rules | 命中的规则或 None |
 | E4 | decide | match 结果 | PolicyDecision (allow / deny / ask) |
@@ -837,8 +837,8 @@ Pattern 匹配支持两种模式：glob（默认）和 regex（`regex: true` 显
 
 | 异常场景 | 处理方式 | 理由 |
 |---|---|---|
-| policy.json 缺失（未 install） | 输出引导提示 + allow | 首次使用不阻塞 |
-| policy.json 解析失败 | **deny** + 错误提示 | fail-closed |
+| runtime.json 缺失（未 install） | 输出引导提示 + allow | 首次使用不阻塞 |
+| runtime.json 解析失败 | **deny** + 错误提示 | fail-closed |
 | 未知工具类型 | allow | 不在管控范围 |
 | Pattern 匹配崩溃 | **deny** + 错误提示 | fail-closed |
 | config_hash 不一致 | 警告 + 用旧策略继续 | 提醒但不阻塞 |
@@ -1116,7 +1116,7 @@ class ResolvedConfig:
 }
 ```
 
-#### policy.json
+#### runtime.json
 
 ```json
 {
@@ -1195,7 +1195,7 @@ class CheckReport:
 | Hook 脚本 + 配置 | G2 | Agent 特定的拦截脚本和注册配置 |
 | 工具配置（.clang-format 等） | G3 | 从规则集复制的工具配置文件 |
 | .pre-commit-config.yaml | G4 | pre-commit 框架配置 |
-| .ai-guard/policy.json | G5 | 策略缓存（Enforcer 消费） |
+| .ai-guard/runtime.json | G5 | 策略缓存（Enforcer 消费） |
 | .git/hooks/pre-commit, pre-push | G6 | Git Hook 脚本 |
 | .ai-guard/state.json | install 命令 | 安装状态记录 |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,7 +145,7 @@ You should see:
 AI Code Guard installed for: claude-code
 
 Generated 6 artifact(s):
-  .ac-guard/policy.json
+  .ac-guard/runtime.json
   .claude/hooks/interceptor.py
   .git/hooks/pre-commit
   .git/hooks/pre-push
@@ -162,7 +162,7 @@ your-python-project/
 ├── .pre-commit-config.yaml     # generated hook manifest
 ├── .ac-guard/
 │   ├── state.json              # install state (agents, artifacts)
-│   └── policy.json             # runtime policy cache
+│   └── runtime.json             # runtime policy cache
 ├── .claude/hooks/interceptor.py  # Claude Code pre_tool_use hook
 └── .git/hooks/
     ├── pre-commit              # → ac-guard gate run --stage commit
@@ -296,7 +296,7 @@ Updated 6 artifact(s) for agents: claude-code
 
 Two things happen under the hood:
 
-1. `.ac-guard/policy.json` (the runtime policy) now contains your new
+1. `.ac-guard/runtime.json` (the runtime policy) now contains your new
    forbidden pattern.
 2. `CLAUDE.md` gains a line under **Write Operations — Forbidden** describing
    the rule in natural language.

--- a/docs/getting-started_zh.md
+++ b/docs/getting-started_zh.md
@@ -138,7 +138,7 @@ ac-guard install --agent claude-code
 AI Code Guard installed for: claude-code
 
 Generated 6 artifact(s):
-  .ac-guard/policy.json
+  .ac-guard/runtime.json
   .claude/hooks/interceptor.py
   .git/hooks/pre-commit
   .git/hooks/pre-push
@@ -155,7 +155,7 @@ your-python-project/
 ├── .pre-commit-config.yaml       # 生成的钩子清单
 ├── .ac-guard/
 │   ├── state.json                # 安装状态（agents、工件清单）
-│   └── policy.json               # 运行时策略缓存
+│   └── runtime.json               # 运行时策略缓存
 ├── .claude/hooks/interceptor.py  # Claude Code pre_tool_use hook
 └── .git/hooks/
     ├── pre-commit                # → ac-guard gate run --stage commit
@@ -284,7 +284,7 @@ Updated 6 artifact(s) for agents: claude-code
 
 背后发生了两件事：
 
-1. `.ac-guard/policy.json`（运行时策略）里新增你的 forbidden 模式
+1. `.ac-guard/runtime.json`（运行时策略）里新增你的 forbidden 模式
 2. `CLAUDE.md` 在 **Write Operations — Forbidden** 一节多了一行自然语言
    描述
 

--- a/src/ac_guard/adapters/_templates/hooks/claude_code.j2
+++ b/src/ac_guard/adapters/_templates/hooks/claude_code.j2
@@ -33,7 +33,7 @@ def main():
     tool_input = input_data.get("tool_input", {})
 
     # Evaluate policy via Enforcer
-    result = evaluate(tool_name, tool_input, Path("."))
+    result = evaluate(tool_name, tool_input, Path("."), agent="claude-code")
 
     # Build reason string for deny/ask decisions
     reason = ""

--- a/src/ac_guard/adapters/_templates/hooks/cursor.j2
+++ b/src/ac_guard/adapters/_templates/hooks/cursor.j2
@@ -27,11 +27,11 @@ input=$(cat)
 # Parse tool call (Cursor uses different formats for different hooks)
 tool_name=$(echo "$input" | jq -r '.tool // .command // .name // "unknown"' 2>/dev/null || echo "unknown")
 
-# Build Enforcer input JSON
+# Build Enforcer input JSON (agent identifies the caller in audit records)
 enforcer_input=$(jq -n \
     --arg tn "$tool_name" \
     --argjson ti "$(echo "$input" | jq '.args // .arguments // {}' 2>/dev/null || echo '{}')" \
-    '{tool_name: $tn, tool_input: $ti}')
+    '{tool_name: $tn, tool_input: $ti, agent: "cursor"}')
 
 # Call Enforcer via Python subprocess
 enforcer_output=$(echo "$enforcer_input" | python3 -m ac_guard.enforcer 2>/dev/null || echo '{"decision": "deny"}')

--- a/src/ac_guard/adapters/_templates/hooks/opencode.j2
+++ b/src/ac_guard/adapters/_templates/hooks/opencode.j2
@@ -31,6 +31,7 @@ function evaluatePolicy(call: ToolCall): {
   const input = JSON.stringify({
     tool_name: call.tool,
     tool_input: call.args || {},
+    agent: "opencode",
   });
 
   try {

--- a/src/ac_guard/adapters/base.py
+++ b/src/ac_guard/adapters/base.py
@@ -107,7 +107,7 @@ class AgentAdapter(ABC):
 
         Args:
             behavior: BehaviorConfig containing behavior rules.
-                (Hook scripts may embed rules or reference policy.json)
+                (Hook scripts may embed rules or reference runtime.json)
 
         Returns:
             List of FileSpec objects for Hook-related files.

--- a/src/ac_guard/cli/install.py
+++ b/src/ac_guard/cli/install.py
@@ -33,7 +33,10 @@ from ac_guard.generator.core import (
 )
 from ac_guard.generator.exceptions import ArtifactWriteError
 from ac_guard.generator.models import STATE_FILE
+from ac_guard.reporter.audit import apply_retention
 from ac_guard.ruleset.cache import get_cache_dir
+
+_LEGACY_RUNTIME_CACHE = ".ac-guard/policy.json"
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -108,9 +111,13 @@ def _run_generator_pipeline(
         generate_precommit_config(resolved_config.code, resolved_config.languages)
     )
 
-    # G5: Policy cache
+    # G5: Policy cache (runtime.json — behavior + audit config)
     artifacts.append(
-        generate_policy_cache(resolved_config.behavior, resolved_config.config_hash)
+        generate_policy_cache(
+            resolved_config.behavior,
+            resolved_config.config_hash,
+            audit=resolved_config.output.audit,
+        )
     )
 
     # G6: Git hooks
@@ -223,6 +230,26 @@ def _load_ruleset_configs(
 # ---------------------------------------------------------------------------
 
 
+def _run_post_install_audit_maintenance(
+    project_root: Path, resolved: ResolvedConfig
+) -> None:
+    """Clean up legacy artifacts and apply audit retention.
+
+    Idempotent; safe to call at the end of both install and update.
+    Silent on I/O failure so it never blocks the pipeline.
+    """
+    # One-time removal of the legacy `.ac-guard/policy.json` (renamed to
+    # runtime.json in v0.1.0). No-op once the file is gone.
+    legacy = project_root / _LEGACY_RUNTIME_CACHE
+    with contextlib.suppress(OSError):
+        if legacy.is_file():
+            legacy.unlink()
+
+    audit_cfg = resolved.output.audit
+    if audit_cfg.enabled and audit_cfg.retention > 0:
+        apply_retention(project_root, audit_cfg.path, audit_cfg.retention)
+
+
 def install_command(
     agents: list[str],
     project_root: Path,
@@ -289,6 +316,8 @@ def install_command(
     state = create_state(all_agents, resolved.config_hash, written_paths)
     write_state(project_root, state)
 
+    _run_post_install_audit_maintenance(project_root, resolved)
+
     _print_install_summary(written_paths, all_agents)
 
 
@@ -344,6 +373,8 @@ def update_command(
         existing_state.installed_agents, resolved.config_hash, written_paths
     )
     write_state(project_root, state)
+
+    _run_post_install_audit_maintenance(project_root, resolved)
 
     agents_str = ", ".join(existing_state.installed_agents)
     print(f"Updated {len(written_paths)} artifact(s) for agents: {agents_str}")

--- a/src/ac_guard/enforcer/cli.py
+++ b/src/ac_guard/enforcer/cli.py
@@ -8,7 +8,10 @@ Usage:
         python3 -m ac_guard.enforcer
 
 Input (stdin JSON):
-    {"tool_name": "...", "tool_input": {...}}
+    {"tool_name": "...", "tool_input": {...}, "agent": "cursor", "project_root": "."}
+    Only ``tool_name`` and ``tool_input`` are required. ``agent`` is
+    recorded in the audit log to identify the caller; ``project_root``
+    defaults to ``.``.
 
 Output (stdout JSON):
     {"decision": "allow|deny|ask", "reason": "...", "pattern": "..."}
@@ -37,8 +40,9 @@ def main() -> None:
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
     project_root = Path(input_data.get("project_root", "."))
+    agent = input_data.get("agent", "")
 
-    result = evaluate(tool_name, tool_input, project_root)
+    result = evaluate(tool_name, tool_input, project_root, agent=agent)
 
     output: dict[str, str] = {"decision": result.decision.value}
     if result.matched_rule and result.matched_rule.reason:

--- a/src/ac_guard/enforcer/engine.py
+++ b/src/ac_guard/enforcer/engine.py
@@ -12,9 +12,12 @@ from ac_guard.enforcer.classifier import classify
 from ac_guard.enforcer.exceptions import PolicyCorruptError
 from ac_guard.enforcer.matcher import Decision, PolicyDecision, evaluate_rules
 from ac_guard.enforcer.policy import load_policy
+from ac_guard.reporter.audit import append_audit_log
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from ac_guard.config.models import AuditConfig
 
 __all__ = ["evaluate"]
 
@@ -23,16 +26,22 @@ def evaluate(
     tool_name: str,
     tool_input: dict[str, Any],
     project_root: Path,
+    agent: str = "",
 ) -> PolicyDecision:
     """Evaluate a tool call against the installed policy.
 
     Orchestrates the full Enforcer pipeline:
-    E1 (load_policy) -> E2 (classify) -> E3/E4 (match + decide).
+    E1 (load_policy) -> E2 (classify) -> E3/E4 (match + decide) ->
+    R3 (append_audit_log when enabled).
 
     Args:
         tool_name: Tool name from the AI agent.
         tool_input: Tool arguments dict.
         project_root: Path to project root directory.
+        agent: Identifier of the invoking agent (``"claude-code"``,
+            ``"cursor"``, ``"opencode"``, ...). Empty string is
+            accepted for backward-compatible callers but leaves the
+            audit record's ``agent`` field empty.
 
     Returns:
         PolicyDecision with the decision, classification context,
@@ -42,6 +51,8 @@ def evaluate(
     try:
         policy_result = load_policy(project_root)
     except PolicyCorruptError:
+        # Fail-closed: deny without auditing (no policy context means
+        # no trustworthy audit record anyway).
         return PolicyDecision(
             decision=Decision.DENY,
             operation="",
@@ -63,7 +74,7 @@ def evaluate(
             policy_hash="",
         )
 
-    behavior, config_hash = policy_result
+    behavior, config_hash, audit_cfg = policy_result
 
     # E2: Classify tool call
     operation, scheme, target = classify(tool_name, tool_input)
@@ -100,7 +111,7 @@ def evaluate(
     # E3/E4: Match and decide
     match_result = evaluate_rules(target, scheme, operation_rules)
 
-    return PolicyDecision(
+    decision = PolicyDecision(
         decision=match_result.decision,
         operation=operation,
         scheme=scheme,
@@ -109,3 +120,24 @@ def evaluate(
         tier=match_result.tier,
         policy_hash=config_hash,
     )
+
+    # R3: Audit. Only real decisions (post-classify, post-match) are
+    # audited — early returns on "corrupt", "no_policy", and
+    # "unknown_tool" are intentionally skipped.
+    _maybe_audit(decision, tool_name, agent, project_root, audit_cfg)
+
+    return decision
+
+
+def _maybe_audit(
+    decision: PolicyDecision,
+    tool_name: str,
+    agent: str,
+    project_root: Path,
+    audit_cfg: AuditConfig,
+) -> None:
+    """Append an audit record when auditing is enabled."""
+    if not audit_cfg.enabled:
+        return
+    record = decision.to_audit_record(tool_name, agent)
+    append_audit_log(record, project_root, audit_cfg.path)

--- a/src/ac_guard/enforcer/exceptions.py
+++ b/src/ac_guard/enforcer/exceptions.py
@@ -10,7 +10,7 @@ class EnforcerError(Exception):
 
 
 class PolicyCorruptError(EnforcerError):
-    """Raised when policy.json cannot be parsed.
+    """Raised when runtime.json cannot be parsed.
 
     Attributes:
         path: Path to the corrupted policy file.

--- a/src/ac_guard/enforcer/matcher.py
+++ b/src/ac_guard/enforcer/matcher.py
@@ -84,7 +84,7 @@ class PolicyDecision:
         matched_rule: The rule that triggered the decision,
             or None if no rule matched.
         tier: Which tier matched.
-        policy_hash: Config hash from policy.json.
+        policy_hash: Config hash from runtime.json.
     """
 
     decision: Decision

--- a/src/ac_guard/enforcer/policy.py
+++ b/src/ac_guard/enforcer/policy.py
@@ -1,6 +1,6 @@
 """Enforcer policy loader (E1 primitive).
 
-Loads ``.ac-guard/policy.json`` and reconstructs a
+Loads ``.ac-guard/runtime.json`` and reconstructs a
 :class:`BehaviorConfig` for runtime rule evaluation.
 """
 
@@ -10,6 +10,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from ac_guard.config.models import (
+    AuditConfig,
     BehaviorConfig,
     OperationRules,
     Rule,
@@ -21,43 +22,60 @@ if TYPE_CHECKING:
 
 __all__ = ["load_policy"]
 
-_POLICY_FILE = ".ac-guard/policy.json"
+_RUNTIME_FILE = ".ac-guard/runtime.json"
 
 
-def load_policy(project_root: Path) -> tuple[BehaviorConfig, str] | None:
-    """Load policy from ``.ac-guard/policy.json``.
+def load_policy(
+    project_root: Path,
+) -> tuple[BehaviorConfig, str, AuditConfig] | None:
+    """Load Enforcer runtime cache from ``.ac-guard/runtime.json``.
 
     Args:
         project_root: Path to the project root directory.
 
     Returns:
-        Tuple of (BehaviorConfig, config_hash) if policy exists,
-        None if no policy file is installed (first-time use).
+        Tuple of (BehaviorConfig, config_hash, AuditConfig) if the
+        cache exists, ``None`` if no runtime file is installed
+        (first-time use). When the cache predates the audit section
+        (legacy install), a disabled ``AuditConfig`` is returned so
+        the caller can proceed without special-casing.
 
     Raises:
-        PolicyCorruptError: If policy.json exists but cannot
+        PolicyCorruptError: If runtime.json exists but cannot
             be parsed as valid JSON.
     """
-    policy_path = project_root / _POLICY_FILE
-    if not policy_path.is_file():
+    runtime_path = project_root / _RUNTIME_FILE
+    if not runtime_path.is_file():
         return None
 
     try:
-        data = json.loads(policy_path.read_text(encoding="utf-8"))
+        data = json.loads(runtime_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
-        raise PolicyCorruptError(str(policy_path), str(e)) from None
+        raise PolicyCorruptError(str(runtime_path), str(e)) from None
 
     config_hash = data.get("config_hash", "")
     behavior_raw = data.get("behavior", {})
     behavior = _deserialize_behavior(behavior_raw)
-    return behavior, config_hash
+    audit = _deserialize_audit(data.get("audit"))
+    return behavior, config_hash, audit
+
+
+def _deserialize_audit(raw: dict[str, Any] | None) -> AuditConfig:
+    """Reconstruct AuditConfig; missing section defaults to disabled."""
+    if raw is None:
+        return AuditConfig(enabled=False)
+    return AuditConfig(
+        enabled=bool(raw.get("enabled", False)),
+        path=raw.get("path", ".ac-guard/audit.jsonl"),
+        retention=int(raw.get("retention_days", 30)),
+    )
 
 
 def _deserialize_behavior(raw: dict[str, Any]) -> BehaviorConfig:
     """Reconstruct BehaviorConfig from serialized dict.
 
     Args:
-        raw: Behavior dict from policy.json.
+        raw: Behavior dict from runtime.json.
 
     Returns:
         BehaviorConfig with deserialized rules.
@@ -73,7 +91,7 @@ def _deserialize_operation_rules(raw: dict[str, Any]) -> OperationRules:
     """Reconstruct OperationRules from serialized dict.
 
     Args:
-        raw: Operation rules dict from policy.json.
+        raw: Operation rules dict from runtime.json.
 
     Returns:
         OperationRules with deserialized rule lists.
@@ -91,7 +109,7 @@ def _deserialize_rule(raw: dict[str, Any]) -> Rule:
     """Reconstruct Rule from serialized dict.
 
     Args:
-        raw: Rule dict from policy.json.
+        raw: Rule dict from runtime.json.
 
     Returns:
         Rule with pattern, reason, message, regex, and source.

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -33,6 +33,7 @@ from ac_guard.shared.types import (
 if TYPE_CHECKING:
     from ac_guard.adapters.base import AgentAdapter
     from ac_guard.config.models import (
+        AuditConfig,
         BehaviorConfig,
         CodeConfig,
         LanguageTools,
@@ -133,7 +134,7 @@ def generate_hook_files(
     Args:
         adapters: List of AgentAdapter instances.
         behavior: BehaviorConfig (Hook scripts may embed rules or
-            reference policy.json).
+            reference runtime.json).
 
     Returns:
         List of FileSpec objects for Hook scripts and configs.
@@ -375,31 +376,46 @@ def delete_artifacts(
 def generate_policy_cache(
     behavior: BehaviorConfig,
     config_hash: str,
+    audit: AuditConfig | None = None,
 ) -> FileSpec:
-    """Generate policy.json for Enforcer runtime (G5).
+    """Generate ``.ac-guard/runtime.json`` for Enforcer runtime (G5).
 
-    The policy cache is consumed by Enforcer at runtime to enforce
-    behavior constraints without re-parsing guard.yaml.
+    This file is the Enforcer runtime cache read by hook subprocesses.
+    It holds everything the hook-side needs to make decisions without
+    re-parsing guard.yaml: behavior rules, policy hash, and audit
+    configuration. The historical filename ``policy.json`` was
+    retired in v0.1.0 — ``runtime.json`` better reflects that the
+    cache now carries more than just policy data.
 
     Args:
         behavior: BehaviorConfig containing read/write/execute rules.
         config_hash: SHA hash of guard.yaml for drift detection.
+        audit: AuditConfig controlling whether ``evaluate()`` writes
+            an audit record per decision. ``None`` is equivalent to
+            omitting the audit section (kept for callsite backward
+            compatibility during tests).
 
     Returns:
-        FileSpec for .ac-guard/policy.json
+        FileSpec for ``.ac-guard/runtime.json``.
     """
-    policy_data = {
+    runtime_data: dict[str, object] = {
         "config_hash": config_hash,
         "behavior": _serialize_behavior(behavior),
     }
+    if audit is not None:
+        runtime_data["audit"] = {
+            "enabled": audit.enabled,
+            "path": audit.path,
+            "retention_days": audit.retention,
+        }
     return FileSpec(
-        path=".ac-guard/policy.json",
-        content=json.dumps(policy_data, indent=2),
+        path=".ac-guard/runtime.json",
+        content=json.dumps(runtime_data, indent=2),
     )
 
 
 def _serialize_behavior(behavior: BehaviorConfig) -> dict:
-    """Serialize BehaviorConfig to dict for policy.json."""
+    """Serialize BehaviorConfig to dict for runtime.json."""
     return {
         "read": _serialize_operation_rules(behavior.read),
         "write": _serialize_operation_rules(behavior.write),
@@ -408,7 +424,7 @@ def _serialize_behavior(behavior: BehaviorConfig) -> dict:
 
 
 def _serialize_operation_rules(rules: OperationRules) -> dict:
-    """Serialize OperationRules to dict for policy.json."""
+    """Serialize OperationRules to dict for runtime.json."""
     return {
         "forbidden": [_serialize_rule(r) for r in rules.forbidden],
         "require_approval": [_serialize_rule(r) for r in rules.require_approval],
@@ -417,7 +433,7 @@ def _serialize_operation_rules(rules: OperationRules) -> dict:
 
 
 def _serialize_rule(rule: Rule) -> dict:
-    """Serialize a single Rule to dict for policy.json.
+    """Serialize a single Rule to dict for runtime.json.
 
     Only includes non-default fields to keep the output minimal.
     """

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -403,7 +403,7 @@ class TestSystemExecuteRulesE2E:
 
         import json
 
-        policy = json.loads((tmp_path / ".ac-guard" / "policy.json").read_text())
+        policy = json.loads((tmp_path / ".ac-guard" / "runtime.json").read_text())
         patterns = {
             rule["pattern"] for rule in policy["behavior"]["execute"]["forbidden"]
         }

--- a/tests/integration/test_enforcer_e2e.py
+++ b/tests/integration/test_enforcer_e2e.py
@@ -29,13 +29,13 @@ def _init_and_install(tmp_path: Path, agents: str = "claude-code") -> None:
 
 
 class TestEnforcerPipeline:
-    """Enforcer evaluate() with real policy.json from install."""
+    """Enforcer evaluate() with real runtime.json from install."""
 
     def test_install_then_evaluate(self, tmp_path: Path) -> None:
-        """install generates policy.json that evaluate() can use."""
+        """install generates runtime.json that evaluate() can use."""
         _init_and_install(tmp_path)
-        # policy.json should exist
-        assert (tmp_path / ".ac-guard" / "policy.json").is_file()
+        # runtime.json should exist
+        assert (tmp_path / ".ac-guard" / "runtime.json").is_file()
         # Evaluate should work (system protection rules present)
         result = evaluate("Write", {"file_path": "src/main.py"}, tmp_path)
         assert result.decision in (Decision.ALLOW, Decision.ASK, Decision.DENY)
@@ -116,17 +116,16 @@ class TestAuditLoggingE2E:
     """Audit logging with real Enforcer decisions."""
 
     def test_evaluate_then_audit(self, tmp_path: Path) -> None:
-        """Evaluate + audit produces correct JSON Lines record."""
+        """evaluate() auto-audits when audit is enabled (standard preset)."""
         _init_and_install(tmp_path)
 
-        result = evaluate("Write", {"file_path": "guard.yaml"}, tmp_path)
-        record = result.to_audit_record("Write", "claude-code")
-        append_audit_log(record, tmp_path)
+        evaluate("Write", {"file_path": "guard.yaml"}, tmp_path, agent="claude-code")
 
         audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
         assert audit_path.is_file()
-        content = audit_path.read_text()
-        parsed = json.loads(content.strip())
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
         assert parsed["agent"] == "claude-code"
         assert parsed["tool"] == "Write"
         assert parsed["decision"] in ("allow", "deny", "ask")
@@ -142,11 +141,10 @@ class TestAuditLoggingE2E:
             ("Bash", {"command": "git status"}),
         ]
         for tool_name, tool_input in tool_calls:
-            result = evaluate(tool_name, tool_input, tmp_path)
-            record = result.to_audit_record(tool_name, "claude-code")
-            append_audit_log(record, tmp_path)
+            evaluate(tool_name, tool_input, tmp_path, agent="claude-code")
 
         audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert audit_path.is_file()
         lines = audit_path.read_text().strip().split("\n")
         assert len(lines) == 3
 
@@ -156,6 +154,7 @@ class TestAuditLoggingE2E:
 
         # Write an old record manually
         audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
         old_record = json.dumps(
             {
                 "timestamp": "2020-01-01T00:00:00+00:00",
@@ -164,10 +163,8 @@ class TestAuditLoggingE2E:
         )
         audit_path.write_text(old_record + "\n")
 
-        # Add a fresh record via evaluate
-        result = evaluate("Read", {"file_path": "src/main.py"}, tmp_path)
-        record = result.to_audit_record("Read", "claude-code")
-        append_audit_log(record, tmp_path)
+        # Add a fresh record via evaluate (auto-audits)
+        evaluate("Read", {"file_path": "src/main.py"}, tmp_path, agent="claude-code")
 
         # Retention should remove the old one
         removed = apply_retention(tmp_path, retention_days=30)
@@ -181,16 +178,16 @@ class TestErrorRecovery:
     """Error scenarios and fail-closed behavior."""
 
     def test_no_policy_allows_all(self, tmp_path: Path) -> None:
-        """Without policy.json, all operations are allowed."""
+        """Without runtime.json, all operations are allowed."""
         result = evaluate("Write", {"file_path": ".git/config"}, tmp_path)
         assert result.decision == Decision.ALLOW
         assert result.tier == "no_policy"
 
     def test_corrupt_policy_denies(self, tmp_path: Path) -> None:
-        """Corrupt policy.json results in deny (fail-closed)."""
+        """Corrupt runtime.json results in deny (fail-closed)."""
         policy_dir = tmp_path / ".ac-guard"
         policy_dir.mkdir(parents=True)
-        (policy_dir / "policy.json").write_text("{{{bad json")
+        (policy_dir / "runtime.json").write_text("{{{bad json")
         result = evaluate("Write", {"file_path": "test.py"}, tmp_path)
         assert result.decision == Decision.DENY
         assert result.tier == "error"

--- a/tests/unit/test_cli/test_install.py
+++ b/tests/unit/test_cli/test_install.py
@@ -41,7 +41,7 @@ def installed_project(project_with_config: Path) -> Path:
         ac_guard_version="0.1.0",
         installed_agents=["claude-code"],
         config_hash="abcd1234",
-        artifacts=["CLAUDE.md", ".ac-guard/policy.json"],
+        artifacts=["CLAUDE.md", ".ac-guard/runtime.json"],
     )
     state_path = project_with_config / STATE_FILE
     state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -49,7 +49,7 @@ def installed_project(project_with_config: Path) -> Path:
     # Create the artifact files so uninstall can delete them
     (project_with_config / "CLAUDE.md").write_text("# Rules\n")
     policy_dir = project_with_config / ".ac-guard"
-    (policy_dir / "policy.json").write_text("{}")
+    (policy_dir / "runtime.json").write_text("{}")
     return project_with_config
 
 

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -46,7 +46,7 @@ def _write_state(
         ac_guard_version="0.1.0",
         installed_agents=agents or ["claude-code"],
         config_hash=config_hash,
-        artifacts=artifacts or ["CLAUDE.md", ".ac-guard/policy.json"],
+        artifacts=artifacts or ["CLAUDE.md", ".ac-guard/runtime.json"],
     )
     state_path = project_root / STATE_FILE
     state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -64,11 +64,11 @@ def installed_project(tmp_path: Path) -> Path:
         tmp_path,
         agents=["claude-code"],
         config_hash=config_hash,
-        artifacts=["CLAUDE.md", ".ac-guard/policy.json", ".pre-commit-config.yaml"],
+        artifacts=["CLAUDE.md", ".ac-guard/runtime.json", ".pre-commit-config.yaml"],
     )
     # Create actual artifact files
     (tmp_path / "CLAUDE.md").write_text("# Rules\n")
-    (tmp_path / ".ac-guard" / "policy.json").write_text(
+    (tmp_path / ".ac-guard" / "runtime.json").write_text(
         json.dumps({"config_hash": config_hash})
     )
     (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")

--- a/tests/unit/test_enforcer/test_cli.py
+++ b/tests/unit/test_enforcer/test_cli.py
@@ -24,10 +24,10 @@ def _run_enforcer(input_data: dict, project_root: Path) -> dict:
 
 
 def _write_policy(project_root: Path, policy_data: dict) -> None:
-    """Write a policy.json file."""
+    """Write a runtime.json file."""
     policy_dir = project_root / ".ac-guard"
     policy_dir.mkdir(parents=True, exist_ok=True)
-    (policy_dir / "policy.json").write_text(
+    (policy_dir / "runtime.json").write_text(
         json.dumps(policy_data, indent=2), encoding="utf-8"
     )
 
@@ -60,7 +60,7 @@ class TestEnforcerCli:
     """Tests for python3 -m ac_guard.enforcer."""
 
     def test_no_policy_allows(self, tmp_path: Path) -> None:
-        """No policy.json returns allow."""
+        """No runtime.json returns allow."""
         result = _run_enforcer(
             {"tool_name": "Write", "tool_input": {"file_path": ".git/config"}},
             tmp_path,
@@ -98,3 +98,28 @@ class TestEnforcerCli:
         )
         output = json.loads(result.stdout.strip())
         assert output["decision"] == "deny"
+
+
+class TestEnforcerCliAudit:
+    """Regression for #75: subprocess entry threads agent into audit."""
+
+    def test_agent_from_stdin_is_recorded(self, tmp_path: Path) -> None:
+        policy = _standard_policy()
+        policy["audit"] = {
+            "enabled": True,
+            "path": ".ac-guard/audit.jsonl",
+            "retention_days": 30,
+        }
+        _write_policy(tmp_path, policy)
+        _run_enforcer(
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": ".git/config"},
+                "agent": "cursor",
+            },
+            tmp_path,
+        )
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert audit_path.is_file()
+        record = json.loads(audit_path.read_text().strip().split("\n")[0])
+        assert record["agent"] == "cursor"

--- a/tests/unit/test_enforcer/test_engine.py
+++ b/tests/unit/test_enforcer/test_engine.py
@@ -10,10 +10,10 @@ from ac_guard.enforcer.matcher import Decision, PolicyDecision
 
 
 def _write_policy(project_root: Path, policy_data: dict) -> None:
-    """Write a policy.json file."""
+    """Write a runtime.json file."""
     policy_dir = project_root / ".ac-guard"
     policy_dir.mkdir(parents=True, exist_ok=True)
-    (policy_dir / "policy.json").write_text(
+    (policy_dir / "runtime.json").write_text(
         json.dumps(policy_data, indent=2), encoding="utf-8"
     )
 
@@ -74,16 +74,16 @@ class TestEvaluateNoPolicy:
     """Tests when no policy is installed."""
 
     def test_no_policy_allows_all(self, tmp_path: Path) -> None:
-        """Without policy.json, all operations are allowed."""
+        """Without runtime.json, all operations are allowed."""
         result = evaluate("Write", {"file_path": ".git/config"}, tmp_path)
         assert result.decision == Decision.ALLOW
         assert result.tier == "no_policy"
 
     def test_corrupt_policy_denies(self, tmp_path: Path) -> None:
-        """Corrupt policy.json results in deny."""
+        """Corrupt runtime.json results in deny."""
         policy_dir = tmp_path / ".ac-guard"
         policy_dir.mkdir(parents=True)
-        (policy_dir / "policy.json").write_text("{{invalid json")
+        (policy_dir / "runtime.json").write_text("{{invalid json")
         result = evaluate("Write", {"file_path": "test.py"}, tmp_path)
         assert result.decision == Decision.DENY
         assert result.tier == "error"
@@ -161,3 +161,71 @@ class TestEvaluateUnknownTool:
         result = evaluate("SomeFutureTool", {"arg": "val"}, tmp_path)
         assert result.decision == Decision.ALLOW
         assert result.tier == "unknown_tool"
+
+
+def _policy_with_audit(enabled: bool) -> dict:
+    policy = _standard_policy()
+    policy["audit"] = {
+        "enabled": enabled,
+        "path": ".ac-guard/audit.jsonl",
+        "retention_days": 30,
+    }
+    return policy
+
+
+class TestEvaluateAuditWiring:
+    """Regression for #75: evaluate() writes audit when enabled."""
+
+    def test_writes_audit_when_enabled(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, _policy_with_audit(enabled=True))
+        evaluate(
+            "Write",
+            {"file_path": "guard.yaml"},
+            tmp_path,
+            agent="claude-code",
+        )
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert audit_path.is_file()
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["agent"] == "claude-code"
+        assert record["tool"] == "Write"
+        assert record["decision"] == "ask"
+
+    def test_does_not_audit_when_disabled(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, _policy_with_audit(enabled=False))
+        evaluate(
+            "Write",
+            {"file_path": "guard.yaml"},
+            tmp_path,
+            agent="claude-code",
+        )
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert not audit_path.exists()
+
+    def test_missing_audit_section_defaults_disabled(self, tmp_path: Path) -> None:
+        """Legacy runtime.json without an audit section is treated as off."""
+        _write_policy(tmp_path, _standard_policy())
+        evaluate(
+            "Write",
+            {"file_path": "guard.yaml"},
+            tmp_path,
+            agent="claude-code",
+        )
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert not audit_path.exists()
+
+    def test_unknown_tool_skips_audit(self, tmp_path: Path) -> None:
+        """Early return on unknown_tool must not write audit."""
+        _write_policy(tmp_path, _policy_with_audit(enabled=True))
+        evaluate("SomeFutureTool", {"arg": "val"}, tmp_path, agent="claude-code")
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        assert not audit_path.exists()
+
+    def test_passes_agent_to_record(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, _policy_with_audit(enabled=True))
+        evaluate("Write", {"file_path": "guard.yaml"}, tmp_path, agent="cursor")
+        audit_path = tmp_path / ".ac-guard" / "audit.jsonl"
+        record = json.loads(audit_path.read_text().strip().split("\n")[0])
+        assert record["agent"] == "cursor"

--- a/tests/unit/test_enforcer/test_exceptions.py
+++ b/tests/unit/test_enforcer/test_exceptions.py
@@ -10,19 +10,19 @@ class TestPolicyCorruptError:
 
     def test_inherits_enforcer_error(self) -> None:
         """PolicyCorruptError is an EnforcerError."""
-        err = PolicyCorruptError("/path/policy.json", "bad json")
+        err = PolicyCorruptError("/path/runtime.json", "bad json")
         assert isinstance(err, EnforcerError)
 
     def test_attributes(self) -> None:
         """PolicyCorruptError stores path and detail."""
-        err = PolicyCorruptError("/path/policy.json", "parse error")
-        assert err.path == "/path/policy.json"
+        err = PolicyCorruptError("/path/runtime.json", "parse error")
+        assert err.path == "/path/runtime.json"
         assert err.detail == "parse error"
 
     def test_str_contains_path(self) -> None:
         """String representation contains the file path."""
-        err = PolicyCorruptError("/path/policy.json")
-        assert "/path/policy.json" in str(err)
+        err = PolicyCorruptError("/path/runtime.json")
+        assert "/path/runtime.json" in str(err)
 
 
 class TestEnforcerError:

--- a/tests/unit/test_enforcer/test_policy.py
+++ b/tests/unit/test_enforcer/test_policy.py
@@ -13,10 +13,10 @@ from ac_guard.enforcer.policy import load_policy
 
 
 def _write_policy(project_root: Path, policy_data: dict) -> None:
-    """Write a policy.json file."""
+    """Write a runtime.json file."""
     policy_dir = project_root / ".ac-guard"
     policy_dir.mkdir(parents=True, exist_ok=True)
-    (policy_dir / "policy.json").write_text(
+    (policy_dir / "runtime.json").write_text(
         json.dumps(policy_data, indent=2), encoding="utf-8"
     )
 
@@ -25,7 +25,7 @@ class TestLoadPolicy:
     """Tests for load_policy function."""
 
     def test_no_policy_returns_none(self, tmp_path: Path) -> None:
-        """Missing policy.json returns None."""
+        """Missing runtime.json returns None."""
         result = load_policy(tmp_path)
         assert result is None
 
@@ -33,12 +33,12 @@ class TestLoadPolicy:
         """Corrupted JSON raises PolicyCorruptError."""
         policy_dir = tmp_path / ".ac-guard"
         policy_dir.mkdir(parents=True)
-        (policy_dir / "policy.json").write_text("not valid json{{{")
+        (policy_dir / "runtime.json").write_text("not valid json{{{")
         with pytest.raises(PolicyCorruptError):
             load_policy(tmp_path)
 
     def test_loads_valid_policy(self, tmp_path: Path) -> None:
-        """Valid policy.json returns (BehaviorConfig, config_hash)."""
+        """Valid runtime.json returns (BehaviorConfig, config_hash)."""
         _write_policy(
             tmp_path,
             {
@@ -52,7 +52,7 @@ class TestLoadPolicy:
         )
         result = load_policy(tmp_path)
         assert result is not None
-        behavior, config_hash = result
+        behavior, config_hash, _audit = result
         assert isinstance(behavior, BehaviorConfig)
         assert config_hash == "abcd1234"
 
@@ -89,7 +89,7 @@ class TestLoadPolicy:
         )
         result = load_policy(tmp_path)
         assert result is not None
-        behavior, _ = result
+        behavior, _, _audit = result
         assert len(behavior.write.forbidden) == 1
         assert behavior.write.forbidden[0].pattern == "file:.git/**"
         assert behavior.write.forbidden[0].reason == "Git internals"
@@ -121,7 +121,7 @@ class TestLoadPolicy:
         )
         result = load_policy(tmp_path)
         assert result is not None
-        behavior, _ = result
+        behavior, _, _audit = result
         assert behavior.execute.forbidden[0].regex is True
 
     def test_empty_behavior(self, tmp_path: Path) -> None:
@@ -139,5 +139,39 @@ class TestLoadPolicy:
         )
         result = load_policy(tmp_path)
         assert result is not None
-        behavior, _ = result
+        behavior, _, _audit = result
         assert behavior.read.forbidden == []
+
+    def test_audit_section_parsed(self, tmp_path: Path) -> None:
+        _write_policy(
+            tmp_path,
+            {
+                "config_hash": "h",
+                "behavior": {"read": {}, "write": {}, "execute": {}},
+                "audit": {
+                    "enabled": True,
+                    "path": ".ac-guard/audit.jsonl",
+                    "retention_days": 90,
+                },
+            },
+        )
+        result = load_policy(tmp_path)
+        assert result is not None
+        _, _, audit = result
+        assert audit.enabled is True
+        assert audit.path == ".ac-guard/audit.jsonl"
+        assert audit.retention == 90
+
+    def test_missing_audit_section_defaults_disabled(self, tmp_path: Path) -> None:
+        """Legacy cache without audit section is loaded as disabled."""
+        _write_policy(
+            tmp_path,
+            {
+                "config_hash": "h",
+                "behavior": {"read": {}, "write": {}, "execute": {}},
+            },
+        )
+        result = load_policy(tmp_path)
+        assert result is not None
+        _, _, audit = result
+        assert audit.enabled is False

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -444,7 +444,7 @@ class TestGeneratePolicyCache:
         behavior = BehaviorConfig.empty()
         result = generate_policy_cache(behavior, "abc123")
         assert isinstance(result, FileSpec)
-        assert result.path == ".ac-guard/policy.json"
+        assert result.path == ".ac-guard/runtime.json"
 
     def test_includes_config_hash(self) -> None:
         behavior = BehaviorConfig.empty()
@@ -495,6 +495,25 @@ class TestGeneratePolicyCache:
         assert "reason" not in rule
         assert "message" not in rule
         assert "regex" not in rule
+
+    def test_runtime_cache_includes_audit_section(self) -> None:
+        from ac_guard.config.models import AuditConfig
+
+        behavior = BehaviorConfig.empty()
+        audit = AuditConfig(enabled=True, path=".ac-guard/audit.jsonl", retention=60)
+        result = generate_policy_cache(behavior, "hash", audit=audit)
+        data = json.loads(result.content)
+        assert data["audit"] == {
+            "enabled": True,
+            "path": ".ac-guard/audit.jsonl",
+            "retention_days": 60,
+        }
+
+    def test_runtime_cache_omits_audit_when_none(self) -> None:
+        behavior = BehaviorConfig.empty()
+        result = generate_policy_cache(behavior, "hash")
+        data = json.loads(result.content)
+        assert "audit" not in data
 
     def test_includes_regex_flag(self) -> None:
         behavior = BehaviorConfig(


### PR DESCRIPTION
## Summary

Three coupled changes to make audit logging actually work end-to-end:

1. **Rename** `.ac-guard/policy.json` → `.ac-guard/runtime.json`. The file now holds both behavior rules and audit config; the old name was misleading. v0.1.0 pre-release = no backward-compat shim; `install` / `update` silently remove any lingering `policy.json`.
2. **Extend** `runtime.json` with an `audit` section sourced from `ResolvedConfig.output.audit`. `load_policy` returns `(BehaviorConfig, hash, AuditConfig)`; legacy caches without the section are treated as `enabled=false`.
3. **Wire** `evaluate()` to call `append_audit_log` when `audit.enabled`. Evaluator gains an `agent` parameter; Python-direct hook (`claude_code.j2`) passes `"claude-code"`, shell/TS subprocess hooks (`cursor.j2`, `opencode.j2`) include `"agent"` in their stdin JSON; `enforcer/cli.py` forwards it.

`apply_retention()` is called at the end of `install` and `update` so `output.audit.retention` actually prunes the log.

Design-level explanation of the bug and why it was missed is in the CHANGELOG's **Fixed** entry; summary: the audit infrastructure (`reporter/audit.py`, `PolicyDecision.to_audit_record`, `AuditConfig`) shipped with M2 WP2.3 but the final wire-up step to `evaluate()` was never merged. Compounding that, `AuditConfig` lived only in CLI-side `ResolvedConfig`, invisible to hook subprocesses that needed it.

## Verified end-to-end

**Claude Code (Python direct):**
```
$ echo '{"tool_name":"Write","tool_input":{"file_path":"guard.yaml"}}' | python3 .claude/hooks/interceptor.py
{"hookSpecificOutput": {"permissionDecision": "ask"}}
$ cat .ac-guard/audit.jsonl
{"timestamp":"...","agent":"claude-code","tool":"Write","operation":"write","scheme":"file","target":"guard.yaml","decision":"ask","reason":null,"matched_rule":"file:guard.yaml","policy_hash":"e5e6fd4f"}
```

**Cursor (bash subprocess):**
```
$ echo '{"tool_name":"Write","tool_input":{"file_path":"guard.yaml"},"agent":"cursor"}' | python3 -m ac_guard.enforcer
{"decision":"ask","pattern":"file:guard.yaml"}
$ cat .ac-guard/audit.jsonl  # agent=cursor recorded
```

**Disabled:** `output.audit.enabled=false` produces no `.ac-guard/audit.jsonl` file.

**Retention:** setting `output.audit.retention: 30` prunes records older than 30 days on the next `install` / `update`.

**Legacy artifact cleanup:** running `install` on a fixture that has both `policy.json` and `runtime.json` leaves only `runtime.json`.

## Test plan

- [x] `pytest tests/` — **854 passed** (+10 regression tests covering every new branch)
  - `TestEvaluateAuditWiring` (5 cases): enabled / disabled / missing section / unknown-tool skips audit / `agent` propagated
  - `TestEnforcerCliAudit::test_agent_from_stdin_is_recorded`
  - `TestLoadPolicy::test_audit_section_parsed`, `test_missing_audit_section_defaults_disabled`
  - `TestGeneratePolicyCache::test_runtime_cache_includes_audit_section`, `test_runtime_cache_omits_audit_when_none`
- [x] Existing `TestAuditLoggingE2E` integration tests updated to assert the new auto-audit flow
- [x] `pre-commit run --all-files` / `ruff check` clean
- [x] Manual E2E on a fresh project for 3 scenarios above
- [x] CI

## Out of scope (tracked)

- [#100](https://github.com/ikroal/ai-code-guard/issues/100) — `ac-guard audit list / tail / stats` CLI commands
- [#101](https://github.com/ikroal/ai-code-guard/issues/101) — Export audit events to SIEM / Prometheus / Loki
- [#102](https://github.com/ikroal/ai-code-guard/issues/102) — User-customizable audit record format

Early-return decision paths (`corrupt` / `no_policy` / `unknown_tool`) intentionally do not audit — those are not real policy decisions.

Closes #75