### PR TITLE
feat(cli): auto-dispatch post_pr_comment from check/verify/gate run (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `check`, `verify`, and `gate run` now auto-dispatch `post_pr_comment`
+  when `output.pr_report.enabled: true`, closing the last mile of the
+  PR-report feature (previously callers had to invoke the primitive by
+  hand). A new `NoPrContextError` (subclass of `ChannelError`) is raised
+  by every channel when no PR/MR can be identified; `post_pr_comment`
+  silently skips in that case, so enabling `pr_report` in a shared
+  `guard.yaml` does not produce warnings on local branches. Real
+  failures (missing token, HTTP 5xx, unresolvable repo) continue to log
+  a stderr warning without affecting exit code.
+  ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
+
 ### Fixed
 
 - Default system `execute.forbidden` now covers four additional

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ When the agent runs, its hook script loads the pre-built policy and matches each
 
 At commit and push time, pre-commit hooks run format, lint, naming, and custom checks. The agent cannot skip these because `git commit --no-verify` is itself a forbidden pattern.
 
-Check results can be posted as PR comments on GitHub, GitLab, Gitea, and Bitbucket via the `output.pr_report` configuration.
+Check results can be posted as PR comments on GitHub, GitLab, Gitea, and Bitbucket via the `output.pr_report` configuration. When `enabled: true`, `check`, `verify`, and `gate run` automatically publish a comment on the associated PR after execution. If no PR can be identified in the current context (e.g. local branch, no PR open yet), the dispatch is silently skipped — no noise in local development.
 
 ## Roadmap
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -108,7 +108,7 @@ Agent 工作时，Hook 脚本加载预构建的策略文件，将每个操作与
 
 提交和推送时，pre-commit Hook 运行格式化、Lint、命名和自定义检查。Agent 无法跳过这些检查，因为 `git commit --no-verify` 本身就是被禁止的模式。
 
-检查结果可通过 `output.pr_report` 配置自动发布到 GitHub、GitLab、Gitea 和 Bitbucket 的 PR 评论。
+检查结果可通过 `output.pr_report` 配置自动发布到 GitHub、GitLab、Gitea 和 Bitbucket 的 PR 评论。开启 `enabled: true` 后，`check`、`verify`、`gate run` 执行结束会自动在关联 PR 上评论；当前环境识别不到 PR 时（例如本地分支、尚未开 PR），会静默跳过——本地开发无噪声。
 
 ## 路线图
 

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -17,6 +17,7 @@ from ac_guard.checker.core import (
 from ac_guard.checker.models import CheckReport, CheckResult
 from ac_guard.config.exceptions import ConfigError
 from ac_guard.config.merger import resolve_config
+from ac_guard.reporter.channel_base import post_pr_comment
 from ac_guard.reporter.formatting import format_gate, format_json, format_terminal
 
 if TYPE_CHECKING:
@@ -69,6 +70,7 @@ def check_command(
             resolved.output.locale,
         )
     )
+    post_pr_comment(report, resolved.output.pr_report, resolved.output.locale)
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -105,6 +107,7 @@ def verify_command(
             resolved.output.locale,
         )
     )
+    post_pr_comment(report, resolved.output.pr_report, resolved.output.locale)
     raise SystemExit(0 if report.passed else 1)
 
 
@@ -209,6 +212,7 @@ def gate_run_command(
 
     message, exit_code = format_gate(report)
     print(message)
+    post_pr_comment(report, resolved.output.pr_report, resolved.output.locale)
     raise SystemExit(exit_code)
 
 

--- a/src/ac_guard/reporter/channel_base.py
+++ b/src/ac_guard/reporter/channel_base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ChannelError",
+    "NoPrContextError",
     "ReportChannel",
     "get_channel",
     "post_pr_comment",
@@ -32,6 +33,17 @@ class ChannelError(Exception):
 
     This is caught by ``post_pr_comment`` to avoid affecting
     the main exit code — failures are logged as warnings.
+    """
+
+
+class NoPrContextError(ChannelError):
+    """Raised when no PR/MR can be identified in the current context.
+
+    Distinct from generic :class:`ChannelError` because it is an
+    expected condition during local development (no PR opened yet)
+    and should be silently skipped by :func:`post_pr_comment` —
+    not logged as a warning. Real failures such as missing tokens
+    or HTTP errors continue to raise plain :class:`ChannelError`.
     """
 
 
@@ -142,6 +154,8 @@ def post_pr_comment(
         markdown = format_markdown(report, locale)
         channel = get_channel(config.platform)
         channel.send(markdown, config)
+    except NoPrContextError:
+        return  # Silent skip: no PR in context (typical in local dev)
     except (ChannelError, Exception) as exc:
         print(f"Warning: PR comment not posted: {exc}", file=sys.stderr)
 

--- a/src/ac_guard/reporter/channel_base.py
+++ b/src/ac_guard/reporter/channel_base.py
@@ -156,8 +156,8 @@ def post_pr_comment(
         channel.send(markdown, config)
     except NoPrContextError:
         return  # Silent skip: no PR in context (typical in local dev)
-    except (ChannelError, Exception) as exc:
-        print(f"Warning: PR comment not posted: {exc}", file=sys.stderr)
+    except Exception as exc:
+        print(f"Warning: PR comment failed to post: {exc}", file=sys.stderr)
 
 
 # Ensure built-in channels are registered on import

--- a/src/ac_guard/reporter/channel_bitbucket.py
+++ b/src/ac_guard/reporter/channel_bitbucket.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter.channel_base import ChannelError, ReportChannel, register_channel
+from ac_guard.reporter.channel_base import (
+    ChannelError,
+    NoPrContextError,
+    ReportChannel,
+    register_channel,
+)
 
 if TYPE_CHECKING:
     from ac_guard.config.models import PrReportConfig
@@ -111,7 +116,7 @@ class BitbucketChannel(ReportChannel):
             except ChannelError:
                 pass  # Fall through to error
 
-        raise ChannelError(
+        raise NoPrContextError(
             "Cannot determine PR ID. Set AI_GUARD_PR_NUMBER, "
             "BITBUCKET_PR_ID, or push your branch and open a PR"
         )

--- a/src/ac_guard/reporter/channel_gitea.py
+++ b/src/ac_guard/reporter/channel_gitea.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter.channel_base import ChannelError, ReportChannel, register_channel
+from ac_guard.reporter.channel_base import (
+    ChannelError,
+    NoPrContextError,
+    ReportChannel,
+    register_channel,
+)
 
 if TYPE_CHECKING:
     from ac_guard.config.models import PrReportConfig
@@ -103,7 +108,7 @@ class GiteaChannel(ReportChannel):
             except ChannelError:
                 pass  # Fall through to error
 
-        raise ChannelError(
+        raise NoPrContextError(
             "Cannot determine PR number. Set AI_GUARD_PR_NUMBER, "
             "or push your branch and open a PR"
         )

--- a/src/ac_guard/reporter/channel_github.py
+++ b/src/ac_guard/reporter/channel_github.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter.channel_base import ChannelError, ReportChannel, register_channel
+from ac_guard.reporter.channel_base import (
+    ChannelError,
+    NoPrContextError,
+    ReportChannel,
+    register_channel,
+)
 
 if TYPE_CHECKING:
     from ac_guard.config.models import PrReportConfig
@@ -116,7 +121,7 @@ class GitHubChannel(ReportChannel):
             except ChannelError:
                 pass  # Fall through to error
 
-        raise ChannelError(
+        raise NoPrContextError(
             "Cannot determine PR number. Set AI_GUARD_PR_NUMBER, "
             "GITHUB_REF (refs/pull/<n>/merge), or push your branch "
             "and open a PR"

--- a/src/ac_guard/reporter/channel_gitlab.py
+++ b/src/ac_guard/reporter/channel_gitlab.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter.channel_base import ChannelError, ReportChannel, register_channel
+from ac_guard.reporter.channel_base import (
+    ChannelError,
+    NoPrContextError,
+    ReportChannel,
+    register_channel,
+)
 
 if TYPE_CHECKING:
     from ac_guard.config.models import PrReportConfig
@@ -112,7 +117,7 @@ class GitLabChannel(ReportChannel):
             except ChannelError:
                 pass  # Fall through to error
 
-        raise ChannelError(
+        raise NoPrContextError(
             "Cannot determine MR IID. Set AI_GUARD_PR_NUMBER, "
             "CI_MERGE_REQUEST_IID, or push your branch and open a MR"
         )

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -360,7 +360,7 @@ class TestCliPrReportIntegration:
             if result.stderr_bytes
             else ""
         )
-        assert "Warning: PR comment not posted" not in combined
+        assert "Warning: PR comment failed to post" not in combined
         assert "Cannot determine PR number" not in combined
 
     def test_cli_check_warns_when_channel_error(self, tmp_path: Path) -> None:
@@ -383,7 +383,7 @@ class TestCliPrReportIntegration:
             if result.stderr_bytes
             else ""
         )
-        assert "Warning: PR comment not posted" in combined
+        assert "Warning: PR comment failed to post" in combined
         assert "500" in combined
 
     def test_cli_check_disabled_skips_channel_entirely(self, tmp_path: Path) -> None:

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -19,7 +19,11 @@ from typer.testing import CliRunner
 from ac_guard.checker.core import run_stage
 from ac_guard.cli.main import app
 from ac_guard.config.models import PrReportConfig
-from ac_guard.reporter.channel_base import post_pr_comment
+from ac_guard.reporter.channel_base import (
+    ChannelError,
+    NoPrContextError,
+    post_pr_comment,
+)
 from ac_guard.reporter.formatting import format_markdown
 
 runner = CliRunner()
@@ -272,6 +276,126 @@ class TestValidationDiscovery:
         assert "format" in output
         assert "naming" in output
         assert "lint" in output
+
+
+# ---------------------------------------------------------------------------
+# D4: CLI Auto-Dispatch of PR Report (WP6.1 / Issue #66)
+# ---------------------------------------------------------------------------
+
+
+def _write_config_pr_report(
+    tmp_path: Path, *, enabled: bool, platform: str = "github"
+) -> Path:
+    """Write a guard.yaml that enables PR reporting for the given platform."""
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "project": {"name": "test", "language": "python"},
+                "output": {
+                    "pr_report": {
+                        "enabled": enabled,
+                        "platform": platform,
+                        "token_env": "GITHUB_TOKEN",
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+class TestCliPrReportIntegration:
+    """D4: CLI commands auto-dispatch post_pr_comment end-to-end (WP6.1)."""
+
+    def test_cli_check_triggers_pr_comment_when_pr_exists(self, tmp_path: Path) -> None:
+        """D4-1: guard check with pr_report.enabled=true → Channel.send called."""
+        config = _write_config_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.reporter.channel_github.GitHubChannel.send") as mock_send,
+        ):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 0
+        assert mock_send.call_count == 1
+        markdown_arg = mock_send.call_args[0][0]
+        assert isinstance(markdown_arg, str)
+        assert len(markdown_arg) > 0
+
+    def test_cli_gate_run_triggers_pr_comment_when_pr_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """D4-2: guard gate run with pr_report.enabled=true → Channel.send called."""
+        config = _write_config_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.reporter.channel_github.GitHubChannel.send") as mock_send,
+        ):
+            result = runner.invoke(
+                app, ["gate", "run", "--stage", "commit", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert mock_send.call_count == 1
+
+    def test_cli_check_silent_when_no_pr_context(self, tmp_path: Path) -> None:
+        """D4-3: NoPrContextError from channel.send → no stderr warning."""
+        config = _write_config_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch(
+                "ac_guard.reporter.channel_github.GitHubChannel.send",
+                side_effect=NoPrContextError("Cannot determine PR number"),
+            ),
+        ):
+            result = runner.invoke(
+                app, ["check", "--config", str(config)], catch_exceptions=False
+            )
+        assert result.exit_code == 0
+        combined = result.output + (
+            result.stderr_bytes.decode("utf-8", errors="replace")
+            if result.stderr_bytes
+            else ""
+        )
+        assert "Warning: PR comment not posted" not in combined
+        assert "Cannot determine PR number" not in combined
+
+    def test_cli_check_warns_when_channel_error(self, tmp_path: Path) -> None:
+        """D4-4: Non-NoPrContext ChannelError → stderr warning preserved."""
+        config = _write_config_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch(
+                "ac_guard.reporter.channel_github.GitHubChannel.send",
+                side_effect=ChannelError("GitHub API returned 500"),
+            ),
+        ):
+            # CliRunner merges stdout+stderr by default; check full output
+            result = runner.invoke(
+                app, ["check", "--config", str(config)], catch_exceptions=False
+            )
+        assert result.exit_code == 0
+        combined = result.output + (
+            result.stderr_bytes.decode("utf-8", errors="replace")
+            if result.stderr_bytes
+            else ""
+        )
+        assert "Warning: PR comment not posted" in combined
+        assert "500" in combined
+
+    def test_cli_check_disabled_skips_channel_entirely(self, tmp_path: Path) -> None:
+        """D4-5: pr_report.enabled=false → channel.send never invoked."""
+        config = _write_config_pr_report(tmp_path, enabled=False)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.reporter.channel_github.GitHubChannel.send") as mock_send,
+        ):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 0
+        assert mock_send.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -274,3 +274,116 @@ class TestJsonOutput:
         data = json.loads(result.output)
         assert data["stage"] == "push"
         assert "results" in data
+
+
+# ---------------------------------------------------------------------------
+# TestCliAutoPostPrComment — WP6.1 / Issue #66
+# ---------------------------------------------------------------------------
+
+
+def _write_config_with_pr_report(tmp_path: Path, *, enabled: bool) -> Path:
+    """Write guard.yaml with output.pr_report.enabled set explicitly."""
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "project": {"name": "test", "language": "python"},
+                "output": {
+                    "locale": "zh-CN",
+                    "pr_report": {
+                        "enabled": enabled,
+                        "platform": "github",
+                        "token_env": "GITHUB_TOKEN",
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+    )
+    return config
+
+
+class TestCliAutoPostPrComment:
+    """check / verify / gate run auto-trigger post_pr_comment (WP6.1)."""
+
+    def test_check_calls_post_pr_comment_with_resolved_config(
+        self, tmp_path: Path
+    ) -> None:
+        """check dispatches post_pr_comment with report + pr_report + locale."""
+        config = _write_config_with_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.cli.check.post_pr_comment") as mock_post,
+        ):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 0
+        assert mock_post.call_count == 1
+        pos_args, _kw_args = mock_post.call_args
+        report_arg, pr_config_arg, locale_arg = pos_args
+        assert report_arg.stage == "commit"
+        assert report_arg.passed is True
+        assert pr_config_arg.enabled is True
+        assert pr_config_arg.platform == "github"
+        assert locale_arg == "zh-CN"
+
+    def test_check_passes_disabled_config_through(self, tmp_path: Path) -> None:
+        """Even when disabled, CLI calls post_pr_comment (primitive self-gates)."""
+        config = _write_config_with_pr_report(tmp_path, enabled=False)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.cli.check.post_pr_comment") as mock_post,
+        ):
+            result = runner.invoke(app, ["check", "--config", str(config)])
+        assert result.exit_code == 0
+        assert mock_post.call_count == 1
+        pos_args, _ = mock_post.call_args
+        _report, pr_config_arg, _locale = pos_args
+        assert pr_config_arg.enabled is False
+
+    def test_verify_calls_post_pr_comment(self, tmp_path: Path) -> None:
+        """verify also dispatches post_pr_comment at end."""
+        config = _write_config_with_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.cli.check.post_pr_comment") as mock_post,
+        ):
+            result = runner.invoke(
+                app, ["verify", "--skip-build", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert mock_post.call_count == 1
+        pos_args, _ = mock_post.call_args
+        report_arg, _, _ = pos_args
+        assert report_arg.stage == "push"
+
+    def test_gate_run_calls_post_pr_comment(self, tmp_path: Path) -> None:
+        """gate run also dispatches post_pr_comment at end."""
+        config = _write_config_with_pr_report(tmp_path, enabled=True)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.cli.check.post_pr_comment") as mock_post,
+        ):
+            result = runner.invoke(
+                app, ["gate", "run", "--stage", "commit", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert mock_post.call_count == 1
+        pos_args, _ = mock_post.call_args
+        report_arg, _, _ = pos_args
+        assert report_arg.stage == "commit"
+
+    def test_run_does_not_call_post_pr_comment(self, tmp_path: Path) -> None:
+        """run is intentionally out of scope (WP6.1): single-check runner.
+
+        Fixates the decision: enabling per-check runs would create PR noise
+        (one comment per check). Re-evaluate in a follow-up issue if needed.
+        """
+        config = _write_config_with_checks(tmp_path)
+        with (
+            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.cli.check.post_pr_comment") as mock_post,
+        ):
+            result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])
+        assert result.exit_code == 0
+        assert mock_post.call_count == 0

--- a/tests/unit/test_reporter/test_channel_base.py
+++ b/tests/unit/test_reporter/test_channel_base.py
@@ -154,5 +154,5 @@ class TestNoPrContextError:
         post_pr_comment(report=report, config=config, locale="en")
 
         captured = capsys.readouterr()
-        assert "Warning: PR comment not posted" in captured.err
+        assert "Warning: PR comment failed to post" in captured.err
         assert "API 500" in captured.err

--- a/tests/unit/test_reporter/test_channel_base.py
+++ b/tests/unit/test_reporter/test_channel_base.py
@@ -7,6 +7,7 @@ import pytest
 from ac_guard.config.models import PrReportConfig
 from ac_guard.reporter.channel_base import (
     ChannelError,
+    NoPrContextError,
     ReportChannel,
     get_channel,
     post_pr_comment,
@@ -91,3 +92,67 @@ class TestPostPrComment:
 
         # Should not raise — catches internally
         post_pr_comment(report=report, config=config, locale="en")
+
+
+class TestNoPrContextError:
+    """NoPrContextError signals 'no PR in context' — silent-skip semantics."""
+
+    def test_is_channel_error_subclass(self) -> None:
+        """NoPrContextError must inherit ChannelError for backward compat."""
+        assert issubclass(NoPrContextError, ChannelError)
+
+    def test_post_pr_comment_silent_on_no_pr_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """NoPrContextError from channel.send => no stderr output, normal return."""
+        from ac_guard.checker.models import CheckReport
+        from ac_guard.reporter import channel_base
+
+        config = PrReportConfig(enabled=True, platform="fake-no-pr")
+        report = CheckReport(stage="commit", passed=True)
+
+        class _NoPrChannel(ReportChannel):
+            @property
+            def name(self) -> str:
+                return "fake-no-pr"
+
+            def send(self, markdown: str, config: PrReportConfig) -> None:
+                raise NoPrContextError("no PR in context")
+
+        monkeypatch.setitem(channel_base._CHANNELS, "fake-no-pr", _NoPrChannel)
+
+        post_pr_comment(report=report, config=config, locale="en")
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_post_pr_comment_warns_on_other_channel_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """ChannelError (not NoPrContextError) => stderr warning."""
+        from ac_guard.checker.models import CheckReport
+        from ac_guard.reporter import channel_base
+
+        config = PrReportConfig(enabled=True, platform="fake-api-500")
+        report = CheckReport(stage="commit", passed=True)
+
+        class _ApiFailChannel(ReportChannel):
+            @property
+            def name(self) -> str:
+                return "fake-api-500"
+
+            def send(self, markdown: str, config: PrReportConfig) -> None:
+                raise ChannelError("API 500")
+
+        monkeypatch.setitem(channel_base._CHANNELS, "fake-api-500", _ApiFailChannel)
+
+        post_pr_comment(report=report, config=config, locale="en")
+
+        captured = capsys.readouterr()
+        assert "Warning: PR comment not posted" in captured.err
+        assert "API 500" in captured.err

--- a/tests/unit/test_reporter/test_channel_bitbucket.py
+++ b/tests/unit/test_reporter/test_channel_bitbucket.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ac_guard.config.models import PrReportConfig
-from ac_guard.reporter.channel_base import ChannelError
+from ac_guard.reporter.channel_base import ChannelError, NoPrContextError
 from ac_guard.reporter.channel_bitbucket import BitbucketChannel
 
 
@@ -160,5 +160,23 @@ class TestBitbucketChannel:
                 return_value=None,
             ),
             pytest.raises(ChannelError, match="PR ID"),
+        ):
+            BitbucketChannel().send("r", self._make_config())
+
+    def test_no_pr_raises_no_pr_context_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No PR discoverable => NoPrContextError (silent-skip contract)."""
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.delenv("BITBUCKET_PR_ID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ac_guard.reporter.channel_bitbucket.get_current_branch",
+                return_value=None,
+            ),
+            pytest.raises(NoPrContextError, match="PR ID"),
         ):
             BitbucketChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_gitea.py
+++ b/tests/unit/test_reporter/test_channel_gitea.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ac_guard.config.models import PrReportConfig
-from ac_guard.reporter.channel_base import ChannelError
+from ac_guard.reporter.channel_base import ChannelError, NoPrContextError
 from ac_guard.reporter.channel_gitea import GiteaChannel
 
 
@@ -147,5 +147,21 @@ class TestGiteaChannel:
                 "ac_guard.reporter.channel_gitea.get_current_branch", return_value=None
             ),
             pytest.raises(ChannelError, match="PR number"),
+        ):
+            GiteaChannel().send("r", self._make_config())
+
+    def test_no_pr_raises_no_pr_context_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No PR discoverable => NoPrContextError (silent-skip contract)."""
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ac_guard.reporter.channel_gitea.get_current_branch", return_value=None
+            ),
+            pytest.raises(NoPrContextError, match="PR number"),
         ):
             GiteaChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_github.py
+++ b/tests/unit/test_reporter/test_channel_github.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ac_guard.config.models import PrReportConfig
-from ac_guard.reporter.channel_base import ChannelError
+from ac_guard.reporter.channel_base import ChannelError, NoPrContextError
 from ac_guard.reporter.channel_github import GitHubChannel
 
 
@@ -195,5 +195,22 @@ class TestGitHubChannel:
                 "ac_guard.reporter.channel_github.get_current_branch", return_value=None
             ),
             pytest.raises(ChannelError, match="PR number"),
+        ):
+            GitHubChannel().send("r", self._make_config())
+
+    def test_no_pr_raises_no_pr_context_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No PR discoverable => NoPrContextError (silent-skip contract)."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ac_guard.reporter.channel_github.get_current_branch", return_value=None
+            ),
+            pytest.raises(NoPrContextError, match="PR number"),
         ):
             GitHubChannel().send("r", self._make_config())

--- a/tests/unit/test_reporter/test_channel_gitlab.py
+++ b/tests/unit/test_reporter/test_channel_gitlab.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ac_guard.config.models import PrReportConfig
-from ac_guard.reporter.channel_base import ChannelError
+from ac_guard.reporter.channel_base import ChannelError, NoPrContextError
 from ac_guard.reporter.channel_gitlab import GitLabChannel
 
 
@@ -146,5 +146,22 @@ class TestGitLabChannel:
                 "ac_guard.reporter.channel_gitlab.get_current_branch", return_value=None
             ),
             pytest.raises(ChannelError, match="MR IID"),
+        ):
+            GitLabChannel().send("r", self._make_config())
+
+    def test_no_mr_raises_no_pr_context_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No MR discoverable => NoPrContextError (silent-skip contract)."""
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.delenv("CI_MERGE_REQUEST_IID", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        with (
+            patch(
+                "ac_guard.reporter.channel_gitlab.get_current_branch", return_value=None
+            ),
+            pytest.raises(NoPrContextError, match="MR IID"),
         ):
             GitLabChannel().send("r", self._make_config())


### PR DESCRIPTION
## Summary

- `check` / `verify` / `gate run` now automatically call `post_pr_comment()` after printing the report, so `output.pr_report.enabled=true` produces PR comments end-to-end without requiring callers to invoke the R4 primitive by hand.
- New `NoPrContextError` (subclass of `ChannelError`) signals "no PR/MR in context." `post_pr_comment` silently skips in that case, so enabling `pr_report` in a shared `guard.yaml` no longer produces stderr warnings on local branches. Real failures (missing token, HTTP 5xx, unresolvable repo) still log a warning.
- `guard run <name>` is intentionally out of scope — running it per-check would create PR comment noise. The decision is fixated with a unit test.

Closes #66

## Changes

| Area | Files |
|---|---|
| Reporter primitive | `src/ac_guard/reporter/channel_base.py` |
| 4 channels | `channel_github.py`, `channel_gitlab.py`, `channel_gitea.py`, `channel_bitbucket.py` |
| CLI integration | `src/ac_guard/cli/check.py` (4 lines: 1 import + 3 call sites) |
| Tests | +17 tests across unit (reporter + CLI) and integration |
| Docs | README.md, README_zh.md, CHANGELOG.md |

## Test plan

- [x] `pytest` — 891 passed (up from 874, +17 new tests)
- [x] `ruff check .` — zero issues
- [x] `pre-commit run --all-files` — all hooks green
- [ ] Manual smoke A (with PR): set `GITHUB_TOKEN` + `AI_GUARD_PR_NUMBER=<existing PR>`, run `ac-guard check`, confirm bot comment appears
- [ ] Manual smoke B (no PR): unset `AI_GUARD_PR_NUMBER` on a local-only branch, run `ac-guard check`, confirm stderr has no "Warning" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)