### PR TITLE
feat(reporter): HTTP retry/backoff layer + test-isolation fix

### DIFF
--- a/src/ac_guard/reporter/_http.py
+++ b/src/ac_guard/reporter/_http.py
@@ -1,0 +1,138 @@
+"""HTTP retry/backoff layer shared by all report channels.
+
+Wraps ``urllib.request.urlopen`` with bounded retries on transient
+failures (connection errors and 408/429/5xx). Business-level 4xx
+errors (401, 403, 404, ...) fail fast — retrying them would only
+waste attempts.
+
+The channel modules are thin wrappers that build auth/accept headers
+and delegate transport to :func:`request_json`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+
+from ac_guard.reporter.channel_base import ChannelError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ["request_json"]
+
+# HTTP status codes considered transient and worth retrying.
+_RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Return ``Retry-After`` header value in seconds, if it parses as int.
+
+    HTTP also permits HTTP-date format; we treat those as unparseable
+    and fall back to exponential backoff. Integer-seconds form is what
+    the APIs we target (GitHub/GitLab/Gitea/Bitbucket) actually emit.
+    """
+    if not value:
+        return None
+    try:
+        return float(value.strip())
+    except ValueError:
+        return None
+
+
+def request_json(
+    url: str,
+    *,
+    method: str,
+    headers: dict[str, str],
+    body: dict | None = None,
+    api_name: str,
+    max_attempts: int = 3,
+    backoff_base: float = 0.5,
+    backoff_cap: float = 8.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict | list | None:
+    """Issue an HTTP request with bounded retries and return parsed JSON.
+
+    Args:
+        url: Absolute URL to request.
+        method: HTTP method (``"GET"`` or ``"POST"``).
+        headers: Fully built request headers (auth, accept, content-type).
+        body: Optional JSON-serializable request body. POST without a
+            body is allowed but unusual.
+        api_name: Human-readable API name used in error messages
+            (e.g. ``"GitHub"``).
+        max_attempts: Upper bound on total attempts (>=1). Default 3.
+        backoff_base: Exponential backoff base in seconds. Default 0.5.
+        backoff_cap: Maximum sleep between attempts in seconds. Default 8.
+        sleep: Injection point for tests.
+
+    Returns:
+        Parsed JSON body on success. Returns ``None`` when the response
+        body is empty (common for POST-without-echo endpoints).
+
+    Raises:
+        ChannelError: On non-retryable HTTP errors (4xx other than 408/429)
+            or when retries are exhausted on retryable failures.
+    """
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    last_exc: BaseException | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:  # noqa: S310 - URL is controlled by caller
+                raw = resp.read()
+                if not raw:
+                    return None
+                return json.loads(raw)
+        except HTTPError as exc:
+            last_exc = exc
+            if exc.code not in _RETRYABLE_STATUS:
+                raise ChannelError(
+                    f"{api_name} API returned {exc.code}: {exc.reason}"
+                ) from exc
+            retry_after = _parse_retry_after(
+                exc.headers.get("Retry-After") if exc.headers else None
+            )
+            if attempt == max_attempts:
+                break
+            _wait(sleep, retry_after, attempt, backoff_base, backoff_cap)
+        except URLError as exc:
+            last_exc = exc
+            if attempt == max_attempts:
+                break
+            _wait(sleep, None, attempt, backoff_base, backoff_cap)
+
+    # Retries exhausted.
+    detail = _describe(last_exc)
+    raise ChannelError(
+        f"{api_name} API request failed after {max_attempts} attempts: {detail}"
+    ) from last_exc
+
+
+def _wait(
+    sleep: Callable[[float], None],
+    retry_after: float | None,
+    attempt: int,
+    base: float,
+    cap: float,
+) -> None:
+    """Sleep between attempts honoring ``Retry-After`` when present."""
+    if retry_after is not None:
+        sleep(retry_after)
+        return
+    delay = min(cap, base * (2 ** (attempt - 1)))
+    sleep(delay)
+
+
+def _describe(exc: BaseException | None) -> str:
+    """Render the last exception for the retries-exhausted error message."""
+    if isinstance(exc, HTTPError):
+        return f"{exc.code} {exc.reason}"
+    if isinstance(exc, URLError):
+        return str(exc.reason)
+    return repr(exc)

--- a/src/ac_guard/reporter/_http.py
+++ b/src/ac_guard/reporter/_http.py
@@ -43,7 +43,7 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
-def request_json(
+def request_json(  # noqa: PLR0913 - public API needs all these knobs
     url: str,
     *,
     method: str,
@@ -84,7 +84,7 @@ def request_json(
     for attempt in range(1, max_attempts + 1):
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
-            with urllib.request.urlopen(req) as resp:  # noqa: S310 - URL is controlled by caller
+            with urllib.request.urlopen(req) as resp:
                 raw = resp.read()
                 if not raw:
                     return None

--- a/src/ac_guard/reporter/channel_bitbucket.py
+++ b/src/ac_guard/reporter/channel_bitbucket.py
@@ -7,13 +7,11 @@ via the ``api_url`` configuration.
 
 from __future__ import annotations
 
-import json
 import os
-import urllib.request
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
+from ac_guard.reporter._http import request_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -171,67 +169,24 @@ class BitbucketChannel(ReportChannel):
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with Bearer auth.
-
-        Args:
-            url: API endpoint URL.
-            body: JSON body dict.
-            token: Bearer token.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(
+        """POST JSON with Bearer auth via the shared retry layer."""
+        request_json(
             url,
-            data=data,
             method="POST",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
             },
+            body=body,
+            api_name="Bitbucket",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                resp.read()
-        except HTTPError as exc:
-            raise ChannelError(
-                f"Bitbucket API returned {exc.code}: {exc.reason}"
-            ) from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to Bitbucket API: {exc.reason}"
-            ) from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with Bearer auth.
-
-        Args:
-            url: API endpoint URL.
-            token: Bearer token.
-
-        Returns:
-            Parsed JSON response.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        req = urllib.request.Request(
+        """GET JSON with Bearer auth via the shared retry layer."""
+        return request_json(
             url,
             method="GET",
-            headers={
-                "Authorization": f"Bearer {token}",
-            },
+            headers={"Authorization": f"Bearer {token}"},
+            api_name="Bitbucket",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
-        except HTTPError as exc:
-            raise ChannelError(
-                f"Bitbucket API returned {exc.code}: {exc.reason}"
-            ) from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to Bitbucket API: {exc.reason}"
-            ) from exc

--- a/src/ac_guard/reporter/channel_gitea.py
+++ b/src/ac_guard/reporter/channel_gitea.py
@@ -7,13 +7,11 @@ via the ``api_url`` configuration.
 
 from __future__ import annotations
 
-import json
 import os
-import urllib.request
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
+from ac_guard.reporter._http import request_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -163,59 +161,24 @@ class GiteaChannel(ReportChannel):
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with token auth.
-
-        Args:
-            url: API endpoint URL.
-            body: JSON body dict.
-            token: API token.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(
+        """POST JSON with token auth via the shared retry layer."""
+        request_json(
             url,
-            data=data,
             method="POST",
             headers={
                 "Authorization": f"token {token}",
                 "Content-Type": "application/json",
             },
+            body=body,
+            api_name="Gitea",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                resp.read()
-        except HTTPError as exc:
-            raise ChannelError(f"Gitea API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(f"Failed to connect to Gitea API: {exc.reason}") from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with token auth.
-
-        Args:
-            url: API endpoint URL.
-            token: API token.
-
-        Returns:
-            Parsed JSON response.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        req = urllib.request.Request(
+        """GET JSON with token auth via the shared retry layer."""
+        return request_json(
             url,
             method="GET",
-            headers={
-                "Authorization": f"token {token}",
-            },
+            headers={"Authorization": f"token {token}"},
+            api_name="Gitea",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
-        except HTTPError as exc:
-            raise ChannelError(f"Gitea API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(f"Failed to connect to Gitea API: {exc.reason}") from exc

--- a/src/ac_guard/reporter/channel_github.py
+++ b/src/ac_guard/reporter/channel_github.py
@@ -7,14 +7,12 @@ via the ``api_url`` configuration.
 
 from __future__ import annotations
 
-import json
 import os
 import re
-import urllib.request
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
+from ac_guard.reporter._http import request_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -177,65 +175,28 @@ class GitHubChannel(ReportChannel):
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with Bearer auth.
-
-        Args:
-            url: API endpoint URL.
-            body: JSON body dict.
-            token: Bearer token.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(
+        """POST JSON with Bearer auth via the shared retry layer."""
+        request_json(
             url,
-            data=data,
             method="POST",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
                 "Content-Type": "application/json",
             },
+            body=body,
+            api_name="GitHub",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                resp.read()
-        except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
-            ) from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with Bearer auth.
-
-        Args:
-            url: API endpoint URL.
-            token: Bearer token.
-
-        Returns:
-            Parsed JSON response.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        req = urllib.request.Request(
+        """GET JSON with Bearer auth via the shared retry layer."""
+        return request_json(
             url,
             method="GET",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
             },
+            api_name="GitHub",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
-        except HTTPError as exc:
-            raise ChannelError(f"GitHub API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitHub API: {exc.reason}"
-            ) from exc

--- a/src/ac_guard/reporter/channel_gitlab.py
+++ b/src/ac_guard/reporter/channel_gitlab.py
@@ -7,14 +7,12 @@ via the ``api_url`` configuration.
 
 from __future__ import annotations
 
-import json
 import os
 import urllib.parse
-import urllib.request
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError, URLError
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
+from ac_guard.reporter._http import request_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -172,63 +170,24 @@ class GitLabChannel(ReportChannel):
 
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
-        """POST JSON to a URL with PRIVATE-TOKEN auth.
-
-        Args:
-            url: API endpoint URL.
-            body: JSON body dict.
-            token: Private token.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(
+        """POST JSON with PRIVATE-TOKEN auth via the shared retry layer."""
+        request_json(
             url,
-            data=data,
             method="POST",
             headers={
                 "PRIVATE-TOKEN": token,
                 "Content-Type": "application/json",
             },
+            body=body,
+            api_name="GitLab",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                resp.read()
-        except HTTPError as exc:
-            raise ChannelError(f"GitLab API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitLab API: {exc.reason}"
-            ) from exc
 
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
-        """GET JSON from a URL with PRIVATE-TOKEN auth.
-
-        Args:
-            url: API endpoint URL.
-            token: Private token.
-
-        Returns:
-            Parsed JSON response.
-
-        Raises:
-            ChannelError: On HTTP or connection error.
-        """
-        req = urllib.request.Request(
+        """GET JSON with PRIVATE-TOKEN auth via the shared retry layer."""
+        return request_json(
             url,
             method="GET",
-            headers={
-                "PRIVATE-TOKEN": token,
-            },
+            headers={"PRIVATE-TOKEN": token},
+            api_name="GitLab",
         )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
-        except HTTPError as exc:
-            raise ChannelError(f"GitLab API returned {exc.code}: {exc.reason}") from exc
-        except URLError as exc:
-            raise ChannelError(
-                f"Failed to connect to GitLab API: {exc.reason}"
-            ) from exc

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for integration tests.
+
+The autouse ``_isolate_cwd`` fixture forces every integration test into
+its own ``tmp_path`` before the test body runs. Without it, any test
+that invokes a cwd-sensitive command (``ac-guard install`` /
+``uninstall`` / ``update``) would operate on the real repository root
+and — now that ac-guard dogfoods itself — actively destroy this repo's
+own installed hooks and state.
+
+Tests that legitimately need a different working directory can still
+call ``monkeypatch.chdir(other_path)`` inside the body; this fixture
+only guarantees the default is never the real repo root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every integration test's cwd to its own tmp_path."""
+    monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_cli_lifecycle.py
+++ b/tests/integration/test_cli_lifecycle.py
@@ -85,13 +85,10 @@ class TestFullLifecycle:
         )
         assert result.exit_code == 0, f"update failed: {result.output}"
 
-        # 8. uninstall --keep-config
-        result = runner.invoke(
-            app,
-            ["uninstall", "--keep-config"],
-        )
-        # uninstall uses cwd, but our state is in tmp_path
-        # Use monkeypatch approach via separate test below
+        # Step 8 (uninstall) is covered by ``test_uninstall_lifecycle``
+        # below, which ``monkeypatch.chdir(tmp_path)``. Running uninstall
+        # here would act on pytest's real cwd and — now that ac-guard
+        # dogfoods itself — wipe this repo's installed hooks.
 
     def test_uninstall_lifecycle(self, tmp_path: Path, monkeypatch: object) -> None:
         """Test uninstall as part of lifecycle (requires chdir)."""

--- a/tests/unit/test_reporter/test_channel_bitbucket.py
+++ b/tests/unit/test_reporter/test_channel_bitbucket.py
@@ -180,3 +180,21 @@ class TestBitbucketChannel:
             pytest.raises(NoPrContextError, match="PR ID"),
         ):
             BitbucketChannel().send("r", self._make_config())
+
+    def test_send_retries_transient_urlerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient URLError is retried by the shared HTTP layer."""
+        from urllib.error import URLError
+
+        monkeypatch.setenv("BITBUCKET_TOKEN", "bb_test123")
+        monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
+        monkeypatch.setenv("BITBUCKET_PR_ID", "42")
+
+        side_effect = [URLError("transient"), self._mock_urlopen()]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect) as m,
+            patch("ac_guard.reporter._http.time.sleep"),
+        ):
+            BitbucketChannel().send("## Report", self._make_config())
+        assert m.call_count == 2

--- a/tests/unit/test_reporter/test_channel_gitea.py
+++ b/tests/unit/test_reporter/test_channel_gitea.py
@@ -165,3 +165,21 @@ class TestGiteaChannel:
             pytest.raises(NoPrContextError, match="PR number"),
         ):
             GiteaChannel().send("r", self._make_config())
+
+    def test_send_retries_transient_urlerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient URLError is retried by the shared HTTP layer."""
+        from urllib.error import URLError
+
+        monkeypatch.setenv("GITEA_TOKEN", "gt_test123")
+        monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("AI_GUARD_PR_NUMBER", "42")
+
+        side_effect = [URLError("transient"), self._mock_urlopen()]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect) as m,
+            patch("ac_guard.reporter._http.time.sleep"),
+        ):
+            GiteaChannel().send("## Report", self._make_config())
+        assert m.call_count == 2

--- a/tests/unit/test_reporter/test_channel_github.py
+++ b/tests/unit/test_reporter/test_channel_github.py
@@ -214,3 +214,21 @@ class TestGitHubChannel:
             pytest.raises(NoPrContextError, match="PR number"),
         ):
             GitHubChannel().send("r", self._make_config())
+
+    def test_send_retries_transient_urlerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single URLError is transparently retried by the shared HTTP layer."""
+        from urllib.error import URLError
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        side_effect = [URLError("transient"), self._mock_urlopen()]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect) as m,
+            patch("ac_guard.reporter._http.time.sleep"),
+        ):
+            GitHubChannel().send("## Report", self._make_config())
+        assert m.call_count == 2

--- a/tests/unit/test_reporter/test_channel_gitlab.py
+++ b/tests/unit/test_reporter/test_channel_gitlab.py
@@ -165,3 +165,21 @@ class TestGitLabChannel:
             pytest.raises(NoPrContextError, match="MR IID"),
         ):
             GitLabChannel().send("r", self._make_config())
+
+    def test_send_retries_transient_urlerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient URLError is retried by the shared HTTP layer."""
+        from urllib.error import URLError
+
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test123")
+        monkeypatch.setenv("CI_PROJECT_ID", "12345")
+        monkeypatch.setenv("CI_MERGE_REQUEST_IID", "42")
+
+        side_effect = [URLError("transient"), self._mock_urlopen()]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect) as m,
+            patch("ac_guard.reporter._http.time.sleep"),
+        ):
+            GitLabChannel().send("## Report", self._make_config())
+        assert m.call_count == 2

--- a/tests/unit/test_reporter/test_http.py
+++ b/tests/unit/test_reporter/test_http.py
@@ -1,0 +1,212 @@
+"""Tests for the shared HTTP retry/backoff layer (WP6.2 / #67)."""
+
+from __future__ import annotations
+
+import io
+import json
+from email.message import Message
+from typing import Any
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from ac_guard.reporter._http import request_json
+from ac_guard.reporter.channel_base import ChannelError
+
+
+class _FakeResponse:
+    """Stand-in for the context manager returned by urlopen."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def _ok(payload: Any) -> _FakeResponse:
+    return _FakeResponse(json.dumps(payload).encode("utf-8"))
+
+
+def _http_error(code: int, *, retry_after: str | None = None) -> HTTPError:
+    hdrs = Message()
+    if retry_after is not None:
+        hdrs["Retry-After"] = retry_after
+    return HTTPError(
+        url="https://example/api",
+        code=code,
+        msg=f"error {code}",
+        hdrs=hdrs,  # type: ignore[arg-type]
+        fp=io.BytesIO(b""),
+    )
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": "Bearer x", "Accept": "application/json"}
+
+
+class _SleepRecorder:
+    """Captures sleep calls for assertion."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+class TestRequestJson:
+    """request_json retry/backoff behaviour."""
+
+    def test_success_without_retry(self) -> None:
+        """200 on first attempt returns parsed body and does not sleep."""
+        sleeper = _SleepRecorder()
+        with patch("urllib.request.urlopen", return_value=_ok({"ok": True})):
+            result = request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitHub",
+                sleep=sleeper,
+            )
+        assert result == {"ok": True}
+        assert sleeper.calls == []
+
+    def test_retries_on_urlerror_then_succeeds(self) -> None:
+        """Transient URLError is retried; a later 200 still succeeds."""
+        sleeper = _SleepRecorder()
+        side_effect = [URLError("net down"), URLError("net down"), _ok([1, 2])]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            result = request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitHub",
+                sleep=sleeper,
+            )
+        assert result == [1, 2]
+        assert len(sleeper.calls) == 2
+
+    def test_retries_exhausted_on_503(self) -> None:
+        """Persistent 503 exhausts retries and raises with attempt count."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(503) for _ in range(3)]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            with pytest.raises(ChannelError, match="after 3 attempts"):
+                request_json(
+                    "https://example/api",
+                    method="POST",
+                    headers=_headers(),
+                    body={"x": 1},
+                    api_name="GitHub",
+                    sleep=sleeper,
+                )
+
+    def test_retries_on_500_then_succeeds(self) -> None:
+        """500 is retryable; next 200 completes the request."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(500), _ok({"ok": 1})]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            result = request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitLab",
+                sleep=sleeper,
+            )
+        assert result == {"ok": 1}
+        assert len(sleeper.calls) == 1
+
+    def test_404_fails_immediately(self) -> None:
+        """Non-retryable 4xx raises without consuming retry budget."""
+        sleeper = _SleepRecorder()
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+            with pytest.raises(ChannelError, match="404"):
+                request_json(
+                    "https://example/api",
+                    method="GET",
+                    headers=_headers(),
+                    api_name="Gitea",
+                    sleep=sleeper,
+                )
+        assert sleeper.calls == []
+
+    def test_401_fails_immediately(self) -> None:
+        """Auth errors must not be retried."""
+        sleeper = _SleepRecorder()
+        with patch("urllib.request.urlopen", side_effect=_http_error(401)):
+            with pytest.raises(ChannelError, match="401"):
+                request_json(
+                    "https://example/api",
+                    method="GET",
+                    headers=_headers(),
+                    api_name="Bitbucket",
+                    sleep=sleeper,
+                )
+        assert sleeper.calls == []
+
+    def test_respects_retry_after_header(self) -> None:
+        """429 with Retry-After overrides exponential backoff."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(429, retry_after="2"), _ok({"ok": 1})]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitHub",
+                sleep=sleeper,
+            )
+        assert sleeper.calls == [2.0]
+
+    def test_exponential_backoff_sequence(self) -> None:
+        """Without Retry-After, sleep durations follow exponential growth."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(503), _http_error(503), _ok({"ok": 1})]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitHub",
+                backoff_base=0.5,
+                sleep=sleeper,
+            )
+        assert sleeper.calls == [0.5, 1.0]
+
+    def test_backoff_cap_applies(self) -> None:
+        """Sleep is clamped to backoff_cap even when the series would exceed it."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(503), _http_error(503), _ok({"ok": 1})]
+        with patch("urllib.request.urlopen", side_effect=side_effect):
+            request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="GitHub",
+                backoff_base=4.0,
+                backoff_cap=5.0,
+                sleep=sleeper,
+            )
+        # attempt 1 -> 4, attempt 2 -> min(5, 8) = 5
+        assert sleeper.calls == [4.0, 5.0]
+
+    def test_empty_response_body_returns_none(self) -> None:
+        """Empty response body (common for POST-no-echo) yields None."""
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(b"")):
+            result = request_json(
+                "https://example/api",
+                method="POST",
+                headers=_headers(),
+                body={"x": 1},
+                api_name="GitHub",
+                sleep=_SleepRecorder(),
+            )
+        assert result is None

--- a/tests/unit/test_reporter/test_http.py
+++ b/tests/unit/test_reporter/test_http.py
@@ -98,16 +98,18 @@ class TestRequestJson:
         """Persistent 503 exhausts retries and raises with attempt count."""
         sleeper = _SleepRecorder()
         side_effect = [_http_error(503) for _ in range(3)]
-        with patch("urllib.request.urlopen", side_effect=side_effect):
-            with pytest.raises(ChannelError, match="after 3 attempts"):
-                request_json(
-                    "https://example/api",
-                    method="POST",
-                    headers=_headers(),
-                    body={"x": 1},
-                    api_name="GitHub",
-                    sleep=sleeper,
-                )
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect),
+            pytest.raises(ChannelError, match="after 3 attempts"),
+        ):
+            request_json(
+                "https://example/api",
+                method="POST",
+                headers=_headers(),
+                body={"x": 1},
+                api_name="GitHub",
+                sleep=sleeper,
+            )
 
     def test_retries_on_500_then_succeeds(self) -> None:
         """500 is retryable; next 200 completes the request."""
@@ -127,29 +129,33 @@ class TestRequestJson:
     def test_404_fails_immediately(self) -> None:
         """Non-retryable 4xx raises without consuming retry budget."""
         sleeper = _SleepRecorder()
-        with patch("urllib.request.urlopen", side_effect=_http_error(404)):
-            with pytest.raises(ChannelError, match="404"):
-                request_json(
-                    "https://example/api",
-                    method="GET",
-                    headers=_headers(),
-                    api_name="Gitea",
-                    sleep=sleeper,
-                )
+        with (
+            patch("urllib.request.urlopen", side_effect=_http_error(404)),
+            pytest.raises(ChannelError, match="404"),
+        ):
+            request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="Gitea",
+                sleep=sleeper,
+            )
         assert sleeper.calls == []
 
     def test_401_fails_immediately(self) -> None:
         """Auth errors must not be retried."""
         sleeper = _SleepRecorder()
-        with patch("urllib.request.urlopen", side_effect=_http_error(401)):
-            with pytest.raises(ChannelError, match="401"):
-                request_json(
-                    "https://example/api",
-                    method="GET",
-                    headers=_headers(),
-                    api_name="Bitbucket",
-                    sleep=sleeper,
-                )
+        with (
+            patch("urllib.request.urlopen", side_effect=_http_error(401)),
+            pytest.raises(ChannelError, match="401"),
+        ):
+            request_json(
+                "https://example/api",
+                method="GET",
+                headers=_headers(),
+                api_name="Bitbucket",
+                sleep=sleeper,
+            )
         assert sleeper.calls == []
 
     def test_respects_retry_after_header(self) -> None:


### PR DESCRIPTION
## Summary

- **Reporter reliability (#67)**: introduce `src/ac_guard/reporter/_http.py` with bounded retries (URLError, 408/429/5xx), exponential backoff + `Retry-After`, and fast-fail on business 4xx. All four channels (GitHub/GitLab/Gitea/Bitbucket) become thin header-building wrappers. `ChannelError` contract and method signatures are unchanged.
- **Test-isolation fix (#118)**: `tests/integration/test_cli_lifecycle.py::test_complete_lifecycle` was invoking `ac-guard uninstall` without `monkeypatch.chdir(tmp_path)`. Post-dogfood (PR #115) that test ran against the real repo root and deleted this repo's own hooks, `.pre-commit-config.yaml`, and `.ac-guard/` state on every `pytest tests/` run. Removed the stray call and added an autouse `_isolate_cwd` fixture so future tests can't make the same mistake.

Closes #67. Covers the fix portion of #118 (the optional uninstall-confirmation UX is left for follow-up).

## Why the test-isolation fix is in this PR

The reporter refactor required running the full suite twice; each run silently destroyed this repo's installed state and left Claude Code's hook self-locked until the interceptor was manually restored. Shipping the fix separately would have meant two more self-lock incidents before the reporter PR could land.

## Test plan

- [x] `pytest tests/unit/test_reporter -q` → 114 passed (10 new `_http` + 4 new channel smoke tests + 100 existing)
- [x] `pytest tests/ -q` → 945 passed (no regressions)
- [x] `pre-commit run --all-files` → all green (ruff, interrogate, bandit, import-linter, conventional-pre-commit)
- [x] Manual: ran full suite a second time; real `.claude/hooks/interceptor.py`, `.git/hooks/*`, `.pre-commit-config.yaml`, `.ac-guard/state.json` all survive
- [ ] CI verifies `pre-commit` + test matrix across Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)