### PR TITLE
chore(m6): tighten ruff thresholds to industry defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ select = [
     "N",      # pep8-naming
     "C90",    # mccabe (complexity)
     "PLR0913", # pylint: too-many-arguments
+    "PLR0915", # pylint: too-many-statements
     "PLE",    # pylint errors
     "PLW",    # pylint warnings
     "PT",     # flake8-pytest-style
@@ -105,24 +106,34 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-# Raised from 10 → 12 to accommodate orchestrators like
-# generator.core.write_artifacts. Further tightening is tracked under
-# the modular refactor (#109); adding `# noqa: C901` per-function is
-# explicitly not allowed (see forbid-noqa pre-commit hook).
-max-complexity = 12
+# Industry-standard McCabe ceiling (NIST / SEI / McCabe 1976). Kept
+# aligned with Ruff's default; orchestrators that exceeded it were
+# refactored via helper extraction rather than relaxed at the
+# config layer. Per-function `# noqa: C901` is banned by the
+# forbid-noqa pre-commit hook.
+max-complexity = 10
 
 [tool.ruff.lint.pylint]
-# Raised from 5 → 9 to cover our genuine multi-knob public APIs
-# (reporter._http.request_json, checker.core.run_stage). Config-level
-# limit keeps the signal on new functions; per-line `# noqa: PLR0913`
-# is banned.
-max-args = 9
+# Pylint / Ruff default. Multi-knob APIs (request_json retry params,
+# run_stage orchestration) are expressed through dataclass option
+# bundles (RetryPolicy, StageOptions) rather than raising the limit.
+# Per-line `# noqa: PLR0913` is banned.
+max-args = 5
+# Pylint default. Functions approaching 50 statements should be split
+# into helpers — large bodies hide branching structure even when
+# cyclomatic complexity stays green.
+max-statements = 50
 
 [tool.ruff.lint.isort]
 known-first-party = ["ac_guard"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "ANN", "ARG", "PLR0913", "C408", "TC"]  # relax requirements for tests
+# scripts/ holds one-off guard infrastructure (tokenizer-style source
+# scanners, etc.). Their cyclomatic complexity tracks the grammar they
+# parse rather than business branching, so C901 doesn't produce useful
+# signal there. All other rules (incl. PLR0913/PLR0915) still apply.
+"scripts/*" = ["C901"]
 
 [tool.ruff.lint.pep8-naming]
 # Private conventions inherited from the retired scripts/checks/_config.py:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,11 +129,6 @@ known-first-party = ["ac_guard"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "ANN", "ARG", "PLR0913", "C408", "TC"]  # relax requirements for tests
-# scripts/ holds one-off guard infrastructure (tokenizer-style source
-# scanners, etc.). Their cyclomatic complexity tracks the grammar they
-# parse rather than business branching, so C901 doesn't produce useful
-# signal there. All other rules (incl. PLR0913/PLR0915) still apply.
-"scripts/*" = ["C901"]
 
 [tool.ruff.lint.pep8-naming]
 # Private conventions inherited from the retired scripts/checks/_config.py:

--- a/scripts/check_encoding.py
+++ b/scripts/check_encoding.py
@@ -53,6 +53,34 @@ def _in_string(pos: int, regions: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in regions)
 
 
+def _skip_string_literal(src: str, i: int) -> int:
+    """Skip past the Python string literal that begins at ``src[i]``.
+
+    Returns the index just past the closing quote, or ``-1`` if the
+    literal is not closed. Handles triple-quoted and single-quoted
+    forms, respecting backslash escapes.
+
+    Precondition: ``src[i]`` is a single or double quote.
+    """
+    triple = src[i : i + 3]
+    if triple in ('"""', "'''"):
+        end = src.find(triple, i + 3)
+        return -1 if end == -1 else end + 3
+
+    quote = src[i]
+    j = i + 1
+    n = len(src)
+    while j < n:
+        c = src[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == quote:
+            return j + 1
+        j += 1
+    return -1
+
+
 def _find_close(src: str, open_paren: int) -> int:
     """Return index of the ``)`` matching ``src[open_paren] == '('``.
 
@@ -61,26 +89,15 @@ def _find_close(src: str, open_paren: int) -> int:
     """
     depth = 0
     i = open_paren
-    in_str: str | None = None
     n = len(src)
     while i < n:
         c = src[i]
-        if in_str:
-            if c == "\\":
-                i += 2
-                continue
-            if c == in_str:
-                in_str = None
-        elif c in ("'", '"'):
-            triple = src[i : i + 3]
-            if triple in ('"""', "'''"):
-                end = src.find(triple, i + 3)
-                if end == -1:
-                    return -1
-                i = end + 3
-                continue
-            in_str = c
-        elif c == "(":
+        if c in ("'", '"'):
+            i = _skip_string_literal(src, i)
+            if i == -1:
+                return -1
+            continue
+        if c == "(":
             depth += 1
         elif c == ")":
             depth -= 1
@@ -98,27 +115,16 @@ def _top_level_has_encoding(inner: str) -> bool:
     only accept an ``encoding=`` match at depth 0 outside any string.
     """
     depth = 0
-    in_str: str | None = None
     i = 0
     n = len(inner)
     while i < n:
         c = inner[i]
-        if in_str:
-            if c == "\\":
-                i += 2
-                continue
-            if c == in_str:
-                in_str = None
-        elif c in ("'", '"'):
-            triple = inner[i : i + 3]
-            if triple in ('"""', "'''"):
-                end = inner.find(triple, i + 3)
-                if end == -1:
-                    return False
-                i = end + 3
-                continue
-            in_str = c
-        elif c == "(":
+        if c in ("'", '"'):
+            i = _skip_string_literal(inner, i)
+            if i == -1:
+                return False
+            continue
+        if c == "(":
             depth += 1
         elif c == ")":
             depth -= 1

--- a/src/ac_guard/checker/core.py
+++ b/src/ac_guard/checker/core.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import subprocess
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from ac_guard.checker.models import CheckReport, CheckResult
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 __all__ = [
     "BUCKET_AWARE_STAGES",
     "TYPE_EXTENSIONS",
+    "StageOptions",
     "detect_language",
     "get_changed_files",
     "run_build",
@@ -29,6 +31,31 @@ __all__ = [
     "run_precommit",
     "run_stage",
 ]
+
+
+@dataclass(frozen=True)
+class StageOptions:
+    """Optional refinements for :func:`run_stage`.
+
+    Keeps the primary orchestration signature short while still allowing
+    callers to override the file list, language set, or build command
+    used by a stage run.
+
+    Attributes:
+        build_command: Shell command to execute for the build check
+            (``pre-push`` stage only). ``None`` disables the build.
+        files: Explicit file list. ``None`` means auto-detect via git.
+        languages: Language identifiers used to resolve pre-commit hook
+            IDs (``format-<lang>`` / ``lint-<lang>``). ``None`` or empty
+            means format/lint shortcuts are silently skipped.
+    """
+
+    build_command: str | None = None
+    files: list[str] | None = None
+    languages: list[str] | None = None
+
+
+_DEFAULT_STAGE_OPTIONS = StageOptions()
 
 
 # Stages where ac-guard provides bucket-aware orchestration (format/lint
@@ -331,9 +358,8 @@ def run_stage(
     stage: str,
     code_config: CodeConfig,
     project_root: Path,
-    build_command: str | None = None,
-    files: list[str] | None = None,
-    languages: list[str] | None = None,
+    *,
+    options: StageOptions = _DEFAULT_STAGE_OPTIONS,
 ) -> CheckReport:
     """Orchestrate all checks for a stage.
 
@@ -344,22 +370,23 @@ def run_stage(
         stage: Check stage ("pre-commit" or "pre-push").
         code_config: CodeConfig with enabled flags and checks.
         project_root: Path to project root directory.
-        build_command: Optional build command (pre-push stage only).
-        files: Explicit file list. If None, auto-detect via git.
-        languages: Language identifiers used to resolve pre-commit
-            hook IDs (``format-<lang>`` / ``lint-<lang>``). Empty list
-            or None means format/lint shortcuts are silently skipped.
+        options: Optional refinements (build command, explicit file list,
+            language identifiers). See :class:`StageOptions`.
 
     Returns:
         CheckReport with aggregated results.
     """
     start = time.monotonic()
-    langs = list(languages or [])
+    langs = list(options.languages or [])
 
     if stage == "pre-push":
-        # Fail-fast: run pre-commit stage first
+        # Fail-fast: run pre-commit stage first, propagating file/language
+        # overrides but suppressing the build command (pre-commit has no build).
         commit_report = run_stage(
-            "pre-commit", code_config, project_root, files=files, languages=langs
+            "pre-commit",
+            code_config,
+            project_root,
+            options=StageOptions(files=options.files, languages=langs),
         )
         if not commit_report.passed:
             elapsed = int((time.monotonic() - start) * 1000)
@@ -370,6 +397,7 @@ def run_stage(
                 duration_ms=elapsed,
             )
 
+    files = options.files
     if files is None:
         files = get_changed_files(stage, project_root)
     results: list[CheckResult] = []
@@ -378,7 +406,9 @@ def run_stage(
         results.extend(_run_commit_checks(code_config, files, project_root, langs))
     else:
         results.extend(
-            _run_push_checks(code_config, files, project_root, build_command, langs)
+            _run_push_checks(
+                code_config, files, project_root, options.build_command, langs
+            )
         )
 
     elapsed = int((time.monotonic() - start) * 1000)

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard.checker.core import (
     BUCKET_AWARE_STAGES,
+    StageOptions,
     get_changed_files,
     run_check,
     run_precommit,
@@ -59,8 +60,10 @@ def check_command(
         "pre-commit",
         resolved.code,
         project_root,
-        files=file_list,
-        languages=list(resolved.languages),
+        options=StageOptions(
+            files=file_list,
+            languages=list(resolved.languages),
+        ),
     )
 
     print(
@@ -96,8 +99,10 @@ def verify_command(
         "pre-push",
         resolved.code,
         project_root,
-        build_command=build_cmd,
-        languages=list(resolved.languages),
+        options=StageOptions(
+            build_command=build_cmd,
+            languages=list(resolved.languages),
+        ),
     )
 
     print(
@@ -233,8 +238,10 @@ def gate_run_command(
             stage,
             resolved.code,
             project_root,
-            build_command=build_cmd,
-            languages=list(resolved.languages),
+            options=StageOptions(
+                build_command=build_cmd,
+                languages=list(resolved.languages),
+            ),
         )
         message, exit_code = format_gate(report)
         print(message)

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -339,61 +339,68 @@ def write_artifacts(
 
     for artifact in artifacts:
         full_path = project_root / artifact.path
-
         try:
-            # Ensure parent directory exists
             full_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Schema v2 (#123 D4): .pre-commit-config.yaml is now a
-            # pure artifact — overwrite unconditionally, no managed-
-            # block splicing. Rule-doc files (CLAUDE.md, etc.) still
-            # honor the managed-block contract so user edits outside
-            # the block survive.
-            if artifact.path == ".pre-commit-config.yaml":
-                content = artifact.content
-            elif full_path.is_file():
-                existing = full_path.read_text(encoding="utf-8")
-                begin, end = markers_for(artifact.path)
-                if begin in existing and end in existing:
-                    new_inner = _unwrap_self_embedded_block(
-                        artifact.content, begin, end
-                    )
-                    content = replace_managed_block(
-                        existing, new_inner, path=artifact.path
-                    )
-                else:
-                    content = artifact.content
-            elif _should_wrap_new_file(artifact.path):
-                content = wrap_with_managed_block(artifact.content, path=artifact.path)
-            else:
-                content = artifact.content
-
-            # Write file
+            content = _resolve_artifact_content(artifact, full_path)
             full_path.write_text(content, encoding="utf-8")
-
-            # Set executable flag if required
             if artifact.executable:
-                current_mode = full_path.stat().st_mode
-                full_path.chmod(
-                    current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                )
-
+                _apply_executable_flag(full_path)
             written_paths.append(artifact.path)
-
         except PermissionError:
             failed_paths.append(artifact.path)
-        except OSError as e:
-            # Other I/O errors (disk full, etc.)
-            if "Permission denied" in str(e) or e.errno == 13:
+        except OSError as exc:
+            if _is_permission_error(exc):
                 failed_paths.append(artifact.path)
             else:
-                # Re-raise unexpected I/O errors
                 raise
 
     if failed_paths:
         raise ArtifactWriteError(failed_paths=failed_paths)
 
     return written_paths
+
+
+def _resolve_artifact_content(artifact: FileSpec, full_path: Path) -> str:
+    """Return the final on-disk content for ``artifact``.
+
+    Schema v2 (#123 D4) rules:
+
+    - ``.pre-commit-config.yaml`` is overwritten unconditionally
+      (pure artifact, no managed-block splicing).
+    - An existing rule-doc file containing markers is spliced — user
+      edits outside the managed block survive.
+    - A new rule-doc file whose extension opts into wrapping
+      (:data:`_WRAP_ON_WRITE_EXTS`) is wrapped in markers.
+    - Everything else is written verbatim from the template.
+    """
+    if artifact.path == ".pre-commit-config.yaml":
+        return artifact.content
+    if full_path.is_file():
+        existing = full_path.read_text(encoding="utf-8")
+        begin, end = markers_for(artifact.path)
+        if begin in existing and end in existing:
+            new_inner = _unwrap_self_embedded_block(artifact.content, begin, end)
+            return replace_managed_block(existing, new_inner, path=artifact.path)
+        return artifact.content
+    if _should_wrap_new_file(artifact.path):
+        return wrap_with_managed_block(artifact.content, path=artifact.path)
+    return artifact.content
+
+
+def _apply_executable_flag(full_path: Path) -> None:
+    """Add user/group/other execute bits to ``full_path`` preserving existing mode."""
+    current_mode = full_path.stat().st_mode
+    full_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _is_permission_error(exc: OSError) -> bool:
+    """Whether an ``OSError`` represents a permission failure.
+
+    ``PermissionError`` is handled separately; this catches platforms
+    that surface permission denials through the generic ``OSError``
+    path (errno 13 or ``Permission denied`` in the message).
+    """
+    return "Permission denied" in str(exc) or exc.errno == 13
 
 
 def delete_artifacts(

--- a/src/ac_guard/reporter/_http.py
+++ b/src/ac_guard/reporter/_http.py
@@ -6,7 +6,7 @@ errors (401, 403, 404, ...) fail fast — retrying them would only
 waste attempts.
 
 The channel modules are thin wrappers that build auth/accept headers
-and delegate transport to :func:`request_json`.
+and delegate transport to :func:`get_json` / :func:`post_json`.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import time
 import urllib.request
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
@@ -22,10 +23,157 @@ from ac_guard.reporter.channel_base import ChannelError
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-__all__ = ["request_json"]
+__all__ = ["RetryPolicy", "get_json", "post_json"]
 
 # HTTP status codes considered transient and worth retrying.
 _RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Retry + exponential-backoff configuration for JSON HTTP requests.
+
+    Attributes:
+        max_attempts: Upper bound on total attempts (>=1).
+        backoff_base: Exponential backoff base in seconds.
+        backoff_cap: Maximum sleep between attempts in seconds.
+        sleep: Sleep function to use between attempts. ``None`` means
+            fall back to :func:`time.sleep` via module attribute lookup,
+            which keeps existing ``patch("...time.sleep")`` test hooks
+            working without per-test ``RetryPolicy`` construction.
+    """
+
+    max_attempts: int = 3
+    backoff_base: float = 0.5
+    backoff_cap: float = 8.0
+    sleep: Callable[[float], None] | None = None
+
+
+_DEFAULT_RETRY = RetryPolicy()
+
+
+def get_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    api_name: str,
+    retry: RetryPolicy = _DEFAULT_RETRY,
+) -> dict | list | None:
+    """Issue a GET request with bounded retries and return parsed JSON.
+
+    Args:
+        url: Absolute URL to request.
+        headers: Fully built request headers (auth, accept).
+        api_name: Human-readable API name used in error messages
+            (e.g. ``"GitHub"``).
+        retry: Retry/backoff policy.
+
+    Returns:
+        Parsed JSON body on success. Returns ``None`` when the response
+        body is empty.
+
+    Raises:
+        ChannelError: On non-retryable HTTP errors (4xx other than
+            408/429) or when retries are exhausted on retryable failures.
+    """
+    return _do_request(
+        _PreparedRequest(url=url, method="GET", headers=headers, body=None),
+        api_name=api_name,
+        retry=retry,
+    )
+
+
+def post_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    body: dict | None = None,
+    api_name: str,
+    retry: RetryPolicy = _DEFAULT_RETRY,
+) -> dict | list | None:
+    """Issue a POST request with bounded retries and return parsed JSON.
+
+    Args:
+        url: Absolute URL to request.
+        headers: Fully built request headers (auth, accept, content-type).
+        body: Optional JSON-serializable request body. POST without a
+            body is allowed but unusual.
+        api_name: Human-readable API name used in error messages.
+        retry: Retry/backoff policy.
+
+    Returns:
+        Parsed JSON body on success. Returns ``None`` when the response
+        body is empty (common for POST-without-echo endpoints).
+
+    Raises:
+        ChannelError: On non-retryable HTTP errors (4xx other than
+            408/429) or when retries are exhausted on retryable failures.
+    """
+    return _do_request(
+        _PreparedRequest(url=url, method="POST", headers=headers, body=body),
+        api_name=api_name,
+        retry=retry,
+    )
+
+
+@dataclass(frozen=True)
+class _PreparedRequest:
+    """Immutable bundle describing a single outbound HTTP request."""
+
+    url: str
+    method: str
+    headers: dict[str, str]
+    body: dict | None
+
+
+def _do_request(
+    request: _PreparedRequest,
+    *,
+    api_name: str,
+    retry: RetryPolicy,
+) -> dict | list | None:
+    """Execute the retry loop for a prepared request."""
+    data = (
+        json.dumps(request.body).encode("utf-8") if request.body is not None else None
+    )
+    last_exc: BaseException | None = None
+
+    for attempt in range(1, retry.max_attempts + 1):
+        req = urllib.request.Request(
+            request.url,
+            data=data,
+            method=request.method,
+            headers=request.headers,
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                raw = resp.read()
+                if not raw:
+                    return None
+                return json.loads(raw)
+        except HTTPError as exc:
+            last_exc = exc
+            if exc.code not in _RETRYABLE_STATUS:
+                raise ChannelError(
+                    f"{api_name} API returned {exc.code}: {exc.reason}"
+                ) from exc
+            retry_after = _parse_retry_after(
+                exc.headers.get("Retry-After") if exc.headers else None
+            )
+            if attempt == retry.max_attempts:
+                break
+            _wait(retry, retry_after, attempt)
+        except URLError as exc:
+            last_exc = exc
+            if attempt == retry.max_attempts:
+                break
+            _wait(retry, None, attempt)
+
+    # Retries exhausted.
+    detail = _describe(last_exc)
+    raise ChannelError(
+        f"{api_name} API request failed after {retry.max_attempts} attempts: {detail}"
+    ) from last_exc
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -43,90 +191,19 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
-def request_json(
-    url: str,
-    *,
-    method: str,
-    headers: dict[str, str],
-    body: dict | None = None,
-    api_name: str,
-    max_attempts: int = 3,
-    backoff_base: float = 0.5,
-    backoff_cap: float = 8.0,
-    sleep: Callable[[float], None] = time.sleep,
-) -> dict | list | None:
-    """Issue an HTTP request with bounded retries and return parsed JSON.
+def _wait(retry: RetryPolicy, retry_after: float | None, attempt: int) -> None:
+    """Sleep between attempts honoring ``Retry-After`` when present.
 
-    Args:
-        url: Absolute URL to request.
-        method: HTTP method (``"GET"`` or ``"POST"``).
-        headers: Fully built request headers (auth, accept, content-type).
-        body: Optional JSON-serializable request body. POST without a
-            body is allowed but unusual.
-        api_name: Human-readable API name used in error messages
-            (e.g. ``"GitHub"``).
-        max_attempts: Upper bound on total attempts (>=1). Default 3.
-        backoff_base: Exponential backoff base in seconds. Default 0.5.
-        backoff_cap: Maximum sleep between attempts in seconds. Default 8.
-        sleep: Injection point for tests.
-
-    Returns:
-        Parsed JSON body on success. Returns ``None`` when the response
-        body is empty (common for POST-without-echo endpoints).
-
-    Raises:
-        ChannelError: On non-retryable HTTP errors (4xx other than 408/429)
-            or when retries are exhausted on retryable failures.
+    Resolves the sleep function at call time so test patches on
+    ``ac_guard.reporter._http.time.sleep`` remain effective even when
+    the default :class:`RetryPolicy` is reused across calls.
     """
-    data = json.dumps(body).encode("utf-8") if body is not None else None
-    last_exc: BaseException | None = None
-
-    for attempt in range(1, max_attempts + 1):
-        req = urllib.request.Request(url, data=data, method=method, headers=headers)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                raw = resp.read()
-                if not raw:
-                    return None
-                return json.loads(raw)
-        except HTTPError as exc:
-            last_exc = exc
-            if exc.code not in _RETRYABLE_STATUS:
-                raise ChannelError(
-                    f"{api_name} API returned {exc.code}: {exc.reason}"
-                ) from exc
-            retry_after = _parse_retry_after(
-                exc.headers.get("Retry-After") if exc.headers else None
-            )
-            if attempt == max_attempts:
-                break
-            _wait(sleep, retry_after, attempt, backoff_base, backoff_cap)
-        except URLError as exc:
-            last_exc = exc
-            if attempt == max_attempts:
-                break
-            _wait(sleep, None, attempt, backoff_base, backoff_cap)
-
-    # Retries exhausted.
-    detail = _describe(last_exc)
-    raise ChannelError(
-        f"{api_name} API request failed after {max_attempts} attempts: {detail}"
-    ) from last_exc
-
-
-def _wait(
-    sleep: Callable[[float], None],
-    retry_after: float | None,
-    attempt: int,
-    base: float,
-    cap: float,
-) -> None:
-    """Sleep between attempts honoring ``Retry-After`` when present."""
+    sleep_fn = retry.sleep if retry.sleep is not None else time.sleep
     if retry_after is not None:
-        sleep(retry_after)
+        sleep_fn(retry_after)
         return
-    delay = min(cap, base * (2 ** (attempt - 1)))
-    sleep(delay)
+    delay = min(retry.backoff_cap, retry.backoff_base * (2 ** (attempt - 1)))
+    sleep_fn(delay)
 
 
 def _describe(exc: BaseException | None) -> str:

--- a/src/ac_guard/reporter/channel_bitbucket.py
+++ b/src/ac_guard/reporter/channel_bitbucket.py
@@ -11,7 +11,7 @@ import os
 from typing import TYPE_CHECKING
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter._http import request_json
+from ac_guard.reporter._http import get_json, post_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -170,9 +170,8 @@ class BitbucketChannel(ReportChannel):
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
         """POST JSON with Bearer auth via the shared retry layer."""
-        request_json(
+        post_json(
             url,
-            method="POST",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
@@ -184,9 +183,8 @@ class BitbucketChannel(ReportChannel):
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
         """GET JSON with Bearer auth via the shared retry layer."""
-        return request_json(
+        return get_json(
             url,
-            method="GET",
             headers={"Authorization": f"Bearer {token}"},
             api_name="Bitbucket",
         )

--- a/src/ac_guard/reporter/channel_gitea.py
+++ b/src/ac_guard/reporter/channel_gitea.py
@@ -11,7 +11,7 @@ import os
 from typing import TYPE_CHECKING
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter._http import request_json
+from ac_guard.reporter._http import get_json, post_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -162,9 +162,8 @@ class GiteaChannel(ReportChannel):
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
         """POST JSON with token auth via the shared retry layer."""
-        request_json(
+        post_json(
             url,
-            method="POST",
             headers={
                 "Authorization": f"token {token}",
                 "Content-Type": "application/json",
@@ -176,9 +175,8 @@ class GiteaChannel(ReportChannel):
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
         """GET JSON with token auth via the shared retry layer."""
-        return request_json(
+        return get_json(
             url,
-            method="GET",
             headers={"Authorization": f"token {token}"},
             api_name="Gitea",
         )

--- a/src/ac_guard/reporter/channel_github.py
+++ b/src/ac_guard/reporter/channel_github.py
@@ -12,7 +12,7 @@ import re
 from typing import TYPE_CHECKING
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter._http import request_json
+from ac_guard.reporter._http import get_json, post_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -176,9 +176,8 @@ class GitHubChannel(ReportChannel):
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
         """POST JSON with Bearer auth via the shared retry layer."""
-        request_json(
+        post_json(
             url,
-            method="POST",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
@@ -191,9 +190,8 @@ class GitHubChannel(ReportChannel):
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
         """GET JSON with Bearer auth via the shared retry layer."""
-        return request_json(
+        return get_json(
             url,
-            method="GET",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",

--- a/src/ac_guard/reporter/channel_gitlab.py
+++ b/src/ac_guard/reporter/channel_gitlab.py
@@ -12,7 +12,7 @@ import urllib.parse
 from typing import TYPE_CHECKING
 
 from ac_guard.reporter._git_info import get_current_branch, get_remote_repo
-from ac_guard.reporter._http import request_json
+from ac_guard.reporter._http import get_json, post_json
 from ac_guard.reporter.channel_base import (
     ChannelError,
     NoPrContextError,
@@ -171,9 +171,8 @@ class GitLabChannel(ReportChannel):
     @staticmethod
     def _post_json(url: str, body: dict, token: str) -> None:
         """POST JSON with PRIVATE-TOKEN auth via the shared retry layer."""
-        request_json(
+        post_json(
             url,
-            method="POST",
             headers={
                 "PRIVATE-TOKEN": token,
                 "Content-Type": "application/json",
@@ -185,9 +184,8 @@ class GitLabChannel(ReportChannel):
     @staticmethod
     def _get_json(url: str, token: str) -> list | dict | None:
         """GET JSON with PRIVATE-TOKEN auth via the shared retry layer."""
-        return request_json(
+        return get_json(
             url,
-            method="GET",
             headers={"PRIVATE-TOKEN": token},
             api_name="GitLab",
         )

--- a/tests/unit/test_checker/test_core.py
+++ b/tests/unit/test_checker/test_core.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from ac_guard.checker.core import (
+    StageOptions,
     _filter_files_by_type,
     get_changed_files,
     run_build,
@@ -178,7 +179,12 @@ class TestRunStage:
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=False)
         )
         with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
-            report = run_stage("pre-push", config, tmp_path, build_command="echo build")
+            report = run_stage(
+                "pre-push",
+                config,
+                tmp_path,
+                options=StageOptions(build_command="echo build"),
+            )
         assert report.passed is True
         assert any(r.name == "build" for r in report.results)
 
@@ -196,8 +202,10 @@ class TestRunStage:
                 "pre-commit",
                 config,
                 tmp_path,
-                files=["a.py"],
-                languages=["python", "typescript"],
+                options=StageOptions(
+                    files=["a.py"],
+                    languages=["python", "typescript"],
+                ),
             )
         hook_ids = [call.args[0] for call in mock_run.call_args_list]
         assert "format-python" in hook_ids
@@ -222,7 +230,7 @@ class TestRunStage:
                     "pre-push",
                     config,
                     tmp_path,
-                    languages=["python", "typescript"],
+                    options=StageOptions(languages=["python", "typescript"]),
                 )
         hook_ids = [call.args[0] for call in mock_run.call_args_list]
         assert "lint-python" in hook_ids
@@ -242,7 +250,7 @@ class TestRunStage:
             patch("ac_guard.checker.core.run_precommit") as mock_run,
             patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
         ):
-            run_stage("pre-push", config, tmp_path, languages=[])
+            run_stage("pre-push", config, tmp_path, options=StageOptions(languages=[]))
         mock_run.assert_not_called()
 
     def test_push_build_failure_skips_lint_and_checks(self, tmp_path: Path) -> None:
@@ -271,8 +279,10 @@ class TestRunStage:
                 "pre-push",
                 config,
                 tmp_path,
-                build_command="make build",
-                languages=["python"],
+                options=StageOptions(
+                    build_command="make build",
+                    languages=["python"],
+                ),
             )
 
         # Build ran once, downstream checkers never invoked
@@ -317,8 +327,10 @@ class TestRunStage:
                 "pre-push",
                 config,
                 tmp_path,
-                build_command="make build",
-                languages=["python"],
+                options=StageOptions(
+                    build_command="make build",
+                    languages=["python"],
+                ),
             )
         precommit_mock.assert_called()
         check_mock.assert_called()

--- a/tests/unit/test_reporter/test_http.py
+++ b/tests/unit/test_reporter/test_http.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
-from ac_guard.reporter._http import request_json
+from ac_guard.reporter._http import RetryPolicy, get_json, post_json
 from ac_guard.reporter.channel_base import ChannelError
 
 
@@ -62,19 +62,23 @@ class _SleepRecorder:
         self.calls.append(seconds)
 
 
-class TestRequestJson:
-    """request_json retry/backoff behaviour."""
+def _policy(sleeper: _SleepRecorder, **overrides: Any) -> RetryPolicy:
+    """Build a RetryPolicy that records sleeps into ``sleeper``."""
+    return RetryPolicy(sleep=sleeper, **overrides)
+
+
+class TestGetJson:
+    """get_json retry/backoff behaviour."""
 
     def test_success_without_retry(self) -> None:
         """200 on first attempt returns parsed body and does not sleep."""
         sleeper = _SleepRecorder()
         with patch("urllib.request.urlopen", return_value=_ok({"ok": True})):
-            result = request_json(
+            result = get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitHub",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert result == {"ok": True}
         assert sleeper.calls == []
@@ -84,44 +88,25 @@ class TestRequestJson:
         sleeper = _SleepRecorder()
         side_effect = [URLError("net down"), URLError("net down"), _ok([1, 2])]
         with patch("urllib.request.urlopen", side_effect=side_effect):
-            result = request_json(
+            result = get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitHub",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert result == [1, 2]
         assert len(sleeper.calls) == 2
-
-    def test_retries_exhausted_on_503(self) -> None:
-        """Persistent 503 exhausts retries and raises with attempt count."""
-        sleeper = _SleepRecorder()
-        side_effect = [_http_error(503) for _ in range(3)]
-        with (
-            patch("urllib.request.urlopen", side_effect=side_effect),
-            pytest.raises(ChannelError, match="after 3 attempts"),
-        ):
-            request_json(
-                "https://example/api",
-                method="POST",
-                headers=_headers(),
-                body={"x": 1},
-                api_name="GitHub",
-                sleep=sleeper,
-            )
 
     def test_retries_on_500_then_succeeds(self) -> None:
         """500 is retryable; next 200 completes the request."""
         sleeper = _SleepRecorder()
         side_effect = [_http_error(500), _ok({"ok": 1})]
         with patch("urllib.request.urlopen", side_effect=side_effect):
-            result = request_json(
+            result = get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitLab",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert result == {"ok": 1}
         assert len(sleeper.calls) == 1
@@ -133,12 +118,11 @@ class TestRequestJson:
             patch("urllib.request.urlopen", side_effect=_http_error(404)),
             pytest.raises(ChannelError, match="404"),
         ):
-            request_json(
+            get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="Gitea",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert sleeper.calls == []
 
@@ -149,12 +133,11 @@ class TestRequestJson:
             patch("urllib.request.urlopen", side_effect=_http_error(401)),
             pytest.raises(ChannelError, match="401"),
         ):
-            request_json(
+            get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="Bitbucket",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert sleeper.calls == []
 
@@ -163,12 +146,11 @@ class TestRequestJson:
         sleeper = _SleepRecorder()
         side_effect = [_http_error(429, retry_after="2"), _ok({"ok": 1})]
         with patch("urllib.request.urlopen", side_effect=side_effect):
-            request_json(
+            get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitHub",
-                sleep=sleeper,
+                retry=_policy(sleeper),
             )
         assert sleeper.calls == [2.0]
 
@@ -177,13 +159,11 @@ class TestRequestJson:
         sleeper = _SleepRecorder()
         side_effect = [_http_error(503), _http_error(503), _ok({"ok": 1})]
         with patch("urllib.request.urlopen", side_effect=side_effect):
-            request_json(
+            get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitHub",
-                backoff_base=0.5,
-                sleep=sleeper,
+                retry=_policy(sleeper, backoff_base=0.5),
             )
         assert sleeper.calls == [0.5, 1.0]
 
@@ -192,27 +172,81 @@ class TestRequestJson:
         sleeper = _SleepRecorder()
         side_effect = [_http_error(503), _http_error(503), _ok({"ok": 1})]
         with patch("urllib.request.urlopen", side_effect=side_effect):
-            request_json(
+            get_json(
                 "https://example/api",
-                method="GET",
                 headers=_headers(),
                 api_name="GitHub",
-                backoff_base=4.0,
-                backoff_cap=5.0,
-                sleep=sleeper,
+                retry=_policy(sleeper, backoff_base=4.0, backoff_cap=5.0),
             )
         # attempt 1 -> 4, attempt 2 -> min(5, 8) = 5
         assert sleeper.calls == [4.0, 5.0]
 
-    def test_empty_response_body_returns_none(self) -> None:
-        """Empty response body (common for POST-no-echo) yields None."""
-        with patch("urllib.request.urlopen", return_value=_FakeResponse(b"")):
-            result = request_json(
+
+class TestPostJson:
+    """post_json retry/backoff behaviour."""
+
+    def test_retries_exhausted_on_503(self) -> None:
+        """Persistent 503 exhausts retries and raises with attempt count."""
+        sleeper = _SleepRecorder()
+        side_effect = [_http_error(503) for _ in range(3)]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect),
+            pytest.raises(ChannelError, match="after 3 attempts"),
+        ):
+            post_json(
                 "https://example/api",
-                method="POST",
                 headers=_headers(),
                 body={"x": 1},
                 api_name="GitHub",
-                sleep=_SleepRecorder(),
+                retry=_policy(sleeper),
+            )
+
+    def test_empty_response_body_returns_none(self) -> None:
+        """Empty response body (common for POST-no-echo) yields None."""
+        with patch("urllib.request.urlopen", return_value=_FakeResponse(b"")):
+            result = post_json(
+                "https://example/api",
+                headers=_headers(),
+                body={"x": 1},
+                api_name="GitHub",
+                retry=_policy(_SleepRecorder()),
             )
         assert result is None
+
+    def test_post_without_body(self) -> None:
+        """POST without a body is allowed and serializes no data."""
+        with patch(
+            "urllib.request.urlopen", return_value=_ok({"created": True})
+        ) as mock_open:
+            result = post_json(
+                "https://example/api",
+                headers=_headers(),
+                api_name="GitHub",
+                retry=_policy(_SleepRecorder()),
+            )
+        assert result == {"created": True}
+        # Verify no body was serialized onto the Request.
+        (sent_req,) = mock_open.call_args.args
+        assert sent_req.data is None
+
+
+class TestRetryPolicyDefaults:
+    """Default RetryPolicy falls back to module-level time.sleep.
+
+    Keeps ``patch('ac_guard.reporter._http.time.sleep', ...)`` style hooks
+    in channel tests working without per-call RetryPolicy overrides.
+    """
+
+    def test_default_policy_uses_module_time_sleep(self) -> None:
+        side_effect = [_http_error(503), _ok({"ok": 1})]
+        with (
+            patch("urllib.request.urlopen", side_effect=side_effect),
+            patch("ac_guard.reporter._http.time.sleep") as mock_sleep,
+        ):
+            result = get_json(
+                "https://example/api",
+                headers=_headers(),
+                api_name="GitHub",
+            )
+        assert result == {"ok": 1}
+        assert mock_sleep.call_count == 1


### PR DESCRIPTION
## Summary

- Tighten `pyproject.toml` lint gates from WP6.2-era relaxations back to Ruff / Pylint defaults: `max-args` 9 → **5**, `max-complexity` 12 → **10**, and introduce `max-statements = 50` via `PLR0915`.
- Refactor the four functions that were forcing the relaxed thresholds so the tighter gates apply to production, infrastructure scripts, and tooling uniformly — no `scripts/*` exemption.
- Replace `reporter._http.request_json` (9 params) with `get_json` / `post_json` + a frozen `RetryPolicy` bundle. `checker.run_stage` likewise collapses three optional args into a `StageOptions` dataclass.

## Why now

The `max-args = 9` threshold was put in place on 2026-04-20 (#134 lineage, commit `1201930`) so that `_http.request_json` and `checker.run_stage` could drop their `# noqa: PLR0913` in favor of a config-level raise. That moved the debt onto the account book but didn't retire it. This PR retires it, aligning the project with well-cited defaults (McCabe 1976 / NIST / SEI on complexity, Pylint defaults on args & statements).

## Changes

| Area | Refactor |
|---|---|
| `reporter/_http.py` | `request_json` → `get_json` (4 args) + `post_json` (5 args); retry knobs collapsed into `RetryPolicy`. 4 channels updated. |
| `checker/core.py` | `run_stage` 6 → 4 params via new `StageOptions`. 3 CLI call sites + 9 unit tests updated; integration tests unchanged (positional only). |
| `generator/core.py` | `write_artifacts` complexity 12 → ≤10 via `_resolve_artifact_content`, `_apply_executable_flag`, `_is_permission_error` helpers. Signature unchanged. |
| `scripts/check_encoding.py` | `_find_close` / `_top_level_has_encoding` share a new `_skip_string_literal` helper; both clear C901 cleanly. No `scripts/*` per-file-ignore needed. |
| `pyproject.toml` | Thresholds lowered; `PLR0915` added to `select`; rationale comments updated. |

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/` — clean under new thresholds, no per-file-ignore outside `tests/*`.
- [x] `uv run pytest tests/` — 963 passed.
- [x] `uv run lint-imports` — `ac-guard module layering` KEPT, 59 files / 152 dependencies.
- [x] `uv run pre-commit run --all-files` — all hooks green (format, lint, forbid-noqa, encoding, interrogate, bandit, import-linter, etc.).
- [x] Spot checks for `_skip_string_literal` behavioural equivalence (triple-quote, backslash-escape, nested paren inside string, unterminated) on top of the full encoding scan over `src/` + `tests/`.

## Notes

No public API surface changes: `post_pr_comment`, `format_gate`, and `write_artifacts` signatures are untouched; only internal reporter entry points and the internal `run_stage` keyword args move to bundle types.