### PR TITLE
refactor(checker,cli): drop _LEGACY_STAGE_ALIAS — unify stage names

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -209,7 +209,7 @@ ac-guard check
 On a clean codebase:
 
 ```
-Stage: commit — PASSED
+Stage: pre-commit — PASSED
 
   [PASS] pre-commit:format-python (295ms)
   [PASS] ruff (37ms)
@@ -231,7 +231,7 @@ ac-guard check
 ```
 
 ```
-Stage: commit — FAILED
+Stage: pre-commit — FAILED
 
   [FAIL] ruff (19ms)
 
@@ -246,7 +246,7 @@ ac-guard check --format json
 
 ```json
 {
-  "stage": "commit",
+  "stage": "pre-commit",
   "passed": false,
   "results": [
     {

--- a/docs/getting-started_zh.md
+++ b/docs/getting-started_zh.md
@@ -199,7 +199,7 @@ ac-guard check
 干净代码上的输出：
 
 ```
-Stage: commit — PASSED
+Stage: pre-commit — PASSED
 
   [PASS] pre-commit:format-python (295ms)
   [PASS] ruff (37ms)
@@ -221,7 +221,7 @@ ac-guard check
 ```
 
 ```
-Stage: commit — FAILED
+Stage: pre-commit — FAILED
 
   [FAIL] ruff (19ms)
 
@@ -236,7 +236,7 @@ ac-guard check --format json
 
 ```json
 {
-  "stage": "commit",
+  "stage": "pre-commit",
   "passed": false,
   "results": [
     {

--- a/src/ac_guard/checker/core.py
+++ b/src/ac_guard/checker/core.py
@@ -37,16 +37,16 @@ def get_changed_files(stage: str, project_root: Path) -> list[str]:
     """Get list of changed files for the given stage.
 
     Args:
-        stage: Check stage ("commit" or "push").
+        stage: Check stage ("pre-commit" or "pre-push").
         project_root: Path to project root directory.
 
     Returns:
         List of changed file paths relative to project root.
     """
-    if stage == "commit":
+    if stage == "pre-commit":
         cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
     else:
-        # Push stage: diff against upstream
+        # pre-push stage: diff against upstream
         cmd = ["git", "diff", "origin/main..HEAD", "--name-only", "--diff-filter=ACMR"]
 
     try:
@@ -311,14 +311,14 @@ def run_stage(
 ) -> CheckReport:
     """Orchestrate all checks for a stage.
 
-    For commit stage: format + naming + custom checks.
-    For push stage: commit first (fail-fast) + build + lint + custom checks.
+    For pre-commit stage: format + lint + custom checks.
+    For pre-push stage: pre-commit first (fail-fast) + build + lint + custom.
 
     Args:
-        stage: Check stage ("commit" or "push").
+        stage: Check stage ("pre-commit" or "pre-push").
         code_config: CodeConfig with enabled flags and checks.
         project_root: Path to project root directory.
-        build_command: Optional build command (push stage only).
+        build_command: Optional build command (pre-push stage only).
         files: Explicit file list. If None, auto-detect via git.
         languages: Language identifiers used to resolve pre-commit
             hook IDs (``format-<lang>`` / ``lint-<lang>``). Empty list
@@ -330,15 +330,15 @@ def run_stage(
     start = time.monotonic()
     langs = list(languages or [])
 
-    if stage == "push":
-        # Fail-fast: run commit stage first
+    if stage == "pre-push":
+        # Fail-fast: run pre-commit stage first
         commit_report = run_stage(
-            "commit", code_config, project_root, files=files, languages=langs
+            "pre-commit", code_config, project_root, files=files, languages=langs
         )
         if not commit_report.passed:
             elapsed = int((time.monotonic() - start) * 1000)
             return CheckReport(
-                stage="push",
+                stage="pre-push",
                 passed=False,
                 results=commit_report.results,
                 duration_ms=elapsed,
@@ -348,7 +348,7 @@ def run_stage(
         files = get_changed_files(stage, project_root)
     results: list[CheckResult] = []
 
-    if stage == "commit":
+    if stage == "pre-commit":
         results.extend(_run_commit_checks(code_config, files, project_root, langs))
     else:
         results.extend(

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -55,7 +55,7 @@ def check_command(
     file_list = files or None
 
     report = run_stage(
-        "commit",
+        "pre-commit",
         resolved.code,
         project_root,
         files=file_list,
@@ -92,7 +92,7 @@ def verify_command(
     build_cmd = None if skip_build else resolved.build_command
 
     report = run_stage(
-        "push",
+        "pre-push",
         resolved.code,
         project_root,
         build_command=build_cmd,
@@ -121,7 +121,7 @@ def run_command(
 
     Args:
         name: Check name to run.
-        stage: Check stage ("commit" or "push").
+        stage: Check stage ("pre-commit" or "pre-push").
         files: Explicit file list, or empty for auto-detect.
         config_path: Path to guard.yaml.
     """
@@ -197,10 +197,9 @@ _GATING_STAGES = frozenset(
     {"pre-commit", "commit-msg", "pre-merge-commit", "pre-push", "pre-rebase"}
 )
 
-# Map schema-v2 stage names onto the legacy ``run_stage`` stage values
-# ("commit" / "push") for stages where ac-guard has bucket-aware logic.
-# Other gating stages delegate straight to pre-commit via subprocess.
-_LEGACY_STAGE_ALIAS = {"pre-commit": "commit", "pre-push": "push"}
+# Stages where ac-guard has bucket-aware logic and runs its own checker.
+# The other gating stages delegate straight to pre-commit via subprocess.
+_BUCKET_AWARE_STAGES = frozenset({"pre-commit", "pre-push"})
 
 
 def gate_run_command(
@@ -231,11 +230,10 @@ def gate_run_command(
     resolved = _load_config(config_path)
     project_root = config_path.parent.resolve()
 
-    if stage in _LEGACY_STAGE_ALIAS:
-        legacy = _LEGACY_STAGE_ALIAS[stage]
-        build_cmd = resolved.build_command if legacy == "push" else None
+    if stage in _BUCKET_AWARE_STAGES:
+        build_cmd = resolved.build_command if stage == "pre-push" else None
         report = run_stage(
-            legacy,
+            stage,
             resolved.code,
             project_root,
             build_command=build_cmd,

--- a/src/ac_guard/cli/main.py
+++ b/src/ac_guard/cli/main.py
@@ -305,8 +305,8 @@ def run_single(
     name: Annotated[str, typer.Argument(help="Check name to run")],
     stage: Annotated[
         str,
-        typer.Option("--stage", "-s", help="Check stage (commit or push)"),
-    ] = "commit",
+        typer.Option("--stage", "-s", help="Check stage (pre-commit or pre-push)"),
+    ] = "pre-commit",
     files: Annotated[
         list[str] | None,
         typer.Option("--files", help="Explicit file paths to check"),

--- a/tests/integration/test_checker_e2e.py
+++ b/tests/integration/test_checker_e2e.py
@@ -508,7 +508,7 @@ class TestLocalePropagation:
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
-        assert "阶段: commit — 通过" in r.output
+        assert "阶段: pre-commit — 通过" in r.output
         assert "项检查通过" in r.output
         assert "PASSED" not in r.output
 
@@ -538,7 +538,7 @@ class TestReportFormats:
     def test_markdown_rendering(self) -> None:
         """F2: Markdown report has table and emoji."""
         report = CheckReport(
-            stage="commit",
+            stage="pre-commit",
             passed=False,
             results=[
                 CheckResult(name="format", passed=True, duration_ms=10),

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -91,12 +91,12 @@ class TestPrReportFlow:
         resolved_config = _resolve(config)
 
         # Run real checker
-        report = run_stage("commit", resolved_config.code, tmp_path)
+        report = run_stage("pre-commit", resolved_config.code, tmp_path)
 
         # Markdown should render without error
         markdown = format_markdown(report)
         assert "✅" in markdown or "❌" in markdown  # emoji indicators
-        assert report.stage in markdown or "commit" in markdown.lower()
+        assert report.stage in markdown or "pre-commit" in markdown.lower()
 
         # post_pr_comment should call channel.send with the markdown
         pr_config = PrReportConfig(enabled=True, platform="github")
@@ -128,7 +128,7 @@ class TestPrReportFlow:
         """D1-2: post_pr_comment failure → no exception, stderr warning."""
         config = _init_and_install(tmp_path)
         resolved_config = _resolve(config)
-        report = run_stage("commit", resolved_config.code, tmp_path)
+        report = run_stage("pre-commit", resolved_config.code, tmp_path)
 
         pr_config = PrReportConfig(enabled=True, platform="github")
 
@@ -145,7 +145,7 @@ class TestPrReportFlow:
         """D1-3: enabled=False → no HTTP call."""
         config = _init_and_install(tmp_path)
         resolved_config = _resolve(config)
-        report = run_stage("commit", resolved_config.code, tmp_path)
+        report = run_stage("pre-commit", resolved_config.code, tmp_path)
 
         pr_config = PrReportConfig(enabled=False)
         with patch("urllib.request.urlopen") as mock_urlopen:
@@ -171,7 +171,7 @@ class TestJsonOutput:
         assert result.exit_code == 0
 
         data = json.loads(result.output)
-        assert data["stage"] == "commit"
+        assert data["stage"] == "pre-commit"
         assert isinstance(data["passed"], bool)
         assert isinstance(data["results"], list)
         assert "duration_ms" in data

--- a/tests/unit/test_checker/test_core.py
+++ b/tests/unit/test_checker/test_core.py
@@ -23,7 +23,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.checker.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "a.py\nb.py\n"
-            files = get_changed_files("commit", tmp_path)
+            files = get_changed_files("pre-commit", tmp_path)
             assert files == ["a.py", "b.py"]
             cmd = mock_run.call_args[0][0]
             assert "--cached" in cmd
@@ -33,7 +33,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.checker.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "c.py\n"
-            files = get_changed_files("push", tmp_path)
+            files = get_changed_files("pre-push", tmp_path)
             assert files == ["c.py"]
             cmd = mock_run.call_args[0][0]
             assert "origin/main..HEAD" in cmd
@@ -43,7 +43,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.checker.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = ""
-            files = get_changed_files("commit", tmp_path)
+            files = get_changed_files("pre-commit", tmp_path)
             assert files == []
 
     def test_git_error_returns_empty(self, tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.checker.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 1
             mock_run.return_value.stdout = ""
-            files = get_changed_files("commit", tmp_path)
+            files = get_changed_files("pre-commit", tmp_path)
             assert files == []
 
 
@@ -139,11 +139,11 @@ class TestRunStage:
     """Tests for run_stage orchestration (K6)."""
 
     def test_commit_stage_runs_checks(self, tmp_path: Path) -> None:
-        """Commit stage runs format + naming checks."""
+        """pre-commit stage runs format + custom checks."""
         config = CodeConfig(pre_commit=StageBucket(format=True))
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
-            report = run_stage("commit", config, tmp_path)
-        assert report.stage == "commit"
+            report = run_stage("pre-commit", config, tmp_path)
+        assert report.stage == "pre-commit"
         # Format and naming are pre-commit hooks — skipped with no files
         assert report.passed is True
 
@@ -156,7 +156,7 @@ class TestRunStage:
             ),
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
-            report = run_stage("commit", config, tmp_path)
+            report = run_stage("pre-commit", config, tmp_path)
         assert report.passed is True
         assert any(r.name == "echo" for r in report.results)
 
@@ -168,8 +168,8 @@ class TestRunStage:
             ),
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
-            report = run_stage("push", config, tmp_path)
-        assert report.stage == "push"
+            report = run_stage("pre-push", config, tmp_path)
+        assert report.stage == "pre-push"
         assert report.passed is False
 
     def test_push_stage_with_build(self, tmp_path: Path) -> None:
@@ -178,7 +178,7 @@ class TestRunStage:
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=False)
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
-            report = run_stage("push", config, tmp_path, build_command="echo build")
+            report = run_stage("pre-push", config, tmp_path, build_command="echo build")
         assert report.passed is True
         assert any(r.name == "build" for r in report.results)
 
@@ -193,7 +193,7 @@ class TestRunStage:
             mock_run.return_value.violations = []
             mock_run.return_value.output = ""
             run_stage(
-                "commit",
+                "pre-commit",
                 config,
                 tmp_path,
                 files=["a.py"],
@@ -219,7 +219,7 @@ class TestRunStage:
                 "ac_guard.checker.core.get_changed_files", return_value=["a.py"]
             ):
                 run_stage(
-                    "push",
+                    "pre-push",
                     config,
                     tmp_path,
                     languages=["python", "typescript"],
@@ -242,7 +242,7 @@ class TestRunStage:
             patch("ac_guard.checker.core.run_precommit") as mock_run,
             patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
         ):
-            run_stage("push", config, tmp_path, languages=[])
+            run_stage("pre-push", config, tmp_path, languages=[])
         mock_run.assert_not_called()
 
     def test_push_build_failure_skips_lint_and_checks(self, tmp_path: Path) -> None:
@@ -268,7 +268,7 @@ class TestRunStage:
             patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
         ):
             report = run_stage(
-                "push",
+                "pre-push",
                 config,
                 tmp_path,
                 build_command="make build",
@@ -314,7 +314,7 @@ class TestRunStage:
                 name="custom", passed=True, duration_ms=1
             )
             run_stage(
-                "push",
+                "pre-push",
                 config,
                 tmp_path,
                 build_command="make build",

--- a/tests/unit/test_checker/test_models.py
+++ b/tests/unit/test_checker/test_models.py
@@ -62,7 +62,7 @@ class TestCheckReport:
     def test_all_passed(self) -> None:
         """Report with all checks passing."""
         report = CheckReport(
-            stage="commit",
+            stage="pre-commit",
             passed=True,
             results=[
                 CheckResult(name="format", passed=True),
@@ -75,7 +75,7 @@ class TestCheckReport:
     def test_any_failed(self) -> None:
         """Report with a failing check."""
         report = CheckReport(
-            stage="push",
+            stage="pre-push",
             passed=False,
             results=[
                 CheckResult(name="lint", passed=True),
@@ -86,5 +86,5 @@ class TestCheckReport:
 
     def test_empty_results(self) -> None:
         """Report with no results."""
-        report = CheckReport(stage="commit", passed=True)
+        report = CheckReport(stage="pre-commit", passed=True)
         assert report.results == []

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -250,7 +250,7 @@ class TestJsonOutput:
             )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["stage"] == "commit"
+        assert data["stage"] == "pre-commit"
         assert data["passed"] is True
         assert "results" in data
 
@@ -273,7 +273,7 @@ class TestJsonOutput:
             )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["stage"] == "push"
+        assert data["stage"] == "pre-push"
         assert "results" in data
 
 
@@ -323,7 +323,7 @@ class TestCliAutoPostPrComment:
         assert mock_post.call_count == 1
         pos_args, _kw_args = mock_post.call_args
         report_arg, pr_config_arg, locale_arg = pos_args
-        assert report_arg.stage == "commit"
+        assert report_arg.stage == "pre-commit"
         assert report_arg.passed is True
         assert pr_config_arg.enabled is True
         assert pr_config_arg.platform == "github"
@@ -357,7 +357,7 @@ class TestCliAutoPostPrComment:
         assert mock_post.call_count == 1
         pos_args, _ = mock_post.call_args
         report_arg, _, _ = pos_args
-        assert report_arg.stage == "push"
+        assert report_arg.stage == "pre-push"
 
     def test_gate_run_calls_post_pr_comment(self, tmp_path: Path) -> None:
         """gate run also dispatches post_pr_comment at end."""
@@ -373,7 +373,7 @@ class TestCliAutoPostPrComment:
         assert mock_post.call_count == 1
         pos_args, _ = mock_post.call_args
         report_arg, _, _ = pos_args
-        assert report_arg.stage == "commit"
+        assert report_arg.stage == "pre-commit"
 
     def test_run_does_not_call_post_pr_comment(self, tmp_path: Path) -> None:
         """run is intentionally out of scope (WP6.1): single-check runner.

--- a/tests/unit/test_reporter/test_channel_base.py
+++ b/tests/unit/test_reporter/test_channel_base.py
@@ -82,7 +82,7 @@ class TestPostPrComment:
         from ac_guard.checker.models import CheckReport
 
         config = PrReportConfig(enabled=True, platform="github")
-        report = CheckReport(stage="commit", passed=True)
+        report = CheckReport(stage="pre-commit", passed=True)
 
         # Ensure send will fail (no env vars set)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -111,7 +111,7 @@ class TestNoPrContextError:
         from ac_guard.reporter import channel_base
 
         config = PrReportConfig(enabled=True, platform="fake-no-pr")
-        report = CheckReport(stage="commit", passed=True)
+        report = CheckReport(stage="pre-commit", passed=True)
 
         class _NoPrChannel(ReportChannel):
             @property
@@ -139,7 +139,7 @@ class TestNoPrContextError:
         from ac_guard.reporter import channel_base
 
         config = PrReportConfig(enabled=True, platform="fake-api-500")
-        report = CheckReport(stage="commit", passed=True)
+        report = CheckReport(stage="pre-commit", passed=True)
 
         class _ApiFailChannel(ReportChannel):
             @property

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -14,7 +14,7 @@ from ac_guard.reporter.formatting import (
 def _passed_report() -> CheckReport:
     """Create a passing report for testing."""
     return CheckReport(
-        stage="commit",
+        stage="pre-commit",
         passed=True,
         results=[
             CheckResult(name="format", passed=True, duration_ms=23),
@@ -27,7 +27,7 @@ def _passed_report() -> CheckReport:
 def _failed_report() -> CheckReport:
     """Create a failing report with violations."""
     return CheckReport(
-        stage="push",
+        stage="pre-push",
         passed=False,
         results=[
             CheckResult(name="lint", passed=True, duration_ms=50),
@@ -61,7 +61,7 @@ def _failed_report() -> CheckReport:
 def _skipped_report() -> CheckReport:
     """Create a report with skipped checks."""
     return CheckReport(
-        stage="commit",
+        stage="pre-commit",
         passed=True,
         results=[
             CheckResult(name="format", passed=True, duration_ms=10),
@@ -83,7 +83,7 @@ class TestFormatTerminal:
         """Passing report shows PASSED."""
         output = format_terminal(_passed_report())
         assert "PASSED" in output
-        assert "commit" in output
+        assert "pre-commit" in output
 
     def test_failed_report(self) -> None:
         """Failing report shows FAILED and violation details."""
@@ -129,14 +129,14 @@ class TestFormatTerminal:
     def test_default_locale_uses_english_labels(self) -> None:
         """Default locale keeps existing English output verbatim."""
         output = format_terminal(_passed_report())
-        assert "Stage: commit — PASSED" in output
+        assert "Stage: pre-commit — PASSED" in output
         assert "2/2 checks passed, 0 failed" in output
         assert "Total time" in output
 
     def test_zh_cn_locale_localizes_headings(self) -> None:
         """zh-CN localizes stage / summary / total_time labels and status."""
         output = format_terminal(_passed_report(), locale="zh-CN")
-        assert "阶段: commit — 通过" in output
+        assert "阶段: pre-commit — 通过" in output
         assert "2/2 项检查通过, 0 项失败" in output
         assert "总耗时" in output
         # PASS / FAIL / SKIP indicators remain ASCII for alignment
@@ -148,13 +148,13 @@ class TestFormatTerminal:
     def test_zh_cn_locale_failure_heading(self) -> None:
         """zh-CN locale shows 失败 when the report fails."""
         output = format_terminal(_failed_report(), locale="zh-CN")
-        assert "阶段: push — 失败" in output
+        assert "阶段: pre-push — 失败" in output
         assert "1/2 项检查通过, 1 项失败" in output
 
     def test_unknown_locale_falls_back_to_english(self) -> None:
         """Unknown locale behaves like the default English labels."""
         output = format_terminal(_passed_report(), locale="fr-FR")
-        assert "Stage: commit — PASSED" in output
+        assert "Stage: pre-commit — PASSED" in output
         assert "2/2 checks passed, 0 failed" in output
 
 
@@ -235,7 +235,7 @@ class TestFormatJson:
         import json
 
         data = json.loads(format_json(_passed_report()))
-        assert data["stage"] == "commit"
+        assert data["stage"] == "pre-commit"
         assert data["passed"] is True
 
     def test_contains_results(self) -> None:


### PR DESCRIPTION
## Summary

Phase 1d follow-up to #123 / #127. Removes the transitional alias map left in `cli/check.py` during Phase 1c and lets `run_stage()` accept schema-v2 stage names (`pre-commit` / `pre-push`) directly.

- `src/ac_guard/checker/core.py` — `run_stage()` and `get_changed_files()` now use `pre-commit` / `pre-push`
- `src/ac_guard/cli/check.py` — drops `_LEGACY_STAGE_ALIAS`; `gate_run_command` routes via `_BUCKET_AWARE_STAGES` frozenset directly
- `src/ac_guard/cli/main.py` — `ac-guard run --stage` help + default updated
- Tests (10 files) — literal assertions updated to match new serialization

## Breaking

`CheckReport.stage` serialized value changes:

| surface | before | after |
|---|---|---|
| JSON | `"stage": "commit"` | `"stage": "pre-commit"` |
| Terminal | `Stage: commit — PASSED` | `Stage: pre-commit — PASSED` |
| PR comment | `ac-guard: commit checks passed` | `ac-guard: pre-commit checks passed` |
| Run CLI | `--stage commit` | `--stage pre-commit` (old rejected) |

No external API consumers. Audit log (Enforcer layer) uses a separate `stage` field and is unaffected. Generator already emits the new names.

## Test plan

- [x] `pytest` — 945/945 passing
- [x] Manual: `.venv/bin/ac-guard gate run --stage pre-commit` → `ac-guard: pre-commit checks passed`
- [x] Manual: `.venv/bin/ac-guard gate run --stage commit` → rejected with `unknown stage 'commit'`
- [x] Manual: `.venv/bin/ac-guard run format --stage pre-commit` → `Stage: pre-commit — PASSED`
- [x] Local pre-commit + pre-push hooks pass

## Development

- Closes: internal cleanup (no tracking issue; surfaced during #127 review)
- Relates: #123, #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)