### PR TITLE
feat(hook): make Claude Code interceptor PATH-resilient

### DIFF
--- a/src/ac_guard/adapters/_render.py
+++ b/src/ac_guard/adapters/_render.py
@@ -11,6 +11,7 @@ This module provides:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -96,6 +97,11 @@ def render_hook(template_name: str, behavior: BehaviorConfig) -> str:
 
     context = {
         "behavior": behavior,
+        # Absolute path of the Python running `ac-guard install`.
+        # Baked into the rendered hook so it can re-exec into an interpreter
+        # that can actually import `ac_guard`, even when Claude Code launches
+        # the hook from a shell whose `$PATH` lacks the project's venv.
+        "python_executable": sys.executable,
     }
 
     return template.render(context)

--- a/src/ac_guard/adapters/_templates/hooks/claude_code.j2
+++ b/src/ac_guard/adapters/_templates/hooks/claude_code.j2
@@ -45,8 +45,9 @@ except ImportError as _exc:
     json.dump(
         {
             "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
                 "permissionDecision": "ask",
-                "reason": (
+                "permissionDecisionReason": (
                     f"ac-guard hook could not import ac_guard ({_exc}); "
                     "reinstall ac-guard or re-run `ac-guard install`"
                 ),
@@ -76,13 +77,14 @@ def main():
     # Output Claude Code expected format
     output = {
         "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
             "permissionDecision": result.decision.value,
         }
     }
 
     # Add reason for deny/ask
     if reason and result.decision.value != "allow":
-        output["hookSpecificOutput"]["reason"] = reason
+        output["hookSpecificOutput"]["permissionDecisionReason"] = reason
 
     json.dump(output, sys.stdout)
     print()  # Ensure newline for Claude Code to read properly

--- a/src/ac_guard/adapters/_templates/hooks/claude_code.j2
+++ b/src/ac_guard/adapters/_templates/hooks/claude_code.j2
@@ -19,10 +19,43 @@ the managed block are preserved.
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
-from ac_guard.enforcer.engine import evaluate
+# --- PATH-resilient re-exec shim ---
+# Claude Code runs this hook via the `python3` on $PATH of the shell that
+# launched `claude`. When that shell did not activate the project's venv
+# (Finder / Raycast / IDE launcher / fresh terminal), `python3` resolves to
+# a system interpreter that cannot import ac_guard. To stay correct under
+# any launch path, we bake the absolute path of the Python that ran
+# `ac-guard install` (which, by definition, can import ac_guard) and
+# re-exec into it when they differ.
+_INSTALL_PY = {{ python_executable | tojson }}
+if sys.executable != _INSTALL_PY and os.path.exists(_INSTALL_PY):
+    os.execv(_INSTALL_PY, [_INSTALL_PY, __file__, *sys.argv[1:]])
+
+# --- Safe-deny on import failure ---
+# If ac_guard is still not importable after the shim (e.g. baked path was
+# removed, venv rebuilt, package uninstalled), never let the tool call
+# silently pass — emit an `ask` decision so the user sees the problem.
+try:
+    from ac_guard.enforcer.engine import evaluate
+except ImportError as _exc:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "permissionDecision": "ask",
+                "reason": (
+                    f"ac-guard hook could not import ac_guard ({_exc}); "
+                    "reinstall ac-guard or re-run `ac-guard install`"
+                ),
+            }
+        },
+        sys.stdout,
+    )
+    print()
+    sys.exit(0)
 
 
 def main():

--- a/tests/unit/test_adapters/test_hooks.py
+++ b/tests/unit/test_adapters/test_hooks.py
@@ -32,6 +32,11 @@ class TestClaudeCodeHook:
         content = render_hook("claude_code", BehaviorConfig.empty())
         assert "permissionDecision" in content
 
+    def test_includes_hook_event_name(self) -> None:
+        """Hook output includes hookEventName (required by Claude Code schema)."""
+        content = render_hook("claude_code", BehaviorConfig.empty())
+        assert '"hookEventName": "PreToolUse"' in content
+
     def test_bakes_install_python_path(self) -> None:
         """Hook bakes the absolute path of the Python that ran `ac-guard install`."""
         content = render_hook("claude_code", BehaviorConfig.empty())

--- a/tests/unit/test_adapters/test_hooks.py
+++ b/tests/unit/test_adapters/test_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 from ac_guard.adapters._render import render_hook
@@ -40,8 +41,9 @@ class TestClaudeCodeHook:
     def test_bakes_install_python_path(self) -> None:
         """Hook bakes the absolute path of the Python that ran `ac-guard install`."""
         content = render_hook("claude_code", BehaviorConfig.empty())
-        # sys.executable is embedded as a JSON-safe Python string literal
-        assert f'_INSTALL_PY = "{sys.executable}"' in content
+        # The template uses Jinja's `| tojson` filter so Windows backslashes
+        # are properly escaped; match the JSON-encoded form.
+        assert f"_INSTALL_PY = {json.dumps(sys.executable)}" in content
 
     def test_has_reexec_shim(self) -> None:
         """Hook re-execs into the baked interpreter when sys.executable differs."""

--- a/tests/unit/test_adapters/test_hooks.py
+++ b/tests/unit/test_adapters/test_hooks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from ac_guard.adapters._render import render_hook
 from ac_guard.config.models import BehaviorConfig
 
@@ -29,6 +31,29 @@ class TestClaudeCodeHook:
         """Claude Code hook outputs permissionDecision format."""
         content = render_hook("claude_code", BehaviorConfig.empty())
         assert "permissionDecision" in content
+
+    def test_bakes_install_python_path(self) -> None:
+        """Hook bakes the absolute path of the Python that ran `ac-guard install`."""
+        content = render_hook("claude_code", BehaviorConfig.empty())
+        # sys.executable is embedded as a JSON-safe Python string literal
+        assert f'_INSTALL_PY = "{sys.executable}"' in content
+
+    def test_has_reexec_shim(self) -> None:
+        """Hook re-execs into the baked interpreter when sys.executable differs."""
+        content = render_hook("claude_code", BehaviorConfig.empty())
+        assert "sys.executable != _INSTALL_PY" in content
+        assert "os.execv(_INSTALL_PY" in content
+
+    def test_has_import_safe_deny(self) -> None:
+        """Hook emits an ask decision when ac_guard cannot be imported."""
+        content = render_hook("claude_code", BehaviorConfig.empty())
+        assert "except ImportError" in content
+        assert '"permissionDecision": "ask"' in content
+
+    def test_generated_hook_is_valid_python(self) -> None:
+        """Rendered hook compiles as valid Python (no syntax errors)."""
+        content = render_hook("claude_code", BehaviorConfig.empty())
+        compile(content, "<generated claude_code hook>", "exec")
 
 
 class TestCursorHook:


### PR DESCRIPTION
## Summary

- Bake the `sys.executable` that ran `ac-guard install` into the generated `.claude/hooks/interceptor.py`; re-exec into it at runtime so Claude Code can invoke the hook from any shell PATH without silently losing `ac_guard`
- Add a fail-safe `ask` decision when `ac_guard` still cannot be imported (baked path gone, venv rebuilt, package uninstalled) so the hook never silently allows an intercepted tool call
- Emit `hookEventName: "PreToolUse"` / `permissionDecisionReason` per Claude Code's current hook-output schema (previously Claude Code rejected every decision with a validation error)

Closes #116.

## Why

Discovered during Track B.2-β dogfood β.5 stdin testing: starting `claude` from a non-venv shell (Finder, Raycast, IDE launcher, fresh terminal) made `python3 .claude/hooks/interceptor.py` resolve to a system interpreter with no `ac_guard` module. The hook exited non-zero without the expected JSON, and Claude Code treated that as a hook error → silently allowed the intercepted tool call. The whole guard system becomes a no-op under those launch paths. Tests passed before only because the session happened to be started from inside an activated venv.

The `hookEventName` fix landed alongside because this PR already regenerates the interceptor and the schema-mismatch error was reproduced live in the same session.

## Test plan

- [x] 26 existing adapter unit tests green (`pytest tests/unit/test_adapters -q`)
- [x] New template tests: venv bake, re-exec shim, import safe-deny, valid Python syntax, hookEventName
- [x] 930 full regression green (`pytest tests/ -q`)
- [x] Manual: ran all 8 Track B.2-β stdin scenarios through `/usr/bin/python3` (Python 3.9, no `ac_guard`) — all return correct `deny`/`ask` JSON via the re-exec shim
- [x] Manual: pointed `_INSTALL_PY` at a nonexistent path — safe-deny branch emits the expected `{"permissionDecision":"ask", ...}` JSON
- [ ] Follow-up: same resilience for Cursor `.sh` and OpenCode `.ts` hooks (separate WP)
- [ ] Follow-up: Track B.2-β PR will rebase onto this and re-run β.7/β.8 with the new interceptor

🤖 Generated with [Claude Code](https://claude.com/claude-code)