### PR TITLE
chore(templates): remove empty ac_guard.templates package

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -6,7 +6,7 @@
 ; in Track B.1 of the M6 cleanup.
 ;
 ; Allowed dependencies (each module implicitly depends on itself):
-;   config, templates, domain  — leaves (no internal deps)
+;   config, domain  — leaves (no internal deps)
 ;   adapters           → config
 ;   checker            → config, domain
 ;   reporter           → config, domain
@@ -32,6 +32,6 @@ layers =
     cli
     enforcer | generator
     checker | reporter | adapters
-    config | templates | domain
+    config | domain
 containers =
     ac_guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a stderr warning without affecting exit code.
   ([#66](https://github.com/ikroal/ai-code-guard/issues/66))
 
+### Removed
+
+- Empty `ac_guard.templates` package dropped. The directory only ever
+  contained an empty `__init__.py` and had zero code or test references;
+  the real Jinja templates live in each feature module's private
+  `_templates/` (`cli/_templates`, `generator/_templates`,
+  `adapters/_templates`, `reporter/_templates`). `.importlinter` layer
+  spec updated to drop the stale `templates` leaf.
+
 ### Fixed
 
 - Default system `execute.forbidden` now covers four additional


### PR DESCRIPTION
## Summary

- Deletes the empty `src/ac_guard/templates/` package (just an empty `__init__.py`, zero code/test references).
- Drops the stale `templates` entry from the `.importlinter` leaf list so the layering contract matches reality.
- Records the removal under `CHANGELOG.md` → `[Unreleased]` → `Removed`.

## Why

Real Jinja templates already live in each feature module's private `_templates/` directory (`cli/_templates`, `generator/_templates`, `adapters/_templates`, `reporter/_templates`) — the top-level `ac_guard.templates` package was leftover scaffolding from a "central templates bucket" idea that was never adopted. Removing it clears one item from the #109 module-boundary audit.

## Scope

This is the first cleanup item from the Epic #133 / #109 module-review plan. The remaining 9 modules (enforcer / generator / config / checker / domain / shared / ruleset / adapters / cli) will each get their own dedicated PR.

## Test plan

- [x] `uv run pytest tests/ -q` — **999 passed** in 11.93s
- [x] `uv run lint-imports` — `ac-guard module layering` contract **kept** (1 kept, 0 broken)
- [x] `pre-commit run --all-files` — all hooks green (format / lint / forbid-noqa / require-explicit-encoding / whitespace / EOF / yaml / toml / private-key / merge-conflict / large-files / interrogate / bandit / import-linter)
- [x] `grep -rn "ac_guard\.templates"` on `src/` and `tests/` — zero hits
- [x] `git rev-list --count HEAD..origin/main` — clean branch from updated main

## Related

Part of #109 module-boundary cleanup (epic #133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)