### PR TITLE
feat(config)!: schema v2 Phase 1a — code.<stage> buckets + loader/merger/validator

### DIFF
--- a/guard.yaml
+++ b/guard.yaml
@@ -23,8 +23,13 @@ behavior:
         message: "scripts/ contains guard infrastructure (lint checkers etc.); edits weaken enforcement"
 
 code:
-  commit:
-    format: true    # → format-python hook, populated inside the managed block
+  # Schema v2 (#123): keyed by pre-commit gating stage name. Most
+  # project hooks live under `pre-commit`; add `pre-push`, `commit-msg`
+  # etc. as needed. `format`/`lint` toggles auto-generate per-language
+  # local hooks from the `languages:` tool map.
+  pre-commit:
+    format: true
+    lint: true      # ruff check --fix at pre-commit stage
     checks:
       forbid-noqa:
         command: "python3 scripts/check_no_noqa.py"
@@ -32,8 +37,6 @@ code:
       require-explicit-encoding:
         command: "python3 scripts/check_encoding.py"
         types: [python]
-  push:
-    lint: true      # → lint-python hook, populated inside the managed block
 
 output:
   audit:

--- a/src/ac_guard/config/defaults/presets/minimal.yaml
+++ b/src/ac_guard/config/defaults/presets/minimal.yaml
@@ -2,9 +2,9 @@
 # 仅内置默认 + format + test
 
 code:
-  commit:
+  pre-commit:
     format: true
-  push:
+  pre-push:
     checks:
       test:
         command: "pytest"

--- a/src/ac_guard/config/defaults/presets/standard.yaml
+++ b/src/ac_guard/config/defaults/presets/standard.yaml
@@ -2,9 +2,9 @@
 # format + lint + test + coverage + audit
 
 code:
-  commit:
+  pre-commit:
     format: true
-  push:
+  pre-push:
     lint: true
     checks:
       test:

--- a/src/ac_guard/config/defaults/presets/strict.yaml
+++ b/src/ac_guard/config/defaults/presets/strict.yaml
@@ -10,9 +10,9 @@ behavior:
         reason: "Credential files are protected"
 
 code:
-  commit:
+  pre-commit:
     format: true
-  push:
+  pre-push:
     lint: true
     checks:
       test:

--- a/src/ac_guard/config/loader.py
+++ b/src/ac_guard/config/loader.py
@@ -65,20 +65,52 @@ class RawCheckItemDict(TypedDict, total=False):
     pass_filenames: bool
 
 
-class RawCodeStageDict(TypedDict, total=False):
-    """Raw code stage (commit or push)."""
+class RawPreCommitHookDict(TypedDict, total=False):
+    """Raw pre-commit hook entry. Only ``id`` is required; all other
+    pre-commit fields pass through verbatim."""
+
+    id: str
+
+
+class RawPreCommitRepoDict(TypedDict, total=False):
+    """Raw pre-commit repo entry."""
+
+    repo: str
+    rev: str
+    hooks: list[RawPreCommitHookDict]
+
+
+class RawStageBucketDict(TypedDict, total=False):
+    """Raw per-stage bucket under ``code.<stage>``."""
 
     format: bool
-    naming: bool
     lint: bool
     checks: dict[str, RawCheckItemDict]
+    hooks: list[RawPreCommitRepoDict]
+
+
+class RawExtraDict(TypedDict, total=False):
+    """Raw ``code._extra`` block (passthrough for non-gating stages)."""
+
+    repos: list[RawPreCommitRepoDict]
 
 
 class RawCodeDict(TypedDict, total=False):
-    """Raw code quality config."""
+    """Raw ``code:`` config, keyed by pre-commit gating stage names."""
 
-    commit: RawCodeStageDict
-    push: RawCodeStageDict
+    # YAML keys use hyphens: pre-commit, commit-msg, pre-merge-commit,
+    # pre-push, pre-rebase. We cannot declare hyphenated identifiers as
+    # TypedDict attributes; the loader uses dict lookups with the yaml
+    # string keys directly.
+    _extra: RawExtraDict
+
+
+class RawPreCommitMetaDict(TypedDict, total=False):
+    """Raw ``_pre_commit:`` top-level block."""
+
+    minimum_version: str
+    default_install_hook_types: list[str]
+    default_language_version: dict[str, str]
 
 
 class RawLanguageToolsDict(TypedDict, total=False):
@@ -149,6 +181,7 @@ class RawConfig(TypedDict, total=False):
     code: RawCodeDict
     build: RawBuildDict
     output: RawOutputDict
+    _pre_commit: RawPreCommitMetaDict
 
 
 # --- Public API ---

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -34,9 +34,13 @@ from ac_guard.config.models import (
     LanguageTools,
     OperationRules,
     OutputConfig,
+    PreCommitHook,
+    PreCommitMeta,
+    PreCommitRepo,
     PrReportConfig,
     ResolvedConfig,
     Rule,
+    StageBucket,
 )
 
 __all__ = ["resolve_config"]
@@ -54,8 +58,12 @@ _BUILTIN_DEFAULTS: RawConfig = {  # type: ignore[typeddict-unknown-key]
         "execute": {},
     },
     "code": {
-        "commit": {"format": True, "naming": False, "checks": {}},
-        "push": {"lint": True, "checks": {}},
+        "pre-commit": {"format": True, "lint": False, "checks": {}, "hooks": []},
+        "commit-msg": {"format": False, "lint": False, "checks": {}, "hooks": []},
+        "pre-merge-commit": {"format": False, "lint": False, "checks": {}, "hooks": []},
+        "pre-push": {"format": False, "lint": True, "checks": {}, "hooks": []},
+        "pre-rebase": {"format": False, "lint": False, "checks": {}, "hooks": []},
+        "_extra": {"repos": []},
     },
     "output": {
         "verbosity": "normal",
@@ -204,11 +212,29 @@ def _merge_operation_rules(
     return merged
 
 
+_GATING_STAGES = (
+    "pre-commit",
+    "commit-msg",
+    "pre-merge-commit",
+    "pre-push",
+    "pre-rebase",
+)
+
+
 def _merge_code(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
     merged = copy.deepcopy(base)
-    for stage in ("commit", "push"):
+    for stage in _GATING_STAGES:
         if stage in overlay:
             merged[stage] = _merge_code_stage(merged.get(stage, {}), overlay[stage])
+    # _extra.repos: append overlay repos (last-write-wins semantics not
+    # meaningful for pre-commit repo lists; concatenate so ruleset-
+    # provided extras survive the user's own declarations).
+    if "_extra" in overlay:
+        base_extra = merged.get("_extra", {"repos": []})
+        overlay_repos = overlay["_extra"].get("repos", [])
+        merged["_extra"] = {
+            "repos": base_extra.get("repos", []) + copy.deepcopy(overlay_repos)
+        }
     return merged
 
 
@@ -217,10 +243,36 @@ def _merge_code_stage(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str
     for key, value in overlay.items():
         if key == "checks":
             merged["checks"] = _deep_merge_checks(merged.get("checks", {}), value)
+        elif key == "hooks":
+            # Append external repo lists: ruleset hooks + user hooks
+            # coexist. Dedup by (repo, rev) last-wins.
+            merged["hooks"] = _merge_precommit_repos(merged.get("hooks", []), value)
         else:
-            # Scalar bools (format, naming, lint)
+            # Scalar bools (format, lint)
             merged[key] = value
     return merged
+
+
+def _merge_precommit_repos(
+    base: list[dict[str, Any]], overlay: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Concatenate two pre-commit repos lists, deduping by (repo, rev).
+
+    When the same (repo, rev) pair appears in both, the overlay's entry
+    replaces the base — hooks list and any other fields are taken from
+    the overlay, letting user guard.yaml override ruleset defaults.
+    """
+    result: list[dict[str, Any]] = [copy.deepcopy(r) for r in base]
+    by_key = {(r.get("repo"), r.get("rev")): i for i, r in enumerate(result)}
+    for repo in overlay:
+        key = (repo.get("repo"), repo.get("rev"))
+        copied = copy.deepcopy(repo)
+        if key in by_key:
+            result[by_key[key]] = copied
+        else:
+            by_key[key] = len(result)
+            result.append(copied)
+    return result
 
 
 def _deep_merge_checks(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -395,6 +447,7 @@ def _to_resolved_config(
         code=_to_code(merged.get("code", {})),
         languages=_to_languages(merged.get("languages", {})),
         output=_to_output(merged.get("output", {})),
+        pre_commit_meta=_to_pre_commit_meta(merged.get("_pre_commit", {})),
         build_command=merged.get("build", {}).get("command"),
         config_hash=config_hash,
         rulesets=merged.get("rulesets", []),
@@ -428,19 +481,53 @@ def _to_rule(raw: dict[str, Any]) -> Rule:
 
 
 def _to_code(raw: dict[str, Any]) -> CodeConfig:
-    commit = raw.get("commit", {})
-    push = raw.get("push", {})
+    buckets: dict[str, StageBucket] = {}
+    for stage in _GATING_STAGES:
+        raw_bucket = raw.get(stage, {})
+        buckets[stage] = _to_stage_bucket(raw_bucket)
+    extra_repos = [
+        _to_precommit_repo(r) for r in raw.get("_extra", {}).get("repos", [])
+    ]
+    # Map yaml hyphenated stage names to Python attribute names.
     return CodeConfig(
-        commit_format=commit.get("format", True),
-        commit_naming=commit.get("naming", False),
-        commit_checks={
-            name: _to_check_item(item)
-            for name, item in commit.get("checks", {}).items()
+        pre_commit=buckets["pre-commit"],
+        commit_msg=buckets["commit-msg"],
+        pre_merge_commit=buckets["pre-merge-commit"],
+        pre_push=buckets["pre-push"],
+        pre_rebase=buckets["pre-rebase"],
+        extra_repos=extra_repos,
+    )
+
+
+def _to_stage_bucket(raw: dict[str, Any]) -> StageBucket:
+    return StageBucket(
+        format=bool(raw.get("format", False)),
+        lint=bool(raw.get("lint", False)),
+        checks={
+            name: _to_check_item(item) for name, item in raw.get("checks", {}).items()
         },
-        push_lint=push.get("lint", True),
-        push_checks={
-            name: _to_check_item(item) for name, item in push.get("checks", {}).items()
-        },
+        hooks=[_to_precommit_repo(r) for r in raw.get("hooks", [])],
+    )
+
+
+def _to_precommit_repo(raw: dict[str, Any]) -> PreCommitRepo:
+    return PreCommitRepo(
+        repo=raw["repo"],
+        rev=raw.get("rev"),
+        hooks=[_to_precommit_hook(h) for h in raw.get("hooks", [])],
+    )
+
+
+def _to_precommit_hook(raw: dict[str, Any]) -> PreCommitHook:
+    extra = {k: v for k, v in raw.items() if k != "id"}
+    return PreCommitHook(id=raw["id"], extra=extra)
+
+
+def _to_pre_commit_meta(raw: dict[str, Any]) -> PreCommitMeta:
+    return PreCommitMeta(
+        minimum_version=raw.get("minimum_version"),
+        default_install_hook_types=raw.get("default_install_hook_types"),
+        default_language_version=dict(raw.get("default_language_version", {})),
     )
 
 

--- a/src/ac_guard/config/models.py
+++ b/src/ac_guard/config/models.py
@@ -3,11 +3,19 @@
 All config-related dataclasses that represent the parsed and merged
 guard.yaml configuration. These are pure data containers with no
 validation logic — schema validation belongs in the config loader.
+
+Schema v2 (#123): ``code:`` is keyed by pre-commit gating stage names
+(pre-commit / commit-msg / pre-merge-commit / pre-push / pre-rebase).
+Each stage bucket holds the same five fields
+(``format`` / ``lint`` / ``checks`` / ``hooks`` / plus ruff N-rules via
+``lint``). ``_pre_commit`` carries top-level pre-commit meta, ``_extra``
+carries passthrough hooks for non-gating stages.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 __all__ = [
     "AuditConfig",
@@ -18,8 +26,12 @@ __all__ = [
     "OperationRules",
     "OutputConfig",
     "PrReportConfig",
+    "PreCommitHook",
+    "PreCommitMeta",
+    "PreCommitRepo",
     "ResolvedConfig",
     "Rule",
+    "StageBucket",
 ]
 
 
@@ -107,7 +119,11 @@ class BehaviorConfig:
 
 @dataclass
 class CheckItem:
-    """A single code check definition.
+    """A single code check definition (short-hand for local hooks).
+
+    A ``CheckItem`` is rendered into the generated
+    ``.pre-commit-config.yaml`` as a ``custom-<name>`` entry under the
+    stage bucket's ``repo: local`` block.
 
     Attributes:
         command: Shell command to execute for this check.
@@ -127,25 +143,174 @@ class CheckItem:
 
 
 @dataclass
-class CodeConfig:
-    """Code quality check configuration.
+class PreCommitHook:
+    """Passthrough wrapper for a single pre-commit hook entry.
+
+    ``id`` is required; all other pre-commit fields (``name`` / ``entry`` /
+    ``args`` / ``language`` / ``types`` / ``pass_filenames`` /
+    ``additional_dependencies`` / ``stages`` / ``always_run`` / ``files`` /
+    ``exclude`` / ...) are carried verbatim in ``extra`` so new
+    pre-commit fields work without schema changes.
 
     Attributes:
-        commit_format: Enable format checking at commit stage.
-        commit_naming: Enable naming convention checking at
-            commit stage.
-        commit_checks: Custom check items run at commit stage,
-            keyed by check name.
-        push_lint: Enable semantic lint at push stage.
-        push_checks: Custom check items run at push stage,
-            keyed by check name.
+        id: Hook identifier (required).
+        extra: Any additional pre-commit hook fields passed through
+            to the generated yaml as-is.
     """
 
-    commit_format: bool = True
-    commit_naming: bool = False
-    commit_checks: dict[str, CheckItem] = field(default_factory=dict)
-    push_lint: bool = True
-    push_checks: dict[str, CheckItem] = field(default_factory=dict)
+    id: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PreCommitRepo:
+    """Passthrough wrapper for a pre-commit ``repos[]`` entry.
+
+    Attributes:
+        repo: Repository URL or the literal ``"local"``.
+        rev: Repository revision tag/branch. ``None`` for local repos.
+        hooks: List of hook entries under this repo.
+    """
+
+    repo: str
+    rev: str | None = None
+    hooks: list[PreCommitHook] = field(default_factory=list)
+
+
+@dataclass
+class StageBucket:
+    """Per-stage configuration bucket under ``code.<stage>``.
+
+    Each bucket produces exactly one local ac-guard repo entry (built
+    from ``format`` / ``lint`` / ``checks``) plus ``hooks`` passed
+    through verbatim in the generated ``.pre-commit-config.yaml``. All
+    resulting hooks carry the bucket's stage as their default
+    ``stages:`` field (user-provided ``stages`` on passthrough hooks
+    overrides).
+
+    Attributes:
+        format: Inject per-language format hooks (``format-<lang>``)
+            from ``languages[*].tools.format``.
+        lint: Inject per-language lint hooks (``lint-<lang>``) from
+            ``languages[*].tools.lint``.
+        checks: Short-hand local hooks rendered as ``custom-<name>``.
+        hooks: Full pre-commit repo/hook declarations. Community repos
+            or project-specific local hooks that need the full
+            passthrough surface live here.
+    """
+
+    format: bool = False
+    lint: bool = False
+    checks: dict[str, CheckItem] = field(default_factory=dict)
+    hooks: list[PreCommitRepo] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """True when no ac-guard semantic or external hooks are declared."""
+        return not self.format and not self.lint and not self.checks and not self.hooks
+
+
+@dataclass
+class CodeConfig:
+    """Code quality configuration, keyed by pre-commit gating stage.
+
+    The five gating stage buckets mirror pre-commit's native stage
+    taxonomy. Non-gating stages (post-* / prepare-commit-msg / manual)
+    live in ``extra_repos`` as passthrough — ac-guard does not gate
+    them but renders them into the generated yaml so pre-commit still
+    executes them.
+
+    Attributes:
+        pre_commit: pre-commit stage (most project hooks land here).
+        commit_msg: commit-msg stage (e.g. conventional-pre-commit).
+        pre_merge_commit: pre-merge-commit stage (rare).
+        pre_push: pre-push stage (heavy checks, test/coverage).
+        pre_rebase: pre-rebase stage (rare).
+        extra_repos: Passthrough repos for non-gating stages
+            (populated from ``code._extra.repos`` in yaml).
+    """
+
+    pre_commit: StageBucket = field(default_factory=StageBucket)
+    commit_msg: StageBucket = field(default_factory=StageBucket)
+    pre_merge_commit: StageBucket = field(default_factory=StageBucket)
+    pre_push: StageBucket = field(default_factory=StageBucket)
+    pre_rebase: StageBucket = field(default_factory=StageBucket)
+    extra_repos: list[PreCommitRepo] = field(default_factory=list)
+
+    GATING_STAGES = (
+        "pre_commit",
+        "commit_msg",
+        "pre_merge_commit",
+        "pre_push",
+        "pre_rebase",
+    )
+
+    def buckets(self) -> list[tuple[str, StageBucket]]:
+        """Return (yaml_stage_name, bucket) pairs for all gating stages."""
+        return [
+            ("pre-commit", self.pre_commit),
+            ("commit-msg", self.commit_msg),
+            ("pre-merge-commit", self.pre_merge_commit),
+            ("pre-push", self.pre_push),
+            ("pre-rebase", self.pre_rebase),
+        ]
+
+    def active_stages(self) -> list[str]:
+        """Return yaml stage names for buckets that have any content.
+
+        Used by ``generate_git_hooks`` to only emit wrappers for
+        stages the project actually uses.
+        """
+        return [name for name, bucket in self.buckets() if not bucket.is_empty()]
+
+    # ---- Legacy read-only shims (Phase 1a, drop in Phase 1c) -----------
+    # These let checker / generator / CLI continue to read ``commit_*`` /
+    # ``push_*`` attributes during the transition to the new bucket API.
+    # Write-paths (merger, test constructors) must use the new fields
+    # directly; shims are read-only.
+
+    @property
+    def commit_format(self) -> bool:
+        return self.pre_commit.format
+
+    @property
+    def commit_naming(self) -> bool:
+        # D8: commit_naming is a dead flag; shim always returns False so
+        # the old checker branch becomes a no-op without removal yet.
+        return False
+
+    @property
+    def commit_checks(self) -> dict[str, CheckItem]:
+        return self.pre_commit.checks
+
+    @property
+    def push_lint(self) -> bool:
+        return self.pre_push.lint
+
+    @property
+    def push_checks(self) -> dict[str, CheckItem]:
+        return self.pre_push.checks
+
+
+@dataclass
+class PreCommitMeta:
+    """Top-level pre-commit yaml fields.
+
+    Populated from guard.yaml's ``_pre_commit:`` block. All fields
+    optional; generator substitutes sensible defaults when absent.
+
+    Attributes:
+        minimum_version: Value for ``minimum_pre_commit_version``
+            in the generated yaml.
+        default_install_hook_types: List for
+            ``default_install_hook_types`` (defaults to the active
+            stages detected from guard.yaml).
+        default_language_version: Map for
+            ``default_language_version`` (e.g. ``{python: python3}``).
+    """
+
+    minimum_version: str | None = None
+    default_install_hook_types: list[str] | None = None
+    default_language_version: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -232,11 +397,13 @@ class ResolvedConfig:
             (e.g. "python", "typescript").
         behavior: Behavior constraint rules across read,
             write, and execute dimensions.
-        code: Code quality check configuration for commit
-            and push stages.
+        code: Code quality configuration keyed by pre-commit
+            gating stage (schema v2).
         languages: Per-language tool mappings, keyed by
             language name.
         output: Output and reporting settings.
+        pre_commit_meta: Top-level pre-commit yaml fields
+            (minimum_version, default_language_version, ...).
         build_command: Optional build command run before
             push-stage checks.
         config_hash: SHA hash of the source guard.yaml,
@@ -250,6 +417,7 @@ class ResolvedConfig:
     code: CodeConfig
     languages: dict[str, LanguageTools]
     output: OutputConfig
+    pre_commit_meta: PreCommitMeta = field(default_factory=PreCommitMeta)
     build_command: str | None = None
     config_hash: str = ""
     rulesets: list[str] = field(default_factory=list)

--- a/src/ac_guard/config/validator.py
+++ b/src/ac_guard/config/validator.py
@@ -62,11 +62,15 @@ class Dict:
         fields: Schema for each allowed key.
         required: Keys that must be present.
         check_regex: Special flag for rule nodes to validate regex patterns.
+        allow_unknown: Accept and skip validation for unknown keys. Used
+            for pre-commit hook passthrough where ac-guard shouldn't
+            enforce a fixed field list (pre-commit may add new fields).
     """
 
     fields: dict[str, SchemaNode]
     required: frozenset[str] = frozenset()
     check_regex: bool = False
+    allow_unknown: bool = False
 
 
 @dataclass(frozen=True)
@@ -138,20 +142,36 @@ _LANGUAGE_ENTRY = Dict(
     required=frozenset({"tools"}),
 )
 
-_COMMIT_STAGE = Dict(
+_PRECOMMIT_HOOK = Dict(
+    # id is required; everything else passes through (schema is lenient
+    # so new pre-commit fields work without ac-guard updates).
+    fields={"id": Str(non_empty=True)},
+    required=frozenset({"id"}),
+    allow_unknown=True,
+)
+
+_PRECOMMIT_REPO = Dict(
+    fields={
+        "repo": Str(non_empty=True),
+        "rev": Str(),
+        "hooks": List(items=_PRECOMMIT_HOOK),
+    },
+    required=frozenset({"repo"}),
+)
+
+# Every gating-stage bucket has the same shape. `naming` is intentionally
+# absent — D8 removed the dead flag; `lint: true` (via ruff N-rules)
+# covers what naming used to try to do.
+_STAGE_BUCKET = Dict(
     fields={
         "format": Bool(),
-        "naming": Bool(),
+        "lint": Bool(),
         "checks": DynDict(values=_CHECK_ITEM),
+        "hooks": List(items=_PRECOMMIT_REPO),
     }
 )
 
-_PUSH_STAGE = Dict(
-    fields={
-        "lint": Bool(),
-        "checks": DynDict(values=_CHECK_ITEM),
-    }
-)
+_EXTRA = Dict(fields={"repos": List(items=_PRECOMMIT_REPO)})
 
 _AUDIT_CONFIG = Dict(
     fields={
@@ -184,7 +204,24 @@ _PROJECT_CONFIG = Dict(
     required=frozenset({"language"}),
 )
 
-_CODE_CONFIG = Dict(fields={"commit": _COMMIT_STAGE, "push": _PUSH_STAGE})
+_CODE_CONFIG = Dict(
+    fields={
+        "pre-commit": _STAGE_BUCKET,
+        "commit-msg": _STAGE_BUCKET,
+        "pre-merge-commit": _STAGE_BUCKET,
+        "pre-push": _STAGE_BUCKET,
+        "pre-rebase": _STAGE_BUCKET,
+        "_extra": _EXTRA,
+    }
+)
+
+_PRE_COMMIT_META = Dict(
+    fields={
+        "minimum_version": Str(),
+        "default_install_hook_types": List(items=Str()),
+        "default_language_version": DynDict(values=Str()),
+    }
+)
 
 _BUILD_CONFIG = Dict(fields={"command": Str()})
 
@@ -201,6 +238,7 @@ _ROOT = Dict(
         "code": _CODE_CONFIG,
         "build": _BUILD_CONFIG,
         "output": _OUTPUT_CONFIG,
+        "_pre_commit": _PRE_COMMIT_META,
     },
     required=frozenset({"version", "project"}),
 )
@@ -329,12 +367,13 @@ class _Validator:
             )
             return
 
-        # Check unknown keys
-        allowed_keys = frozenset(node.fields.keys())
-        for key in data:
-            if key not in allowed_keys:
-                child_path = f"{path}.{key}" if path else key
-                self._add(child_path, f"unknown key '{key}'", key)
+        # Check unknown keys (unless passthrough allowed)
+        if not node.allow_unknown:
+            allowed_keys = frozenset(node.fields.keys())
+            for key in data:
+                if key not in allowed_keys:
+                    child_path = f"{path}.{key}" if path else key
+                    self._add(child_path, f"unknown key '{key}'", key)
 
         # Check required fields and recurse into present fields
         for name, child_node in node.fields.items():

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -42,12 +42,11 @@ def _config_with_checks(tmp_path: Path, *, fail: bool = False) -> Path:
         tmp_path,
         {
             "code": {
-                "commit": {
+                "pre-commit": {
                     "format": False,
-                    "naming": False,
                     "checks": {"custom-commit": {"command": cmd}},
                 },
-                "push": {
+                "pre-push": {
                     "lint": False,
                     "checks": {"custom-push": {"command": "echo push-ok"}},
                 },
@@ -78,8 +77,8 @@ class TestFullCheckLifecycle:
                     "version": 1,
                     "project": {"name": "test", "language": "python"},
                     "code": {
-                        "commit": {"format": False, "naming": False},
-                        "push": {"lint": False},
+                        "pre-commit": {"format": False},
+                        "pre-push": {"lint": False},
                     },
                 },
                 default_flow_style=False,
@@ -210,8 +209,8 @@ class TestVerifyCommand:
             {
                 "build": {"command": "echo built"},
                 "code": {
-                    "commit": {"format": False, "naming": False},
-                    "push": {"lint": False},
+                    "pre-commit": {"format": False},
+                    "pre-push": {"lint": False},
                 },
             },
         )
@@ -234,8 +233,8 @@ class TestVerifyCommand:
                     "python": {"tools": {"format": "black", "lint": "ruff"}},
                 },
                 "code": {
-                    "commit": {"format": False, "naming": False},
-                    "push": {
+                    "pre-commit": {"format": False},
+                    "pre-push": {
                         "lint": True,
                         "checks": {
                             "custom": {
@@ -354,8 +353,8 @@ class TestMultiLanguageE2E:
                         },
                     },
                     "code": {
-                        "commit": {"format": True, "naming": False},
-                        "push": {"lint": True},
+                        "pre-commit": {"format": True},
+                        "pre-push": {"lint": True},
                     },
                 },
                 default_flow_style=False,
@@ -485,9 +484,8 @@ class TestLocalePropagation:
                     "python": {"tools": {"format": "black", "lint": "ruff"}},
                 },
                 "code": {
-                    "commit": {
+                    "pre-commit": {
                         "format": False,
-                        "naming": False,
                         "checks": {
                             "demo": {
                                 "command": "echo ok",
@@ -495,7 +493,7 @@ class TestLocalePropagation:
                             }
                         },
                     },
-                    "push": {"lint": False},
+                    "pre-push": {"lint": False},
                 },
             },
         )

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -49,9 +49,8 @@ def _write_config_with_checks(tmp_path: Path) -> Path:
         "version": 1,
         "project": {"name": "test-project", "language": "python"},
         "code": {
-            "commit": {
+            "pre-commit": {
                 "format": True,
-                "naming": True,
                 "checks": {
                     "unit-test": {
                         "command": "pytest tests/unit",
@@ -59,7 +58,7 @@ def _write_config_with_checks(tmp_path: Path) -> Path:
                     },
                 },
             },
-            "push": {
+            "pre-push": {
                 "lint": True,
                 "checks": {
                     "typecheck": {
@@ -200,9 +199,8 @@ class TestJsonOutput:
             "version": 1,
             "project": {"name": "test", "language": "python"},
             "code": {
-                "commit": {
+                "pre-commit": {
                     "format": False,
-                    "naming": False,
                     "checks": {"fail": {"command": "exit 1"}},
                 },
             },

--- a/tests/unit/test_checker/test_core.py
+++ b/tests/unit/test_checker/test_core.py
@@ -12,7 +12,7 @@ from ac_guard.checker.core import (
     run_check,
     run_stage,
 )
-from ac_guard.config.models import CheckItem, CodeConfig
+from ac_guard.config.models import CheckItem, CodeConfig, StageBucket
 
 
 class TestGetChangedFiles:
@@ -140,7 +140,7 @@ class TestRunStage:
 
     def test_commit_stage_runs_checks(self, tmp_path: Path) -> None:
         """Commit stage runs format + naming checks."""
-        config = CodeConfig(commit_format=True, commit_naming=True)
+        config = CodeConfig(pre_commit=StageBucket(format=True))
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
             report = run_stage("commit", config, tmp_path)
         assert report.stage == "commit"
@@ -150,9 +150,10 @@ class TestRunStage:
     def test_commit_stage_with_custom_checks(self, tmp_path: Path) -> None:
         """Commit stage runs custom checks."""
         config = CodeConfig(
-            commit_format=False,
-            commit_naming=False,
-            commit_checks={"echo": CheckItem(command="echo ok")},
+            pre_commit=StageBucket(
+                format=False,
+                checks={"echo": CheckItem(command="echo ok")},
+            ),
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
             report = run_stage("commit", config, tmp_path)
@@ -162,7 +163,9 @@ class TestRunStage:
     def test_push_stage_fail_fast(self, tmp_path: Path) -> None:
         """Push stage fails fast if commit stage fails."""
         config = CodeConfig(
-            commit_checks={"fail": CheckItem(command="exit 1")},
+            pre_commit=StageBucket(
+                checks={"fail": CheckItem(command="exit 1")},
+            ),
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
             report = run_stage("push", config, tmp_path)
@@ -172,9 +175,7 @@ class TestRunStage:
     def test_push_stage_with_build(self, tmp_path: Path) -> None:
         """Push stage runs build command."""
         config = CodeConfig(
-            commit_format=False,
-            commit_naming=False,
-            push_lint=False,
+            pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=False)
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
             report = run_stage("push", config, tmp_path, build_command="echo build")
@@ -183,7 +184,7 @@ class TestRunStage:
 
     def test_format_iterates_per_language(self, tmp_path: Path) -> None:
         """commit_format=True emits one pre-commit call per configured language."""
-        config = CodeConfig(commit_format=True, commit_naming=False)
+        config = CodeConfig(pre_commit=StageBucket(format=True))
         with patch("ac_guard.checker.core.run_precommit") as mock_run:
             mock_run.return_value.passed = True
             mock_run.return_value.name = "stub"
@@ -204,7 +205,9 @@ class TestRunStage:
 
     def test_lint_iterates_per_language(self, tmp_path: Path) -> None:
         """push_lint=True emits one pre-commit call per configured language."""
-        config = CodeConfig(commit_format=False, commit_naming=False, push_lint=True)
+        config = CodeConfig(
+            pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=True)
+        )
         with patch("ac_guard.checker.core.run_precommit") as mock_run:
             mock_run.return_value.passed = True
             mock_run.return_value.name = "stub"
@@ -225,19 +228,16 @@ class TestRunStage:
         assert "lint-python" in hook_ids
         assert "lint-typescript" in hook_ids
 
-    def test_naming_returns_skipped_when_enabled(self, tmp_path: Path) -> None:
-        """commit_naming=True returns a skipped CheckResult (not a pre-commit call)."""
-        config = CodeConfig(commit_format=False, commit_naming=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]):
-            report = run_stage("commit", config, tmp_path, languages=["python"])
-        naming_results = [r for r in report.results if r.name == "naming"]
-        assert len(naming_results) == 1
-        assert naming_results[0].skipped is True
-        assert "not yet implemented" in naming_results[0].output.lower()
+    # D8: ``commit_naming`` flag removed in schema v2 (#123). Shim in
+    # CodeConfig always returns False, so the checker's naming branch
+    # is now unreachable. The dedicated "naming returns skipped" test
+    # is obsolete; ruff N-rules (via ``lint: true``) replaced it.
 
     def test_no_languages_skips_format_and_lint(self, tmp_path: Path) -> None:
         """Empty languages list silently skips format/lint shortcuts."""
-        config = CodeConfig(commit_format=True, commit_naming=False, push_lint=True)
+        config = CodeConfig(
+            pre_commit=StageBucket(format=True), pre_push=StageBucket(lint=True)
+        )
         with (
             patch("ac_guard.checker.core.run_precommit") as mock_run,
             patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
@@ -250,10 +250,11 @@ class TestRunStage:
         from ac_guard.checker.models import CheckResult
 
         config = CodeConfig(
-            commit_format=False,
-            commit_naming=False,
-            push_lint=True,
-            push_checks={"custom": CheckItem(command="echo should-not-run")},
+            pre_commit=StageBucket(format=False),
+            pre_push=StageBucket(
+                lint=True,
+                checks={"custom": CheckItem(command="echo should-not-run")},
+            ),
         )
         failing_build = CheckResult(
             name="build", passed=False, duration_ms=10, output="build broke"
@@ -293,10 +294,11 @@ class TestRunStage:
         from ac_guard.checker.models import CheckResult
 
         config = CodeConfig(
-            commit_format=False,
-            commit_naming=False,
-            push_lint=True,
-            push_checks={"custom": CheckItem(command="echo ok")},
+            pre_commit=StageBucket(format=False),
+            pre_push=StageBucket(
+                lint=True,
+                checks={"custom": CheckItem(command="echo ok")},
+            ),
         )
         passing_build = CheckResult(name="build", passed=True, duration_ms=10)
         with (

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -35,14 +35,13 @@ def _write_config_with_checks(tmp_path: Path) -> Path:
                 "version": 1,
                 "project": {"name": "test", "language": "python"},
                 "code": {
-                    "commit": {
+                    "pre-commit": {
                         "format": False,
-                        "naming": False,
                         "checks": {
                             "echo-test": {"command": "echo ok"},
                         },
                     },
-                    "push": {
+                    "pre-push": {
                         "lint": False,
                         "checks": {
                             "fail-test": {"command": "exit 1"},
@@ -83,9 +82,8 @@ class TestCheckCommand:
                     "version": 1,
                     "project": {"name": "test", "language": "python"},
                     "code": {
-                        "commit": {
+                        "pre-commit": {
                             "format": False,
-                            "naming": False,
                             "checks": {"fail": {"command": "exit 1"}},
                         },
                     },
@@ -210,9 +208,8 @@ class TestGateRunCommand:
                     "version": 1,
                     "project": {"name": "test", "language": "python"},
                     "code": {
-                        "commit": {
+                        "pre-commit": {
                             "format": False,
-                            "naming": False,
                             "checks": {"fail": {"command": "exit 1"}},
                         },
                     },

--- a/tests/unit/test_cli/test_init.py
+++ b/tests/unit/test_cli/test_init.py
@@ -282,7 +282,7 @@ class TestRenderGuardYaml:
         config = {
             "version": 1,
             "project": {"name": "test", "language": "python"},
-            "code": {"commit": {"format": True}},
+            "code": {"pre-commit": {"format": True}},
         }
         yaml_content = _render_guard_yaml(config, "standard")
         # Count occurrences of "project:" (should be exactly 1)

--- a/tests/unit/test_cli/test_presets.py
+++ b/tests/unit/test_cli/test_presets.py
@@ -19,7 +19,7 @@ class TestLoadPreset:
         config = load_preset("minimal")
         assert isinstance(config, dict)
         assert "code" in config
-        assert config["code"]["commit"]["format"] is True
+        assert config["code"]["pre-commit"]["format"] is True
         assert config["output"]["audit"]["enabled"] is False
 
     def test_load_preset_standard(self) -> None:
@@ -27,10 +27,10 @@ class TestLoadPreset:
         config = load_preset("standard")
         assert isinstance(config, dict)
         assert "code" in config
-        assert config["code"]["commit"]["format"] is True
-        # naming shortcut is not shipped in presets (see issue #95)
-        assert "naming" not in config["code"]["commit"]
-        assert config["code"]["push"]["lint"] is True
+        assert config["code"]["pre-commit"]["format"] is True
+        # D8: naming flag removed; lint via ruff N-rules covers it.
+        assert "naming" not in config["code"]["pre-commit"]
+        assert config["code"]["pre-push"]["lint"] is True
         assert config["output"]["audit"]["enabled"] is True
 
     def test_load_preset_strict(self) -> None:

--- a/tests/unit/test_cli/test_validation.py
+++ b/tests/unit/test_cli/test_validation.py
@@ -18,20 +18,19 @@ def _write_config(tmp_path: Path, *, custom_checks: bool = False) -> Path:
         "version": 1,
         "project": {"name": "test", "language": "python"},
         "code": {
-            "commit": {
+            "pre-commit": {
                 "format": True,
-                "naming": True,
             },
-            "push": {
+            "pre-push": {
                 "lint": True,
             },
         },
     }
     if custom_checks:
-        config["code"]["commit"]["checks"] = {
+        config["code"]["pre-commit"]["checks"] = {
             "test": {"command": "pytest --cov", "timeout": 120},
         }
-        config["code"]["push"]["checks"] = {
+        config["code"]["pre-push"]["checks"] = {
             "typecheck": {
                 "command": "mypy src/",
                 "timeout": 60,

--- a/tests/unit/test_config/test_loader.py
+++ b/tests/unit/test_config/test_loader.py
@@ -57,7 +57,7 @@ class TestLoadConfigSuccess:
                 },
             },
             "code": {
-                "commit": {
+                "pre-commit": {
                     "format": True,
                     "checks": {
                         "lic": {"command": "./check-lic.sh"},

--- a/tests/unit/test_config/test_merger.py
+++ b/tests/unit/test_config/test_merger.py
@@ -72,13 +72,13 @@ class TestResolveConfigMinimal:
     def test_default_code_config(self, tmp_path: Path) -> None:
         path = _write_yaml(tmp_path, _minimal_guard())
         result = resolve_config(path)
-        assert result.code.commit_format is True
-        # naming defaults to False because the shortcut is not yet
-        # implemented (see checker skip path and issue #95).
+        # Defaults: pre-commit.format=True, pre-push.lint=True (from
+        # _DEFAULT_CONFIG); commit_naming is D8 dead-flag shim.
+        assert result.code.pre_commit.format is True
+        assert result.code.pre_push.lint is True
+        assert result.code.pre_commit.checks == {}
+        assert result.code.pre_push.checks == {}
         assert result.code.commit_naming is False
-        assert result.code.push_lint is True
-        assert result.code.commit_checks == {}
-        assert result.code.push_checks == {}
 
     def test_default_output_config(self, tmp_path: Path) -> None:
         path = _write_yaml(tmp_path, _minimal_guard())
@@ -140,18 +140,20 @@ class TestScalarOverride:
         assert result.output.locale == "zh-CN"
 
     def test_override_commit_format(self, tmp_path: Path) -> None:
-        data = _minimal_guard(code={"commit": {"format": False}})
+        data = _minimal_guard(code={"pre-commit": {"format": False}})
         path = _write_yaml(tmp_path, data)
         result = resolve_config(path)
-        assert result.code.commit_format is False
-        # naming remains False (default; shortcut unimplemented — see #95)
+        assert result.code.pre_commit.format is False
+        assert result.code.commit_format is False  # legacy shim
+        # D8: commit_naming shim always False
         assert result.code.commit_naming is False
 
     def test_override_push_lint(self, tmp_path: Path) -> None:
-        data = _minimal_guard(code={"push": {"lint": False}})
+        data = _minimal_guard(code={"pre-push": {"lint": False}})
         path = _write_yaml(tmp_path, data)
         result = resolve_config(path)
-        assert result.code.push_lint is False
+        assert result.code.pre_push.lint is False
+        assert result.code.push_lint is False  # legacy shim
 
     def test_build_command(self, tmp_path: Path) -> None:
         data = _minimal_guard(build={"command": "make build"})
@@ -558,7 +560,7 @@ class TestDeepMergeChecks:
     def test_override_check_field(self, tmp_path: Path) -> None:
         rs: dict = {
             "code": {
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "mytest": {"command": "pytest", "timeout": 300},
                     },
@@ -567,7 +569,7 @@ class TestDeepMergeChecks:
         }
         data = _minimal_guard(
             code={
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "mytest": {"command": "pytest -x", "timeout": 600},
                     },
@@ -576,14 +578,14 @@ class TestDeepMergeChecks:
         )
         path = _write_yaml(tmp_path, data)
         result = resolve_config(path, rulesets=[("rs", rs)])
-        check = result.code.commit_checks["mytest"]
+        check = result.code.pre_commit.checks["mytest"]
         assert check.command == "pytest -x"
         assert check.timeout == 600
 
     def test_add_new_check(self, tmp_path: Path) -> None:
         rs: dict = {
             "code": {
-                "push": {
+                "pre-push": {
                     "checks": {
                         "lint": {"command": "ruff check ."},
                     },
@@ -592,7 +594,7 @@ class TestDeepMergeChecks:
         }
         data = _minimal_guard(
             code={
-                "push": {
+                "pre-push": {
                     "checks": {
                         "typecheck": {"command": "mypy src/"},
                     },
@@ -601,13 +603,13 @@ class TestDeepMergeChecks:
         )
         path = _write_yaml(tmp_path, data)
         result = resolve_config(path, rulesets=[("rs", rs)])
-        assert "lint" in result.code.push_checks
-        assert "typecheck" in result.code.push_checks
+        assert "lint" in result.code.pre_push.checks
+        assert "typecheck" in result.code.pre_push.checks
 
     def test_preserve_unmentioned_check(self, tmp_path: Path) -> None:
         rs: dict = {
             "code": {
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "existing": {"command": "echo ok"},
                     },
@@ -616,7 +618,7 @@ class TestDeepMergeChecks:
         }
         data = _minimal_guard(
             code={
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "new": {"command": "echo new"},
                     },
@@ -625,25 +627,23 @@ class TestDeepMergeChecks:
         )
         path = _write_yaml(tmp_path, data)
         result = resolve_config(path, rulesets=[("rs", rs)])
-        assert "existing" in result.code.commit_checks
-        assert "new" in result.code.commit_checks
+        assert "existing" in result.code.pre_commit.checks
+        assert "new" in result.code.pre_commit.checks
 
     def test_partial_field_override(self, tmp_path: Path) -> None:
         """Overlay changes only timeout; command preserved from base."""
         rs: dict = {
             "code": {
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "test": {"command": "pytest", "timeout": 300},
                     },
                 },
             },
         }
-        # User guard.yaml must pass validation, so command is required.
-        # But two rulesets can do partial override between them.
         rs2: dict = {
             "code": {
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "test": {"command": "pytest", "timeout": 600},
                     },
@@ -652,7 +652,7 @@ class TestDeepMergeChecks:
         }
         path = _write_yaml(tmp_path, _minimal_guard())
         result = resolve_config(path, rulesets=[("rs1", rs), ("rs2", rs2)])
-        check = result.code.commit_checks["test"]
+        check = result.code.pre_commit.checks["test"]
         assert check.command == "pytest"
         assert check.timeout == 600
 

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -159,32 +159,73 @@ class TestCheckItem:
 
 
 class TestCodeConfig:
+    """CodeConfig is keyed by pre-commit gating stage (schema v2, #123)."""
+
     def test_all_defaults(self):
         cfg = CodeConfig()
         assert cfg is not None
 
     def test_defaults_values(self):
         cfg = CodeConfig()
-        assert cfg.commit_format is True
-        # naming defaults to False — shortcut unimplemented (issue #95)
+        # Dataclass defaults: every bucket empty. The merger applies
+        # project-level defaults (pre-commit.format=True, pre-push.lint=
+        # True) via _DEFAULT_CONFIG — not this constructor.
+        assert cfg.pre_commit.format is False
+        assert cfg.pre_commit.lint is False
+        assert cfg.pre_commit.checks == {}
+        assert cfg.pre_commit.hooks == []
+        assert cfg.pre_push.lint is False
+        assert cfg.pre_push.hooks == []
+        assert cfg.extra_repos == []
+        # Legacy shim: commit_naming is always False (D8, dead flag).
         assert cfg.commit_naming is False
-        assert cfg.commit_checks == {}
-        assert cfg.push_lint is True
-        assert cfg.push_checks == {}
 
     def test_with_check_items(self):
+        from ac_guard.config.models import StageBucket
+
         cfg = CodeConfig(
-            commit_checks={"license": CheckItem(command="check-license")},
-            push_checks={"test": CheckItem(command="pytest", timeout=600)},
+            pre_commit=StageBucket(
+                checks={"license": CheckItem(command="check-license")}
+            ),
+            pre_push=StageBucket(
+                checks={"test": CheckItem(command="pytest", timeout=600)}
+            ),
         )
+        assert "license" in cfg.pre_commit.checks
+        assert cfg.pre_push.checks["test"].timeout == 600
+        # Legacy shim access
         assert "license" in cfg.commit_checks
         assert cfg.push_checks["test"].timeout == 600
 
     def test_default_factory_independence(self):
         a = CodeConfig()
         b = CodeConfig()
-        a.commit_checks["x"] = CheckItem(command="x")
-        assert "x" not in b.commit_checks
+        a.pre_commit.checks["x"] = CheckItem(command="x")
+        assert "x" not in b.pre_commit.checks
+
+    def test_buckets_helper_returns_all_five(self):
+        cfg = CodeConfig()
+        names = [name for name, _ in cfg.buckets()]
+        assert names == [
+            "pre-commit",
+            "commit-msg",
+            "pre-merge-commit",
+            "pre-push",
+            "pre-rebase",
+        ]
+
+    def test_active_stages_empty_when_all_buckets_empty(self):
+        cfg = CodeConfig()
+        assert cfg.active_stages() == []
+
+    def test_active_stages_reports_non_empty(self):
+        from ac_guard.config.models import StageBucket
+
+        cfg = CodeConfig(
+            pre_commit=StageBucket(format=True),
+            pre_push=StageBucket(checks={"test": CheckItem(command="pytest")}),
+        )
+        assert cfg.active_stages() == ["pre-commit", "pre-push"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config/test_validator.py
+++ b/tests/unit/test_config/test_validator.py
@@ -59,9 +59,8 @@ class TestValidMinimalConfig:
                 },
             },
             "code": {
-                "commit": {
+                "pre-commit": {
                     "format": True,
-                    "naming": True,
                     "checks": {
                         "license_header": {
                             "command": "./scripts/check-license.sh",
@@ -69,7 +68,7 @@ class TestValidMinimalConfig:
                         },
                     },
                 },
-                "push": {
+                "pre-push": {
                     "lint": True,
                     "checks": {
                         "test": {"command": "pytest", "timeout": 300},
@@ -245,7 +244,7 @@ class TestBehaviorField:
 class TestCodeField:
     def test_check_missing_command(self) -> None:
         data = _minimal_config(
-            code={"commit": {"checks": {"my_check": {"timeout": 30}}}}
+            code={"pre-commit": {"checks": {"my_check": {"timeout": 30}}}}
         )
         with pytest.raises(ConfigValidationError) as exc_info:
             validate_raw_config(data)
@@ -254,7 +253,7 @@ class TestCodeField:
     def test_timeout_negative(self) -> None:
         data = _minimal_config(
             code={
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "my_check": {"command": "echo", "timeout": -1},
                     },
@@ -268,7 +267,7 @@ class TestCodeField:
     def test_timeout_zero(self) -> None:
         data = _minimal_config(
             code={
-                "commit": {
+                "pre-commit": {
                     "checks": {
                         "my_check": {"command": "echo", "timeout": 0},
                     },

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -16,6 +16,7 @@ from ac_guard.config.models import (
     LanguageTools,
     OperationRules,
     Rule,
+    StageBucket,
 )
 from ac_guard.generator.core import (
     MARKER_BEGIN,
@@ -825,30 +826,32 @@ class TestGeneratePrecommitConfig:
         assert "repo: local" in result.content
 
     def test_includes_format_hooks_when_enabled(self) -> None:
-        code = CodeConfig(commit_format=True)
+        code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
         result = generate_precommit_config(code, languages)
         assert "format-python" in result.content
         assert "black" in result.content
 
     def test_includes_lint_hooks_when_enabled(self) -> None:
-        code = CodeConfig(push_lint=True)
+        code = CodeConfig(pre_push=StageBucket(lint=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
         result = generate_precommit_config(code, languages)
         assert "lint-python" in result.content
         assert "ruff" in result.content
 
     def test_omits_format_when_disabled(self) -> None:
-        code = CodeConfig(commit_format=False)
+        code = CodeConfig(pre_commit=StageBucket(format=False))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
         result = generate_precommit_config(code, languages)
         assert "format-python" not in result.content
 
     def test_includes_custom_checks(self) -> None:
         code = CodeConfig(
-            commit_checks={
-                "test": CheckItem(command="pytest", pass_filenames=False),
-            },
+            pre_commit=StageBucket(
+                checks={
+                    "test": CheckItem(command="pytest", pass_filenames=False),
+                }
+            ),
         )
         languages = {}
         result = generate_precommit_config(code, languages)
@@ -856,13 +859,15 @@ class TestGeneratePrecommitConfig:
         assert "pytest" in result.content
 
     def test_includes_language_types(self) -> None:
-        code = CodeConfig(commit_format=True)
+        code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
         result = generate_precommit_config(code, languages)
         assert "types: [python]" in result.content
 
     def test_handles_multiple_languages(self) -> None:
-        code = CodeConfig(commit_format=True, push_lint=True)
+        code = CodeConfig(
+            pre_commit=StageBucket(format=True), pre_push=StageBucket(lint=True)
+        )
         languages = {
             "python": LanguageTools(format="black", lint="ruff"),
             "typescript": LanguageTools(format="prettier", lint="eslint"),
@@ -882,7 +887,9 @@ class TestPrecommitManagedBlock:
         tmp_path: Path, *, format_on: bool = True, lint_on: bool = True
     ) -> str:
         """Run generator + write_artifacts; return the on-disk content."""
-        code = CodeConfig(commit_format=format_on, push_lint=lint_on)
+        code = CodeConfig(
+            pre_commit=StageBucket(format=format_on), pre_push=StageBucket(lint=lint_on)
+        )
         languages = {"python": LanguageTools(format="black", lint="ruff")}
         spec = generate_precommit_config(code, languages)
         write_artifacts(tmp_path, [spec])


### PR DESCRIPTION
Part 1 of 3 for #123.

## Summary

Restructures guard.yaml schema to key `code` by pre-commit gating stage names (pre-commit / commit-msg / pre-merge-commit / pre-push / pre-rebase). Each stage bucket holds `format` / `lint` / `checks` (short-hand commands) / `hooks` (full pre-commit passthrough). Adds `_extra.repos` escape hatch for non-gating stages and `_pre_commit` top-level meta.

Drops dead `commit_naming` flag (D8 — ruff N-rules via `lint: true` covers it).

**Breaking**: old `code.commit.*` / `code.push.*` keys no longer accepted. This repo's guard.yaml and the minimal/standard/strict presets are migrated.

Legacy shim on CodeConfig keeps `commit_format` / `commit_naming` / etc. readable so downstream modules (checker / generator / CLI) continue to work without modification during Phase 1b+.

## Test plan

- [x] pytest tests/ -q → 948 passed
- [x] Loader/validator/merger tests updated for new schema
- [x] Presets (minimal/standard/strict) + this repo's guard.yaml migrated

## Stacked on top of

First in a 3-PR sequence:
1. **This PR** · schema + loader + merger + validator
2. Phase 1b · generator + template + git hooks + gate CLI — `feat/m6-guard-yaml-stages-phase1b`
3. Phase 1c · drop shim + rewrite checker/CLI to bucket API — `feat/m6-guard-yaml-stages-phase1c`

Closes #123 (alongside 1b + 1c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
