### PR TITLE
feat(doctor): multi-language coverage + stage semantic fit + local hook PATH

### DIFF
--- a/src/ac_guard/checker/core.py
+++ b/src/ac_guard/checker/core.py
@@ -20,12 +20,49 @@ if TYPE_CHECKING:
     from ac_guard.config.models import CheckItem, CodeConfig
 
 __all__ = [
+    "BUCKET_AWARE_STAGES",
+    "TYPE_EXTENSIONS",
+    "detect_language",
     "get_changed_files",
     "run_build",
     "run_check",
     "run_precommit",
     "run_stage",
 ]
+
+
+# Stages where ac-guard provides bucket-aware orchestration (format/lint
+# shortcuts, build command, CheckReport for reporter/audit). Other gating
+# stages delegate to ``pre-commit run --hook-stage`` via cli/check.py.
+BUCKET_AWARE_STAGES: frozenset[str] = frozenset({"pre-commit", "pre-push"})
+
+
+# Maps ac-guard language identifier → set of file extensions. Shared by
+# the file-type filter and by ``doctor``'s language coverage check.
+TYPE_EXTENSIONS: dict[str, frozenset[str]] = {
+    "python": frozenset({".py", ".pyi"}),
+    "javascript": frozenset({".js", ".jsx", ".mjs"}),
+    "typescript": frozenset({".ts", ".tsx", ".mts"}),
+    "go": frozenset({".go"}),
+    "rust": frozenset({".rs"}),
+    "java": frozenset({".java"}),
+    "c": frozenset({".c", ".h"}),
+    "cpp": frozenset({".cpp", ".cc", ".cxx", ".hpp", ".hh"}),
+}
+
+
+def detect_language(path: str) -> str | None:
+    """Return the ac-guard language name for a file path, or None.
+
+    Uses the extension → language map in ``TYPE_EXTENSIONS``. Returns
+    ``None`` for paths with no matching extension (configs, text files,
+    binaries, etc.).
+    """
+    lower = path.lower()
+    for lang, exts in TYPE_EXTENSIONS.items():
+        if any(lower.endswith(ext) for ext in exts):
+            return lang
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -229,20 +266,9 @@ def _filter_files_by_type(files: list[str], types: list[str] | None) -> list[str
     if types is None:
         return files
 
-    type_extensions = {
-        "python": {".py", ".pyi"},
-        "javascript": {".js", ".jsx", ".mjs"},
-        "typescript": {".ts", ".tsx", ".mts"},
-        "go": {".go"},
-        "rust": {".rs"},
-        "java": {".java"},
-        "c": {".c", ".h"},
-        "cpp": {".cpp", ".cc", ".cxx", ".hpp", ".hh"},
-    }
-
     valid_exts: set[str] = set()
     for t in types:
-        valid_exts.update(type_extensions.get(t, {f".{t}"}))
+        valid_exts.update(TYPE_EXTENSIONS.get(t, frozenset({f".{t}"})))
 
     return [f for f in files if any(f.endswith(ext) for ext in valid_exts)]
 

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ac_guard.checker.core import (
+    BUCKET_AWARE_STAGES,
     get_changed_files,
     run_check,
     run_precommit,
@@ -197,10 +198,6 @@ _GATING_STAGES = frozenset(
     {"pre-commit", "commit-msg", "pre-merge-commit", "pre-push", "pre-rebase"}
 )
 
-# Stages where ac-guard has bucket-aware logic and runs its own checker.
-# The other gating stages delegate straight to pre-commit via subprocess.
-_BUCKET_AWARE_STAGES = frozenset({"pre-commit", "pre-push"})
-
 
 def gate_run_command(
     stage: str,
@@ -230,7 +227,7 @@ def gate_run_command(
     resolved = _load_config(config_path)
     project_root = config_path.parent.resolve()
 
-    if stage in _BUCKET_AWARE_STAGES:
+    if stage in BUCKET_AWARE_STAGES:
         build_cmd = resolved.build_command if stage == "pre-push" else None
         report = run_stage(
             stage,

--- a/src/ac_guard/cli/main.py
+++ b/src/ac_guard/cli/main.py
@@ -244,10 +244,21 @@ def doctor(
             help="Path to guard.yaml",
         ),
     ] = Path("guard.yaml"),
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="Treat warnings as failures (useful for CI).",
+        ),
+    ] = False,
 ) -> None:
     """Run environment diagnostics and check system health."""
     project_root = config.parent.resolve()
-    doctor_command(project_root=project_root, config_path=config)
+    doctor_command(
+        project_root=project_root,
+        config_path=config,
+        strict=strict,
+    )
 
 
 @app.command()

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -8,12 +8,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shlex
 import shutil
+import subprocess
 import sys
+from collections import Counter
 from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
+from ac_guard.checker.core import BUCKET_AWARE_STAGES, detect_language
 from ac_guard.config.exceptions import ConfigError
 from ac_guard.config.loader import load_config
 from ac_guard.config.merger import resolve_config
@@ -21,6 +25,8 @@ from ac_guard.generator.core import read_state
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from ac_guard.config.models import ResolvedConfig
 
 __all__ = ["status_command", "doctor_command", "agents_command"]
 
@@ -198,38 +204,77 @@ def _print_rules(config_path: Path) -> None:
 def doctor_command(
     project_root: Path,
     config_path: Path,
+    *,
+    strict: bool = False,
 ) -> None:
     """Execute the doctor command.
 
-    Performs systematic environment diagnostics.
+    Performs systematic environment diagnostics. FAIL always exits 1;
+    with ``strict=True`` any WARN also exits 1 (useful for CI).
 
     Args:
         project_root: Path to project root directory.
         config_path: Path to guard.yaml.
+        strict: Treat WARN severity as failure.
     """
+    tally = _Tally()
+
     print("AI Code Guard Doctor")
     print("=" * 40)
 
     # 1. Tool dependencies
     print("\n1. Tool Dependencies")
-    _check_python()
-    _check_git()
-    _check_pre_commit()
+    _check_python(tally)
+    _check_git(tally)
+    _check_pre_commit(tally)
 
     # 2. Configuration state
     print("\n2. Configuration")
-    _check_config(config_path)
+    resolved = _check_config(config_path, tally)
 
     # 3. File integrity
     print("\n3. File Integrity")
-    _check_file_integrity(project_root)
+    _check_file_integrity(project_root, tally)
 
     # 4. Drift detection
     print("\n4. Drift Detection")
-    _check_drift(project_root, config_path)
+    _check_drift(project_root, config_path, tally)
+
+    # 5-7. Config-dependent checks (skip when config failed to load)
+    if resolved is not None:
+        print("\n5. Local Hook Entries")
+        _check_local_hook_entries(resolved, project_root, tally)
+
+        print("\n6. Language Coverage")
+        _check_language_coverage(resolved, project_root, tally)
+
+        print("\n7. Stage Semantic Fit")
+        _check_stage_semantic_fit(resolved, tally)
+
+    # Exit policy: FAIL always exits 1. WARN exits 1 only under --strict.
+    if tally.fail > 0 or (strict and tally.warn > 0):
+        print(
+            f"\n{tally.fail} failure(s), {tally.warn} warning(s). "
+            "Run 'ac-guard install' or fix guard.yaml and re-run doctor."
+        )
+        raise SystemExit(1)
 
 
-def _check_python() -> None:
+class _Tally:
+    """Aggregate WARN / FAIL counts across doctor checks."""
+
+    def __init__(self) -> None:
+        self.warn = 0
+        self.fail = 0
+
+    def warn_inc(self) -> None:
+        self.warn += 1
+
+    def fail_inc(self) -> None:
+        self.fail += 1
+
+
+def _check_python(tally: _Tally) -> None:
     """Check Python version."""
     version = sys.version.split()[0]
     major, minor = sys.version_info[:2]
@@ -237,53 +282,65 @@ def _check_python() -> None:
         print(f"  [ok] Python {version}")
     else:
         print(f"  [FAIL] Python {version} (requires >= 3.10)")
+        tally.fail_inc()
 
 
-def _check_git() -> None:
+def _check_git(tally: _Tally) -> None:
     """Check git availability."""
     git_path = shutil.which("git")
     if git_path:
         print(f"  [ok] git found at {git_path}")
     else:
         print("  [FAIL] git not found. Install git.")
+        tally.fail_inc()
 
 
-def _check_pre_commit() -> None:
+def _check_pre_commit(tally: _Tally) -> None:
     """Check pre-commit availability."""
     pc_path = shutil.which("pre-commit")
     if pc_path:
         print(f"  [ok] pre-commit found at {pc_path}")
     else:
         print("  [WARN] pre-commit not found. Install: pip install pre-commit")
+        tally.warn_inc()
 
 
-def _check_config(config_path: Path) -> None:
-    """Validate guard.yaml configuration.
+def _check_config(config_path: Path, tally: _Tally) -> ResolvedConfig | None:
+    """Validate guard.yaml — returns ResolvedConfig so later checks can reuse it.
 
-    Args:
-        config_path: Path to guard.yaml.
+    Returns None on invalid/missing config so the remaining per-config
+    checks can be skipped without raising.
     """
     if not config_path.is_file():
         print(f"  [FAIL] guard.yaml not found at {config_path}")
         print("         Run 'ac-guard init' to create one.")
-        return
+        tally.fail_inc()
+        return None
 
     try:
         load_config(config_path)
-        print(f"  [ok] guard.yaml valid ({config_path})")
     except ConfigError as e:
         print(f"  [FAIL] guard.yaml invalid: {e}")
+        tally.fail_inc()
+        return None
+
+    try:
+        resolved = resolve_config(config_path)
+    except ConfigError as e:
+        print(f"  [FAIL] guard.yaml cannot be resolved: {e}")
+        tally.fail_inc()
+        return None
+
+    print(f"  [ok] guard.yaml valid ({config_path})")
+    return resolved
 
 
-def _check_file_integrity(project_root: Path) -> None:
-    """Check artifact file integrity.
-
-    Args:
-        project_root: Path to project root directory.
-    """
+def _check_file_integrity(project_root: Path, tally: _Tally) -> None:
+    """Check artifact file integrity."""
     state = read_state(project_root)
     if state is None:
         print("  [WARN] Not installed (no state.json)")
+        tally.warn_inc()
         return
 
     missing = []
@@ -297,17 +354,13 @@ def _check_file_integrity(project_root: Path) -> None:
         for path in missing:
             print(f"         {path}")
         print("         Run 'ac-guard update' to regenerate.")
+        tally.fail_inc()
     else:
         print(f"  [ok] All {len(state.artifacts)} artifact(s) present")
 
 
-def _check_drift(project_root: Path, config_path: Path) -> None:
-    """Check configuration drift.
-
-    Args:
-        project_root: Path to project root directory.
-        config_path: Path to guard.yaml.
-    """
+def _check_drift(project_root: Path, config_path: Path, tally: _Tally) -> None:
+    """Check configuration drift."""
     state = read_state(project_root)
     if state is None:
         print("  [SKIP] Not installed")
@@ -315,14 +368,195 @@ def _check_drift(project_root: Path, config_path: Path) -> None:
 
     if not config_path.is_file():
         print("  [WARN] guard.yaml not found")
+        tally.warn_inc()
         return
 
     current_hash = _compute_config_hash(config_path)
     if current_hash != state.config_hash:
         print("  [WARN] Configuration drift detected")
         print("         Run 'ac-guard update' to sync.")
+        tally.warn_inc()
     else:
         print("  [ok] No drift")
+
+
+# ---------------------------------------------------------------------------
+# New Phase 2 PR A checks
+# ---------------------------------------------------------------------------
+
+# Unguarded-language files below this threshold are ignored — avoids noise
+# from scattered config files (.ts shim, single .go vendored, ...).
+_LANGUAGE_COVERAGE_MIN_FILES = 3
+
+
+def _check_local_hook_entries(
+    resolved: ResolvedConfig, project_root: Path, tally: _Tally
+) -> None:
+    """Verify every ``repo: local`` hook's entry resolves to something runnable.
+
+    For each local hook declared under any ``code.<stage>.hooks`` bucket,
+    take the first token of ``entry`` (via ``shlex.split``) and look for
+    it in ``PATH`` or as a file under the project root. Anything that
+    can't be resolved is a ``[FAIL]`` — pre-commit would only surface
+    the error at the first hook invocation, which is too late.
+    """
+    found_any = False
+    for _stage_name, bucket in resolved.code.buckets():
+        for repo in bucket.hooks:
+            if repo.repo != "local":
+                continue
+            for hook in repo.hooks:
+                # PATH matters only for ``language: system`` — other
+                # languages (python/node/docker/...) have pre-commit
+                # install the entry into an isolated env, so we can't
+                # and shouldn't second-guess availability.
+                if hook.extra.get("language") != "system":
+                    continue
+                entry = hook.extra.get("entry")
+                if not isinstance(entry, str) or not entry.strip():
+                    continue
+                found_any = True
+                token = shlex.split(entry)[0] if entry.strip() else ""
+                if not token:
+                    continue
+                location = _resolve_entry(token, project_root)
+                if location:
+                    print(f"  [ok] {hook.id}: {token} ({location})")
+                else:
+                    print(f"  [FAIL] {hook.id}: {token} not in PATH or project")
+                    print("         Install the tool or adjust the guard.yaml entry.")
+                    tally.fail_inc()
+    if not found_any:
+        print("  [ok] No system-language local hooks to verify")
+
+
+def _resolve_entry(token: str, project_root: Path) -> str | None:
+    """Return a human-readable location string if ``token`` is runnable.
+
+    Tries ``shutil.which`` (PATH) first, then checks whether the token
+    resolves to a file under ``project_root``. Returns ``None`` if
+    neither works.
+    """
+    path = shutil.which(token)
+    if path:
+        return "PATH"
+    candidate = project_root / token
+    if candidate.is_file():
+        return "project-relative"
+    return None
+
+
+def _check_language_coverage(
+    resolved: ResolvedConfig, project_root: Path, tally: _Tally
+) -> None:
+    """Compare ``languages:`` declarations against actual repo files (D9).
+
+    Uses ``git ls-files`` to enumerate tracked files, attributes each to
+    a language by extension (``detect_language``), and cross-references
+    the ``languages:`` map. Three cases:
+
+    - declared + has files → ``[ok]``
+    - declared + zero files → ``[WARN]`` (user likely forgot to stage / wrong lang)
+    - undeclared + ≥ ``_LANGUAGE_COVERAGE_MIN_FILES`` → ``[WARN]``
+    - undeclared + < threshold → silent (scattered config files, not worth noise)
+    """
+    counts = _count_languages_by_extension(project_root)
+    declared = set(resolved.languages.keys())
+
+    # Declared languages
+    for lang in sorted(declared):
+        n = counts.get(lang, 0)
+        if n > 0:
+            print(f"  [ok] {lang}: {n} files")
+        else:
+            print(
+                f"  [WARN] {lang}: declared in languages: but no source files "
+                f"found under {project_root}"
+            )
+            tally.warn_inc()
+
+    # Undeclared languages with meaningful presence
+    undeclared = sorted(
+        lang
+        for lang, n in counts.items()
+        if lang not in declared and n >= _LANGUAGE_COVERAGE_MIN_FILES
+    )
+    for lang in undeclared:
+        print(
+            f"  [WARN] {lang}: {counts[lang]} files but no entry in languages: — "
+            f"format/lint shortcuts won't cover them"
+        )
+        tally.warn_inc()
+
+    if not declared and not undeclared:
+        print("  [ok] No tracked source files to check")
+
+
+def _count_languages_by_extension(project_root: Path) -> Counter[str]:
+    """Return ``{language_name: file_count}`` over git-tracked files.
+
+    Falls back to an empty counter if ``git`` fails (e.g. not a repo) —
+    doctor's ``_check_git`` already reports git issues, so we stay silent
+    here to avoid double-reporting.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return Counter()
+
+    if result.returncode != 0:
+        return Counter()
+
+    counts: Counter[str] = Counter()
+    for path in result.stdout.splitlines():
+        lang = detect_language(path)
+        if lang:
+            counts[lang] += 1
+    return counts
+
+
+def _check_stage_semantic_fit(resolved: ResolvedConfig, tally: _Tally) -> None:
+    """Flag format/lint toggles placed on stages where they silent-skip.
+
+    The ``format``/``lint`` shortcuts inject per-language hooks with
+    ``types: [<lang>]`` filtering. On ``commit-msg``/``pre-merge-commit``
+    /``pre-rebase``, pre-commit's runtime type filter never matches the
+    commit-message file (or the branch name for pre-rebase), so those
+    hooks never run. This is pre-commit's native filtering behavior, not
+    an ac-guard restriction — but it's invisible to the user until they
+    notice lint didn't happen, which is too late.
+    """
+    offenders: list[tuple[str, str]] = []
+    for stage_name, bucket in resolved.code.buckets():
+        if stage_name in BUCKET_AWARE_STAGES:
+            continue
+        if bucket.format:
+            offenders.append((stage_name, "format"))
+        if bucket.lint:
+            offenders.append((stage_name, "lint"))
+
+    if not offenders:
+        print("  [ok] format/lint shortcuts only on pre-commit/pre-push")
+        return
+
+    for stage_name, toggle in offenders:
+        print(
+            f"  [WARN] code.{stage_name}.{toggle} is on, but pre-commit's "
+            f"types: filter won't match files at the {stage_name} stage — "
+            f"the generated hooks will silent-skip."
+        )
+        print(
+            f"         Move to code.pre-commit.{toggle} or "
+            f"code.pre-push.{toggle}, or remove the toggle."
+        )
+        tally.warn_inc()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -184,10 +184,11 @@ class TestDoctorCommand:
         )
 
     def test_doctor_not_initialized(self, tmp_path: Path) -> None:
-        """doctor reports when not initialized."""
+        """doctor reports when not initialized — missing config is FAIL."""
         config = tmp_path / "guard.yaml"
         result = runner.invoke(app, ["doctor", "--config", str(config)])
-        assert result.exit_code == 0
+        # Missing guard.yaml is a failure (can't diagnose without it).
+        assert result.exit_code == 1
         assert "guard.yaml" in result.output.lower()
 
     def test_doctor_checks_artifacts(self, installed_project: Path) -> None:
@@ -204,6 +205,256 @@ class TestDoctorCommand:
         result = runner.invoke(app, ["doctor", "--config", str(config)])
         assert result.exit_code == 0
         assert "pre-commit" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestDoctorLocalHookEntries (Phase 2 PR A)
+# ---------------------------------------------------------------------------
+
+
+def _yaml_with_local_hook(
+    tmp_path: Path, *, entry: str, language: str = "system"
+) -> Path:
+    """Write guard.yaml with one repo: local hook using the given entry."""
+    data = {
+        "version": 1,
+        "project": {"name": "t", "language": "python"},
+        "code": {
+            "pre-commit": {
+                "hooks": [
+                    {
+                        "repo": "local",
+                        "hooks": [
+                            {
+                                "id": "custom-hook",
+                                "name": "Custom",
+                                "entry": entry,
+                                "language": language,
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+    }
+    return _write_guard_yaml(tmp_path, data)
+
+
+class TestDoctorLocalHookEntries:
+    """Phase 2 PR A — verify doctor catches missing local hook entries."""
+
+    def test_entry_in_path_is_ok(self, tmp_path: Path) -> None:
+        """A system-language entry resolvable in PATH is reported ok."""
+        # ``python3`` is guaranteed present on every dev/CI box.
+        config = _yaml_with_local_hook(tmp_path, entry="python3 -c 'pass'")
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[ok] custom-hook: python3 (PATH)" in result.output
+
+    def test_entry_project_relative_is_ok(self, tmp_path: Path) -> None:
+        """An entry that resolves to a file under project_root is ok."""
+        script = tmp_path / "scripts" / "custom.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/sh\n", encoding="utf-8")
+        config = _yaml_with_local_hook(tmp_path, entry="scripts/custom.sh")
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[ok] custom-hook: scripts/custom.sh (project-relative)" in result.output
+
+    def test_missing_entry_is_fail(self, tmp_path: Path) -> None:
+        """An entry absent from PATH and project yields FAIL + exit 1."""
+        config = _yaml_with_local_hook(tmp_path, entry="definitely-not-a-real-tool-xyz")
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 1
+        assert "[FAIL]" in result.output
+        assert "definitely-not-a-real-tool-xyz" in result.output
+
+    def test_non_system_language_is_skipped(self, tmp_path: Path) -> None:
+        """language: python (not system) bypasses the PATH check entirely."""
+        config = _yaml_with_local_hook(
+            tmp_path, entry="mypy-but-its-pre-commit-managed", language="python"
+        )
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        # Without system-language local hooks, doctor reports the "nothing
+        # to verify" variant and does not FAIL even though entry is bogus.
+        assert "[ok] No system-language local hooks to verify" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestDoctorLanguageCoverage (Phase 2 PR A)
+# ---------------------------------------------------------------------------
+
+
+def _init_git_with_files(tmp_path: Path, files: dict[str, str]) -> None:
+    """Initialize a git repo at tmp_path and stage each (relpath → content)."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    for relpath, content in files.items():
+        full = tmp_path / relpath
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content, encoding="utf-8")
+        subprocess.run(
+            ["git", "add", relpath],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+
+def _yaml_with_languages(
+    tmp_path: Path, langs: dict[str, dict[str, str]] | None = None
+) -> Path:
+    """Write guard.yaml declaring the given languages (empty default = python)."""
+    data: dict = {
+        "version": 1,
+        "project": {"name": "t", "language": "python"},
+    }
+    if langs is not None:
+        data["languages"] = {
+            name: {
+                "tools": {
+                    "format": tools.get("format", "echo fmt"),
+                    "lint": tools.get("lint", "echo lint"),
+                }
+            }
+            for name, tools in langs.items()
+        }
+    return _write_guard_yaml(tmp_path, data)
+
+
+class TestDoctorLanguageCoverage:
+    """Phase 2 PR A — language coverage (D9) detects drift between repo and config."""
+
+    def test_declared_with_files_is_ok(self, tmp_path: Path) -> None:
+        """Declared python + tracked .py files → [ok] with count."""
+        _init_git_with_files(tmp_path, {f"src/a{i}.py": "" for i in range(5)})
+        config = _yaml_with_languages(tmp_path, {"python": {}})
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[ok] python: 5 files" in result.output
+
+    def test_declared_without_files_is_warn(self, tmp_path: Path) -> None:
+        """Declared rust + zero .rs files → [WARN]."""
+        _init_git_with_files(tmp_path, {"README.md": ""})
+        config = _yaml_with_languages(tmp_path, {"rust": {}})
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[WARN] rust" in result.output
+        assert "no source files found" in result.output
+
+    def test_undeclared_above_threshold_is_warn(self, tmp_path: Path) -> None:
+        """Undeclared typescript + >=3 .ts files → [WARN]."""
+        _init_git_with_files(tmp_path, {f"web/b{i}.ts": "" for i in range(4)})
+        config = _yaml_with_languages(tmp_path, {"python": {}})
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[WARN] typescript" in result.output
+        assert "4 files" in result.output
+
+    def test_undeclared_below_threshold_is_silent(self, tmp_path: Path) -> None:
+        """Undeclared language with <3 files is suppressed."""
+        _init_git_with_files(tmp_path, {"x.go": "", "scripts/setup.go": ""})
+        config = _yaml_with_languages(tmp_path, {"python": {}})
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        # Go files below threshold → no warn line about go.
+        assert "go" not in result.output.lower().split("\n6.")[1].split("\n7.")[0]
+
+    def test_not_a_git_repo_is_silent(self, tmp_path: Path) -> None:
+        """When git ls-files fails, check stays quiet (git diag already covered)."""
+        config = _yaml_with_languages(tmp_path, {"python": {}})
+        # No .git dir in tmp_path → git ls-files returns non-zero
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        # Declared python with 0 files → WARN (repo empty). That's
+        # acceptable; we're only asserting no crash.
+        assert "6. Language Coverage" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestDoctorStageSemanticFit (Phase 2 PR A)
+# ---------------------------------------------------------------------------
+
+
+def _yaml_with_stage(tmp_path: Path, stage: str, field: str, value: bool) -> Path:
+    """Write a guard.yaml toggling one stage bucket field."""
+    data = {
+        "version": 1,
+        "project": {"name": "t", "language": "python"},
+        "code": {stage: {field: value}},
+    }
+    return _write_guard_yaml(tmp_path, data)
+
+
+class TestDoctorStageSemanticFit:
+    """Phase 2 PR A — warn on format/lint toggles attached to non-fitting stages."""
+
+    def test_pre_commit_format_is_ok(self, tmp_path: Path) -> None:
+        """Canonical placement — no warning."""
+        config = _yaml_with_stage(tmp_path, "pre-commit", "format", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[ok] format/lint shortcuts only on pre-commit/pre-push" in (
+            result.output
+        )
+
+    def test_commit_msg_format_is_warn(self, tmp_path: Path) -> None:
+        """commit-msg.format: true is a silent-skip footgun."""
+        config = _yaml_with_stage(tmp_path, "commit-msg", "format", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[WARN]" in result.output
+        assert "code.commit-msg.format" in result.output
+        # Exit 0 because WARN alone doesn't fail without --strict
+        assert result.exit_code == 0
+
+    def test_pre_rebase_lint_is_warn(self, tmp_path: Path) -> None:
+        """pre-rebase.lint: true is equally meaningless (no files to lint)."""
+        config = _yaml_with_stage(tmp_path, "pre-rebase", "lint", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[WARN]" in result.output
+        assert "code.pre-rebase.lint" in result.output
+
+    def test_pre_push_lint_is_ok(self, tmp_path: Path) -> None:
+        """pre-push is bucket-aware — lint there is the canonical place."""
+        config = _yaml_with_stage(tmp_path, "pre-push", "lint", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert "[ok] format/lint shortcuts only on pre-commit/pre-push" in (
+            result.output
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDoctorStrict (Phase 2 PR A)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorStrict:
+    """Phase 2 PR A — --strict policy for CI."""
+
+    def test_strict_with_warn_exits_one(self, tmp_path: Path) -> None:
+        """With --strict, any WARN causes exit 1."""
+        config = _yaml_with_stage(tmp_path, "commit-msg", "format", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config), "--strict"])
+        assert result.exit_code == 1
+        assert "[WARN]" in result.output
+
+    def test_non_strict_with_warn_exits_zero(self, tmp_path: Path) -> None:
+        """Without --strict, WARN is informational and doctor still exits 0."""
+        config = _yaml_with_stage(tmp_path, "commit-msg", "format", True)
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 0
+        assert "[WARN]" in result.output
+
+    def test_fail_always_exits_one(self, tmp_path: Path) -> None:
+        """FAIL unconditionally exits 1, regardless of --strict."""
+        config = _yaml_with_local_hook(tmp_path, entry="definitely-not-a-real-tool-xyz")
+        result = runner.invoke(app, ["doctor", "--config", str(config)])
+        assert result.exit_code == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 2 PR A of Issue #123 · adds three `ac-guard doctor` checks so silent-skip misconfigurations surface at install-time rather than at the first failing commit.

### New checks (sections 5-7 of doctor output)

- **5 · Local Hook Entries** — for every `repo: local` hook with `language: system`, verify its `entry` first token resolves in `$PATH` or as a project-relative file. FAIL otherwise.
- **6 · Language Coverage** (D9) — compare `languages:` declarations against `git ls-files` by extension. WARN on declared-without-files and on ≥3 undeclared files for a detected language.
- **7 · Stage Semantic Fit** — WARN on `format` / `lint` toggles placed on `commit-msg` / `pre-merge-commit` / `pre-rebase`. Message framed in pre-commit terms ("pre-commit's `types:` filter won't match files at this stage") rather than as an ac-guard-invented rule.

### `--strict` flag

Escalates any WARN to exit 1. FAIL unconditionally exits 1 (prev: printed but exited 0). Makes doctor suitable for CI.

### Design decision

Considered splitting `StageBucket` into type-distinct buckets (`GatingStageBucket` / `MessageStageBucket` / `PolicyStageBucket`) so the validator could hard-reject `commit-msg.format: true`. **Rejected** — ac-guard is pre-commit's declarative middle layer, schema must stay a superset of pre-commit's. pre-commit itself accepts `stages: [commit-msg]` + `types: [python]` and silent-skips at runtime; requiring guard.yaml to be stricter than `.pre-commit-config.yaml` would break the "schema-permissive, filter at runtime" mental model users already have from pre-commit. Footgun lives in the doctor observability layer, not the validator.

### Refactor

Lifted `BUCKET_AWARE_STAGES` (was `_BUCKET_AWARE_STAGES` in `cli/check.py`) and the extension→language map (was inline in `_filter_files_by_type`) to public exports on `checker/core.py`. `detect_language(path)` helper added.

### Breaking

Missing `guard.yaml` now exits 1 (previously exited 0 despite printing `[FAIL]`). Updated `test_doctor_not_initialized`.

## Test plan

- [x] `pytest tests/unit/test_cli/test_status.py` — 36/36 passing
- [x] Full suite — 961/961 passing
- [x] Manual: `.venv/bin/ac-guard doctor` on this repo → all 7 sections `[ok]`
- [x] Manual: `.venv/bin/ac-guard doctor --strict` on clean repo → exit 0
- [x] Manual: bogus entry in local hook → `[FAIL]` + exit 1
- [x] Manual: `commit-msg.format: true` in test fixture → `[WARN]` + exit 0 (or 1 with `--strict`)

## Development

- Relates: #123 (Phase 2)
- Follow-up (deferred): `languages._ignore: [lang]` escape hatch — the 3-file threshold suppresses most noise; add only if monorepos report false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)