### PR TITLE
fix(policy): block 4 more hook-bypass patterns (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Default system `execute.forbidden` now covers four additional
+  hook-bypass patterns on top of `--no-verify`:
+  `SKIP=<id> git commit/push` (pre-commit env-var bypass),
+  `git -c core.hooksPath=…` (one-shot hook-path override),
+  `git config core.hooksPath <path>` (permanent override — read/unset
+  forms still pass through), and `git rebase --exec/-x` (arbitrary
+  command execution inside rebase). All four ship as `regex`
+  rules with `_source: system` and remain user-removable via the
+  standard `behavior.execute.forbidden.remove` escape hatch.
+  ([#104](https://github.com/ikroal/ai-code-guard/issues/104))
 - Built-in `commit.format` / `push.lint` shortcuts now invoke the
   language-specific hook IDs (`format-<lang>` / `lint-<lang>`) that the
   Generator actually emits, so `ac-guard check` passes out of the box for

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -79,42 +79,32 @@ _SYSTEM_PROTECTION_PATTERNS: list[str] = [
 _SYSTEM_EXECUTE_FORBIDDEN: list[dict[str, Any]] = [
     {
         "pattern": "shell:git commit --no-verify*",
-        "reason": "--no-verify skips pre-commit checks / --no-verify 跳过 pre-commit 检查",
+        "reason": "--no-verify skips pre-commit checks",
     },
     {
         "pattern": "shell:git push --no-verify*",
-        "reason": "--no-verify skips pre-push checks / --no-verify 跳过 pre-push 检查",
+        "reason": "--no-verify skips pre-push checks",
     },
     {
         "pattern": r"shell:SKIP=\S+\s+git\s+(?:commit|push)\b.*",
         "regex": True,
-        "reason": (
-            "SKIP= env-var bypasses pre-commit hooks / "
-            "SKIP= 环境变量前缀绕过 pre-commit hooks"
-        ),
+        "reason": "SKIP= env-var bypasses pre-commit hooks",
     },
     {
         "pattern": r"shell:git\s+.*-c\s+core\.hooks[Pp]ath=\S+.*",
         "regex": True,
-        "reason": (
-            "git -c core.hooksPath overrides the hook path / "
-            "git -c core.hooksPath 一次性覆盖 hook 路径绕过门禁"
-        ),
+        "reason": "git -c core.hooksPath overrides the hook path",
     },
     {
         "pattern": r"shell:(?i)git\s+config\s.*core\.hookspath\s+\S+.*",
         "regex": True,
-        "reason": (
-            "git config core.hooksPath permanently overrides the hook path / "
-            "git config core.hooksPath 永久覆盖 hook 路径"
-        ),
+        "reason": "git config core.hooksPath permanently overrides the hook path",
     },
     {
         "pattern": r"shell:git\s+rebase\s+.*(?:--exec|-x\s+).*",
         "regex": True,
         "reason": (
-            "git rebase --exec can run arbitrary commands bypassing per-commit "
-            "hooks / git rebase --exec 可在 rebase 过程执行任意命令绕过 hook"
+            "git rebase --exec can run arbitrary commands bypassing per-commit hooks"
         ),
     },
 ]

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -76,9 +76,47 @@ _SYSTEM_PROTECTION_PATTERNS: list[str] = [
     "file:.git/hooks/**",
 ]
 
-_SYSTEM_EXECUTE_FORBIDDEN: list[str] = [
-    "shell:git commit --no-verify*",
-    "shell:git push --no-verify*",
+_SYSTEM_EXECUTE_FORBIDDEN: list[dict[str, Any]] = [
+    {
+        "pattern": "shell:git commit --no-verify*",
+        "reason": "--no-verify skips pre-commit checks / --no-verify 跳过 pre-commit 检查",
+    },
+    {
+        "pattern": "shell:git push --no-verify*",
+        "reason": "--no-verify skips pre-push checks / --no-verify 跳过 pre-push 检查",
+    },
+    {
+        "pattern": r"shell:SKIP=\S+\s+git\s+(?:commit|push)\b.*",
+        "regex": True,
+        "reason": (
+            "SKIP= env-var bypasses pre-commit hooks / "
+            "SKIP= 环境变量前缀绕过 pre-commit hooks"
+        ),
+    },
+    {
+        "pattern": r"shell:git\s+.*-c\s+core\.hooks[Pp]ath=\S+.*",
+        "regex": True,
+        "reason": (
+            "git -c core.hooksPath overrides the hook path / "
+            "git -c core.hooksPath 一次性覆盖 hook 路径绕过门禁"
+        ),
+    },
+    {
+        "pattern": r"shell:(?i)git\s+config\s.*core\.hookspath\s+\S+.*",
+        "regex": True,
+        "reason": (
+            "git config core.hooksPath permanently overrides the hook path / "
+            "git config core.hooksPath 永久覆盖 hook 路径"
+        ),
+    },
+    {
+        "pattern": r"shell:git\s+rebase\s+.*(?:--exec|-x\s+).*",
+        "regex": True,
+        "reason": (
+            "git rebase --exec can run arbitrary commands bypassing per-commit "
+            "hooks / git rebase --exec 可在 rebase 过程执行任意命令绕过 hook"
+        ),
+    },
 ]
 
 _DEFAULT_LANGUAGES_YAML = Path(__file__).parent / "defaults" / "languages.yaml"
@@ -238,8 +276,8 @@ def _inject_system_rules(merged: dict[str, Any]) -> None:
 
     execute = behavior.setdefault("execute", {})
     forbidden = execute.setdefault("forbidden", [])
-    for pattern in _SYSTEM_EXECUTE_FORBIDDEN:
-        forbidden.append({"pattern": pattern, "_source": "system"})
+    for entry in _SYSTEM_EXECUTE_FORBIDDEN:
+        forbidden.append({**entry, "_source": "system"})
 
 
 def _auto_populate_languages(merged: dict[str, Any]) -> None:

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -391,11 +391,9 @@ class TestMultiLanguageE2E:
 
 
 class TestSystemExecuteRulesE2E:
-    """H: --no-verify family is auto-blocked in execute.forbidden."""
+    """H: hook-bypass family is auto-blocked in execute.forbidden."""
 
-    def test_install_populates_policy_with_no_verify_rules(
-        self, tmp_path: Path
-    ) -> None:
+    def test_install_populates_policy_with_bypass_rules(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)
         (tmp_path / ".git").mkdir()
         r = runner.invoke(app, ["install", "-a", "claude-code", "-c", str(config)])
@@ -404,11 +402,18 @@ class TestSystemExecuteRulesE2E:
         import json
 
         policy = json.loads((tmp_path / ".ac-guard" / "runtime.json").read_text())
-        patterns = {
-            rule["pattern"] for rule in policy["behavior"]["execute"]["forbidden"]
-        }
+        rules = policy["behavior"]["execute"]["forbidden"]
+        patterns = {rule["pattern"] for rule in rules}
         assert "shell:git commit --no-verify*" in patterns
         assert "shell:git push --no-verify*" in patterns
+        # #104: 4 hook-bypass patterns (regex)
+        assert any("SKIP=" in p for p in patterns)
+        assert any("-c" in p and "hooks" in p for p in patterns)
+        assert any("config" in p and "hookspath" in p.lower() for p in patterns)
+        assert any("rebase" in p and "exec" in p for p in patterns)
+        # Regex flag persists to runtime cache
+        regex_rules = [r for r in rules if r.get("regex")]
+        assert len(regex_rules) == 4
 
 
 class TestLocalePropagation:

--- a/tests/unit/test_config/test_merger.py
+++ b/tests/unit/test_config/test_merger.py
@@ -329,15 +329,35 @@ class TestSystemExecuteRules:
         path = _write_yaml(tmp_path, _minimal_guard())
         result = resolve_config(path)
         patterns = [r.pattern for r in result.behavior.execute.forbidden]
-        for expected in _SYSTEM_EXECUTE_FORBIDDEN:
-            assert expected in patterns
+        for entry in _SYSTEM_EXECUTE_FORBIDDEN:
+            assert entry["pattern"] in patterns
 
     def test_execute_forbidden_source_is_system(self, tmp_path: Path) -> None:
         path = _write_yaml(tmp_path, _minimal_guard())
         result = resolve_config(path)
+        system_patterns = {e["pattern"] for e in _SYSTEM_EXECUTE_FORBIDDEN}
         for rule in result.behavior.execute.forbidden:
-            if rule.pattern in _SYSTEM_EXECUTE_FORBIDDEN:
+            if rule.pattern in system_patterns:
                 assert rule.source == "system"
+
+    def test_execute_forbidden_regex_flag_preserved(self, tmp_path: Path) -> None:
+        """Regex entries retain ``regex=True`` after resolution."""
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        by_pattern = {r.pattern: r for r in result.behavior.execute.forbidden}
+        for entry in _SYSTEM_EXECUTE_FORBIDDEN:
+            rule = by_pattern[entry["pattern"]]
+            assert rule.regex is entry.get("regex", False)
+
+    def test_execute_forbidden_has_bypass_patterns(self, tmp_path: Path) -> None:
+        """Regression for #104 — 4 bypass patterns on top of --no-verify."""
+        path = _write_yaml(tmp_path, _minimal_guard())
+        result = resolve_config(path)
+        patterns = [r.pattern for r in result.behavior.execute.forbidden]
+        assert any("SKIP=" in p for p in patterns)
+        assert any("-c" in p and "hooks" in p for p in patterns)
+        assert any("config" in p and "hookspath" in p.lower() for p in patterns)
+        assert any("rebase" in p and "exec" in p for p in patterns)
 
     def test_user_execute_rules_coexist_with_system_rules(self, tmp_path: Path) -> None:
         data = _minimal_guard(
@@ -351,8 +371,8 @@ class TestSystemExecuteRules:
         result = resolve_config(path)
         patterns = [r.pattern for r in result.behavior.execute.forbidden]
         assert "shell:rm -rf /*" in patterns
-        for expected in _SYSTEM_EXECUTE_FORBIDDEN:
-            assert expected in patterns
+        for entry in _SYSTEM_EXECUTE_FORBIDDEN:
+            assert entry["pattern"] in patterns
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_enforcer/test_engine.py
+++ b/tests/unit/test_enforcer/test_engine.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from ac_guard.enforcer.engine import evaluate
 from ac_guard.enforcer.matcher import Decision, PolicyDecision
 
@@ -161,6 +163,87 @@ class TestEvaluateUnknownTool:
         result = evaluate("SomeFutureTool", {"arg": "val"}, tmp_path)
         assert result.decision == Decision.ALLOW
         assert result.tier == "unknown_tool"
+
+
+def _bypass_policy() -> dict:
+    """Policy that mirrors the 4 system bypass regex rules from #104."""
+    return {
+        "config_hash": "bypass",
+        "behavior": {
+            "read": {"forbidden": [], "require_approval": [], "allow": []},
+            "write": {"forbidden": [], "require_approval": [], "allow": []},
+            "execute": {
+                "forbidden": [
+                    {
+                        "pattern": r"shell:SKIP=\S+\s+git\s+(?:commit|push)\b.*",
+                        "regex": True,
+                        "source": "system",
+                    },
+                    {
+                        "pattern": r"shell:git\s+.*-c\s+core\.hooks[Pp]ath=\S+.*",
+                        "regex": True,
+                        "source": "system",
+                    },
+                    {
+                        "pattern": (
+                            r"shell:(?i)git\s+config\s.*core\.hookspath\s+\S+.*"
+                        ),
+                        "regex": True,
+                        "source": "system",
+                    },
+                    {
+                        "pattern": r"shell:git\s+rebase\s+.*(?:--exec|-x\s+).*",
+                        "regex": True,
+                        "source": "system",
+                    },
+                ],
+                "require_approval": [],
+                "allow": [],
+            },
+        },
+    }
+
+
+class TestSystemBypassPatterns:
+    """Regression for #104: 4 hook-bypass patterns are denied; look-alikes pass."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "SKIP=ruff git commit -m x",
+            "SKIP=ruff,mypy git push origin main",
+            "git -c core.hooksPath=/tmp commit -m x",
+            "git -c user.name=X -c core.hooksPath=/tmp push",
+            "git config core.hooksPath /tmp",
+            "git config --local core.hooksPath /tmp/hooks",
+            "git config --global core.hookspath /opt/hooks",
+            'git rebase --exec "rm -rf /" HEAD~3',
+            "git rebase -x 'echo pwned' HEAD~3",
+        ],
+    )
+    def test_bypass_command_denied(self, tmp_path: Path, cmd: str) -> None:
+        _write_policy(tmp_path, _bypass_policy())
+        result = evaluate("Bash", {"command": cmd}, tmp_path)
+        assert result.decision == Decision.DENY, f"expected deny for {cmd!r}"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "SKIP=foo make test",
+            "git -c user.name=Alice commit -m x",
+            "git config --get core.hooksPath",
+            "git config --unset core.hooksPath",
+            "git config --list",
+            "git rebase -i HEAD~3",
+            "git rebase -X ours HEAD~3",
+            "git commit -m 'normal commit'",
+            "git push origin feature",
+        ],
+    )
+    def test_lookalike_command_allowed(self, tmp_path: Path, cmd: str) -> None:
+        _write_policy(tmp_path, _bypass_policy())
+        result = evaluate("Bash", {"command": cmd}, tmp_path)
+        assert result.decision == Decision.ALLOW, f"expected allow for {cmd!r}"
 
 
 def _policy_with_audit(enabled: bool) -> dict:


### PR DESCRIPTION
## Summary

- Upgrades `_SYSTEM_EXECUTE_FORBIDDEN` to `list[dict]` so system rules can carry `regex: true` and a localized `reason` alongside the `pattern`
- Adds 4 regex-based bypass rules on top of `--no-verify`: `SKIP=` env-var prefix, `git -c core.hooksPath=`, `git config core.hooksPath <value>` (set-form only), `git rebase --exec/-x`
- Escape hatch preserved — the new rules live at `_source: system` and can be removed via `behavior.execute.forbidden.remove: [...]`

Closes #104.

## Test plan

- [x] `pytest tests/unit/test_config/test_merger.py::TestSystemExecuteRules` — 5 pass (structure + new pattern assertions)
- [x] `pytest tests/unit/test_enforcer/test_engine.py::TestSystemBypassPatterns` — 18 parametrized tests covering 9 deny samples + 9 pass-through samples
- [x] `pytest tests/integration/test_checker_e2e.py::TestSystemExecuteRulesE2E` — confirms 4 regex rules land in `runtime.json` after install
- [x] Full suite: 874 passed (previously 854; +20 new)
- [x] pre-commit (ruff, docstrings, type-hints, naming, import-deps, security, path-integrity, test-structure) — all green
- [x] Manual smoke:
  ```bash
  echo '{"tool_name":"Bash","tool_input":{"command":"SKIP=ruff git commit -m x"}}' | python3 -m ac_guard.enforcer   # → deny
  echo '{"tool_name":"Bash","tool_input":{"command":"git rebase -i HEAD~3"}}'      | python3 -m ac_guard.enforcer   # → allow
  ```

## False-positive audit

The design intentionally drops the `CI=<val> git commit/push` pattern we considered — CI environments sometimes inline `CI=true` on the command line. Revisit if evidence emerges.

For `git config core.hooksPath`, the regex requires a trailing value token, so `--get`, `--unset`, `--unset-all`, `--list` pass through and only the set/replace form is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)