### PR TITLE
refactor!: rename checker→code_gate and enforcer→action_guard

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -8,14 +8,14 @@
 ; Allowed dependencies (each module implicitly depends on itself):
 ;   config, domain  — leaves (no internal deps)
 ;   adapters           → config, domain
-;   checker            → config, domain
+;   code_gate          → config, domain
 ;   reporter           → config, domain
 ;   generator          → config, adapters, domain
-;   enforcer           → config, checker, reporter
-;   cli                → config, generator, adapters, enforcer, checker, reporter, domain
+;   enforcer           → config, code_gate, reporter
+;   cli                → config, generator, adapters, enforcer, code_gate, reporter, domain
 ;
 ; Within the same layer, modules may NOT import each other — e.g.
-; enforcer must not import generator, checker must not import adapters.
+; enforcer must not import generator, code_gate must not import adapters.
 ;
 ; The `domain` layer holds cross-module *intermediate* data contracts
 ; (FileSpec / StageOutcome / CheckResult / Violation) plus the ac-guard
@@ -39,7 +39,7 @@ type = layers
 layers =
     cli
     enforcer | generator
-    checker | reporter | adapters
+    code_gate | reporter | adapters
     config | domain
 containers =
     ac_guard
@@ -54,7 +54,7 @@ type = forbidden
 allow_indirect_imports = True
 source_modules =
     ac_guard.adapters
-    ac_guard.checker
+    ac_guard.code_gate
     ac_guard.cli
     ac_guard.enforcer
     ac_guard.generator

--- a/.importlinter
+++ b/.importlinter
@@ -11,11 +11,11 @@
 ;   code_gate          → config, domain
 ;   reporter           → config, domain
 ;   generator          → config, adapters, domain
-;   enforcer           → config, code_gate, reporter
-;   cli                → config, generator, adapters, enforcer, code_gate, reporter, domain
+;   action_guard       → config, code_gate, reporter
+;   cli                → config, generator, adapters, action_guard, code_gate, reporter, domain
 ;
 ; Within the same layer, modules may NOT import each other — e.g.
-; enforcer must not import generator, code_gate must not import adapters.
+; action_guard must not import generator, code_gate must not import adapters.
 ;
 ; The `domain` layer holds cross-module *intermediate* data contracts
 ; (FileSpec / StageOutcome / CheckResult / Violation) plus the ac-guard
@@ -38,7 +38,7 @@ name = ac-guard module layering
 type = layers
 layers =
     cli
-    enforcer | generator
+    action_guard | generator
     code_gate | reporter | adapters
     config | domain
 containers =
@@ -56,7 +56,7 @@ source_modules =
     ac_guard.adapters
     ac_guard.code_gate
     ac_guard.cli
-    ac_guard.enforcer
+    ac_guard.action_guard
     ac_guard.generator
     ac_guard.reporter
 forbidden_modules =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — Module rename: `checker` → `code_gate`, `enforcer` → `action_guard`.**
+  The two core modules now name their roles directly: `code_gate` is the
+  git hook-time code quality gate (pass/fail), `action_guard` is the
+  agent hook-time runtime policy guard (allow/deny/ask).
+
+  **Public API changes (no backward-compat shim):**
+
+  | Old | New |
+  |---|---|
+  | `from ac_guard.checker ...` | `from ac_guard.code_gate ...` |
+  | `from ac_guard.enforcer ...` | `from ac_guard.action_guard ...` |
+  | `python3 -m ac_guard.enforcer` | `python3 -m ac_guard.action_guard` |
+  | `EnforcerError` | `ActionGuardError` |
+
+  **Action required:** if you already ran `ac-guard install`, re-run it
+  after upgrading — previously generated hook scripts (`.claude/hooks/*`,
+  `.cursor/hooks/*`, `opencode` integration) still import
+  `ac_guard.enforcer` and will fail with `ModuleNotFoundError` until
+  regenerated. The CLI surface (`ac-guard check / verify / run / gate
+  run`) and `guard.yaml` schema are unchanged.
+
 - **BREAKING — Reporter API collapse** (follow-up to the earlier Reporter
   API restructure below). Further consolidation based on the "Reporter
   serves only **humans or Agents** — nothing else" principle.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Check results can be posted as PR comments on GitHub, GitLab, Gitea, and Bitbuck
 
 ```mermaid
 flowchart LR
-    P1[✅ Phase 1<br/>Config + Generator + CLI] --> P2[✅ Phase 2<br/>Enforcer]
-    P2 --> P3[✅ Phase 3<br/>Checker + Reporter]
+    P1[✅ Phase 1<br/>Config + Generator + CLI] --> P2[✅ Phase 2<br/>Action Guard]
+    P2 --> P3[✅ Phase 3<br/>Code Gate + Reporter]
     P3 --> P4[✅ Phase 4<br/>Ruleset Management]
     P4 --> P5[✅ Phase 5<br/>PR Report + CI/CD]
     P5 --> M6[🚧 M6<br/>Production Readiness]

--- a/src/ac_guard/action_guard/__init__.py
+++ b/src/ac_guard/action_guard/__init__.py
@@ -1,14 +1,14 @@
-"""Enforcer module — runtime behavior policy enforcement.
+"""Action guard module — runtime behavior policy enforcement.
 
 Provides pattern matching, tool classification, policy loading,
 and the top-level evaluate() entry point for AI agent behavior
 enforcement.
 """
 
-from ac_guard.enforcer.classifier import classify
-from ac_guard.enforcer.engine import evaluate
-from ac_guard.enforcer.exceptions import EnforcerError, PolicyCorruptError
-from ac_guard.enforcer.matcher import (
+from ac_guard.action_guard.classifier import classify
+from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.exceptions import ActionGuardError, PolicyCorruptError
+from ac_guard.action_guard.matcher import (
     VALID_SCHEMES,
     Decision,
     MatchResult,
@@ -18,11 +18,11 @@ from ac_guard.enforcer.matcher import (
     matches,
     parse_pattern,
 )
-from ac_guard.enforcer.policy import load_policy
+from ac_guard.action_guard.policy import load_policy
 
 __all__ = [
     "Decision",
-    "EnforcerError",
+    "ActionGuardError",
     "MatchResult",
     "PolicyCorruptError",
     "PolicyDecision",

--- a/src/ac_guard/action_guard/__main__.py
+++ b/src/ac_guard/action_guard/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running Action guard as ``python3 -m ac_guard.action_guard``."""
+
+from ac_guard.action_guard.cli import main
+
+main()

--- a/src/ac_guard/action_guard/classifier.py
+++ b/src/ac_guard/action_guard/classifier.py
@@ -1,4 +1,4 @@
-"""Enforcer tool call classifier (E2 primitive).
+"""Action guard tool call classifier (E2 primitive).
 
 Maps ``(tool_name, tool_input)`` to ``(operation, scheme, target)``
 for downstream pattern matching by the matcher (E3).

--- a/src/ac_guard/action_guard/cli.py
+++ b/src/ac_guard/action_guard/cli.py
@@ -1,11 +1,11 @@
-"""Enforcer CLI entry point for subprocess invocation.
+"""Action guard CLI entry point for subprocess invocation.
 
 Provides a thin JSON stdin/stdout interface for non-Python hooks
-(Cursor bash, OpenCode TypeScript) to call the Enforcer engine.
+(Cursor bash, OpenCode TypeScript) to call the Action guard engine.
 
 Usage:
     echo '{"tool_name": "Write", "tool_input": {"file_path": "x.py"}}' | \
-        python3 -m ac_guard.enforcer
+        python3 -m ac_guard.action_guard
 
 Input (stdin JSON):
     {"tool_name": "...", "tool_input": {...}, "agent": "cursor", "project_root": "."}
@@ -23,7 +23,7 @@ import json
 import sys
 from pathlib import Path
 
-from ac_guard.enforcer.engine import evaluate
+from ac_guard.action_guard.engine import evaluate
 
 __all__: list[str] = []
 

--- a/src/ac_guard/action_guard/engine.py
+++ b/src/ac_guard/action_guard/engine.py
@@ -1,4 +1,4 @@
-"""Enforcer engine — top-level evaluate function.
+"""Action guard engine — top-level evaluate function.
 
 Combines E1 (load_policy), E2 (classify), and E3/E4 (match + decide)
 into a single entry point for runtime behavior enforcement.
@@ -9,17 +9,17 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-from ac_guard.audit import append_record
-from ac_guard.config import Rule
-from ac_guard.enforcer.classifier import classify
-from ac_guard.enforcer.exceptions import PolicyCorruptError
-from ac_guard.enforcer.matcher import (
+from ac_guard.action_guard.classifier import classify
+from ac_guard.action_guard.exceptions import PolicyCorruptError
+from ac_guard.action_guard.matcher import (
     Decision,
     MatchResult,
     PolicyDecision,
     evaluate_rules,
 )
-from ac_guard.enforcer.policy import load_policy
+from ac_guard.action_guard.policy import load_policy
+from ac_guard.audit import append_record
+from ac_guard.config import Rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -46,7 +46,7 @@ def evaluate(
 ) -> PolicyDecision:
     """Evaluate a tool call against the installed policy.
 
-    Orchestrates the full Enforcer pipeline:
+    Orchestrates the full Action guard pipeline:
     E1 (load_policy) -> E2 (classify) -> E3/E4 (match + decide) ->
     R3 (audit.append_record when enabled).
 

--- a/src/ac_guard/action_guard/exceptions.py
+++ b/src/ac_guard/action_guard/exceptions.py
@@ -1,15 +1,15 @@
-"""Enforcer exception types."""
+"""Action guard exception types."""
 
 from __future__ import annotations
 
-__all__ = ["EnforcerError", "PolicyCorruptError"]
+__all__ = ["ActionGuardError", "PolicyCorruptError"]
 
 
-class EnforcerError(Exception):
-    """Base exception for all Enforcer errors."""
+class ActionGuardError(Exception):
+    """Base exception for all Action guard errors."""
 
 
-class PolicyCorruptError(EnforcerError):
+class PolicyCorruptError(ActionGuardError):
     """Raised when runtime.json cannot be parsed.
 
     Attributes:

--- a/src/ac_guard/action_guard/matcher.py
+++ b/src/ac_guard/action_guard/matcher.py
@@ -1,4 +1,4 @@
-"""Enforcer pattern matching engine (E3 primitive).
+"""Action guard pattern matching engine (E3 primitive).
 
 Parses ``{scheme}:{body}`` patterns, matches resource targets against
 rules using glob or regex, and evaluates three-tier decision logic

--- a/src/ac_guard/action_guard/policy.py
+++ b/src/ac_guard/action_guard/policy.py
@@ -1,4 +1,4 @@
-"""Enforcer policy loader (E1 primitive).
+"""Action guard policy loader (E1 primitive).
 
 Loads ``.ac-guard/runtime.json`` and reconstructs a
 :class:`BehaviorConfig` for runtime rule evaluation.
@@ -9,13 +9,13 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from ac_guard.action_guard.exceptions import PolicyCorruptError
 from ac_guard.config import (
     AuditConfig,
     BehaviorConfig,
     OperationRules,
     Rule,
 )
-from ac_guard.enforcer.exceptions import PolicyCorruptError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,7 +28,7 @@ _RUNTIME_FILE = ".ac-guard/runtime.json"
 def load_policy(
     project_root: Path,
 ) -> tuple[BehaviorConfig, str, AuditConfig] | None:
-    """Load Enforcer runtime cache from ``.ac-guard/runtime.json``.
+    """Load Action guard runtime cache from ``.ac-guard/runtime.json``.
 
     Args:
         project_root: Path to the project root directory.

--- a/src/ac_guard/adapters/_templates/hooks/claude_code.j2
+++ b/src/ac_guard/adapters/_templates/hooks/claude_code.j2
@@ -3,7 +3,7 @@ Claude Code PreToolUse Hook template.
 
 Generates a Python script that:
 1. Reads stdin JSON (Claude Code format: tool_name, tool_input)
-2. Calls Enforcer engine for policy decision
+2. Calls Action guard engine for policy decision
 3. Outputs stdout JSON (Claude Code format: hookSpecificOutput.permissionDecision)
 
 This template is rendered by adapters/_render.render_hook("claude_code", behavior).
@@ -40,7 +40,7 @@ if sys.executable != _INSTALL_PY and os.path.exists(_INSTALL_PY):
 # removed, venv rebuilt, package uninstalled), never let the tool call
 # silently pass — emit an `ask` decision so the user sees the problem.
 try:
-    from ac_guard.enforcer.engine import evaluate
+    from ac_guard.action_guard.engine import evaluate
 except ImportError as _exc:
     json.dump(
         {
@@ -66,7 +66,7 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Evaluate policy via Enforcer
+    # Evaluate policy via Action guard
     result = evaluate(tool_name, tool_input, Path("."), agent="claude-code")
 
     # Build reason string for deny/ask decisions

--- a/src/ac_guard/adapters/_templates/hooks/cursor.j2
+++ b/src/ac_guard/adapters/_templates/hooks/cursor.j2
@@ -3,7 +3,7 @@ Cursor Hook template (shell script).
 
 Generates a bash script that:
 1. Reads stdin JSON (Cursor format)
-2. Calls Enforcer via python3 -m ac_guard.enforcer subprocess
+2. Calls Action guard via python3 -m ac_guard.action_guard subprocess
 3. Outputs stdout JSON (Cursor format)
 
 This template is rendered by adapters/_render.render_hook("cursor", behavior).
@@ -27,17 +27,17 @@ input=$(cat)
 # Parse tool call (Cursor uses different formats for different hooks)
 tool_name=$(echo "$input" | jq -r '.tool // .command // .name // "unknown"' 2>/dev/null || echo "unknown")
 
-# Build Enforcer input JSON (agent identifies the caller in audit records)
-enforcer_input=$(jq -n \
+# Build Action guard input JSON (agent identifies the caller in audit records)
+action_guard_input=$(jq -n \
     --arg tn "$tool_name" \
     --argjson ti "$(echo "$input" | jq '.args // .arguments // {}' 2>/dev/null || echo '{}')" \
     '{tool_name: $tn, tool_input: $ti, agent: "cursor"}')
 
-# Call Enforcer via Python subprocess
-enforcer_output=$(echo "$enforcer_input" | python3 -m ac_guard.enforcer 2>/dev/null || echo '{"decision": "deny"}')
+# Call Action guard via Python subprocess
+action_guard_output=$(echo "$action_guard_input" | python3 -m ac_guard.action_guard 2>/dev/null || echo '{"decision": "deny"}')
 
 # Extract decision
-decision=$(echo "$enforcer_output" | jq -r '.decision // "deny"' 2>/dev/null || echo "deny")
+decision=$(echo "$action_guard_output" | jq -r '.decision // "deny"' 2>/dev/null || echo "deny")
 
 # Cursor does not support "ask" — downgrade to "deny"
 if [ "$decision" = "ask" ]; then

--- a/src/ac_guard/adapters/_templates/hooks/opencode.j2
+++ b/src/ac_guard/adapters/_templates/hooks/opencode.j2
@@ -3,7 +3,7 @@ OpenCode Plugin template (TypeScript).
 
 Generates a TypeScript plugin that:
 1. Intercepts tool calls via OpenCode plugin API
-2. Calls Enforcer via python3 -m ac_guard.enforcer subprocess
+2. Calls Action guard via python3 -m ac_guard.action_guard subprocess
 3. Throws error to block forbidden operations
 
 This template is rendered by adapters/_render.render_hook("opencode", behavior).
@@ -23,7 +23,7 @@ This template is rendered by adapters/_render.render_hook("opencode", behavior).
 import type { Tool, ToolCall } from "opencode";
 import { execSync } from "child_process";
 
-// Policy evaluation via Python Enforcer subprocess
+// Policy evaluation via Python Action guard subprocess
 function evaluatePolicy(call: ToolCall): {
   decision: string;
   reason?: string;
@@ -35,7 +35,7 @@ function evaluatePolicy(call: ToolCall): {
   });
 
   try {
-    const output = execSync(`echo '${input.replace(/'/g, "\\'")}' | python3 -m ac_guard.enforcer`, {
+    const output = execSync(`echo '${input.replace(/'/g, "\\'")}' | python3 -m ac_guard.action_guard`, {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -43,7 +43,7 @@ function evaluatePolicy(call: ToolCall): {
     return JSON.parse(output);
   } catch {
     // Fail-closed: subprocess error → deny
-    return { decision: "deny", reason: "Enforcer subprocess error" };
+    return { decision: "deny", reason: "Action guard subprocess error" };
   }
 }
 

--- a/src/ac_guard/adapters/claude_code.py
+++ b/src/ac_guard/adapters/claude_code.py
@@ -52,7 +52,7 @@ class ClaudeCodeAdapter(AgentAdapter):
         Uses Jinja2 template (hooks/claude_code.j2) for the Hook script.
         Returns a Python Hook script that:
         - Reads stdin JSON (tool_name, tool_input)
-        - Calls Enforcer for policy decision (placeholder for WP2)
+        - Calls Action guard for policy decision (placeholder for WP2)
         - Returns stdout JSON (hookSpecificOutput.permissionDecision)
         """
         hook_content = render_hook("claude_code", behavior)

--- a/src/ac_guard/adapters/cursor.py
+++ b/src/ac_guard/adapters/cursor.py
@@ -51,7 +51,7 @@ class CursorAdapter(AgentAdapter):
         Uses Jinja2 template (hooks/cursor.j2) for the Hook script.
         Returns a shell script that:
         - Reads stdin JSON (Cursor format)
-        - Calls Enforcer for policy decision (placeholder for WP2)
+        - Calls Action guard for policy decision (placeholder for WP2)
         - Returns JSON output
         """
         hook_content = render_hook("cursor", behavior)

--- a/src/ac_guard/adapters/opencode.py
+++ b/src/ac_guard/adapters/opencode.py
@@ -50,7 +50,7 @@ class OpenCodeAdapter(AgentAdapter):
         Uses Jinja2 template (hooks/opencode.j2) for the plugin.
         Returns a TypeScript plugin file that:
         - Intercepts tool calls via OpenCode plugin API
-        - Calls Enforcer for policy decision (placeholder for WP2)
+        - Calls Action guard for policy decision (placeholder for WP2)
         - Throws error to block forbidden operations
         """
         plugin_content = render_hook("opencode", behavior)

--- a/src/ac_guard/audit/__init__.py
+++ b/src/ac_guard/audit/__init__.py
@@ -13,7 +13,7 @@ Guarantees
   partial-state corruption on crash mid-write.
 - **Availability (Q3)**: ``append_record`` and ``prune_by_age`` are
   non-blocking (``OSError`` logged to stderr, not raised) — audit
-  failures never block enforcer's hot path.
+  failures never block action_guard's hot path.
 - **Append-only invariant (S2)**: Old records are never modified
   in place; bulk replace via ``rewrite_records`` is the only
   mutation path.

--- a/src/ac_guard/audit/core.py
+++ b/src/ac_guard/audit/core.py
@@ -45,7 +45,7 @@ def append_record(
 
     **Non-blocking (Q3)**: Any ``OSError`` is printed to stderr but
     never raised, so audit failures do not affect the caller's
-    primary path (e.g., enforcer's policy decision).
+    primary path (e.g., action_guard's policy decision).
 
     Args:
         record: Business fields for the audit entry. ``timestamp``

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -1,14 +1,14 @@
 """check, verify, run, and gate command implementations for AI Code Guard CLI.
 
 Provides CLI entry points for code quality checking, delegating to
-the Checker module for execution and Reporter for output formatting.
+the code_gate module for execution and Reporter for output formatting.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ac_guard.checker.core import (
+from ac_guard.code_gate.core import (
     BUCKET_AWARE_STAGES,
     StageOptions,
     get_changed_files,
@@ -234,7 +234,7 @@ def gate_run_command(
         raise SystemExit(0 if outcome.passed else 1)
 
     # commit-msg / pre-merge-commit / pre-rebase — ac-guard doesn't
-    # yet model these in its bucket-aware checker. Delegate to
+    # yet model these in its bucket-aware code_gate. Delegate to
     # pre-commit's native stage runner; it reads the generated
     # .pre-commit-config.yaml and executes hooks declared for this
     # stage via their ``stages:`` field.

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
-from ac_guard.checker.core import BUCKET_AWARE_STAGES, detect_language
+from ac_guard.code_gate.core import BUCKET_AWARE_STAGES, detect_language
 from ac_guard.config import ConfigError, load_config, resolve_config
 from ac_guard.generator.core import read_state
 

--- a/src/ac_guard/code_gate/__init__.py
+++ b/src/ac_guard/code_gate/__init__.py
@@ -1,6 +1,6 @@
-"""Checker module — code quality check orchestration."""
+"""Code gate — git hook-time code quality orchestration (K2-K6)."""
 
-from ac_guard.checker.core import (
+from ac_guard.code_gate.core import (
     get_changed_files,
     run_build,
     run_check,

--- a/src/ac_guard/code_gate/core.py
+++ b/src/ac_guard/code_gate/core.py
@@ -1,4 +1,4 @@
-"""Checker core — check orchestration primitives (K2-K6).
+"""Code gate core — check orchestration primitives (K2-K6).
 
 Orchestrates code quality checks across commit and push stages
 by delegating to pre-commit framework and custom check commands.

--- a/src/ac_guard/code_gate/models.py
+++ b/src/ac_guard/code_gate/models.py
@@ -1,9 +1,9 @@
-"""Backward-compatibility shim — checker data models moved to ac_guard.domain.
+"""Backward-compatibility shim — code gate data models moved to ac_guard.domain.
 
 The ``StageOutcome`` / ``CheckResult`` / ``Violation`` dataclasses now live in
 :mod:`ac_guard.domain.models` because they are **intermediate result
-types** flowing between multiple modules (checker → cli → reporter), not
-checker-internal implementation details. See that module's docstring for
+types** flowing between multiple modules (code_gate → cli → reporter), not
+code_gate-internal implementation details. See that module's docstring for
 the admission criteria of the domain layer.
 
 New code should import from :mod:`ac_guard.domain.models`. This shim

--- a/src/ac_guard/config/models.py
+++ b/src/ac_guard/config/models.py
@@ -361,7 +361,7 @@ class ResolvedConfig:
 
     Produced by the config loader after merging defaults,
     rulesets, and the project guard.yaml. This is the single
-    configuration object passed to Generator, Enforcer, and
+    configuration object passed to Generator, Action guard, and
     other modules.
 
     Attributes:

--- a/src/ac_guard/enforcer/__main__.py
+++ b/src/ac_guard/enforcer/__main__.py
@@ -1,5 +1,0 @@
-"""Allow running Enforcer as ``python3 -m ac_guard.enforcer``."""
-
-from ac_guard.enforcer.cli import main
-
-main()

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -365,9 +365,9 @@ def generate_policy_cache(
     config_hash: str,
     audit: AuditConfig | None = None,
 ) -> FileSpec:
-    """Generate ``.ac-guard/runtime.json`` for Enforcer runtime (G5).
+    """Generate ``.ac-guard/runtime.json`` for Action guard runtime (G5).
 
-    This file is the Enforcer runtime cache read by hook subprocesses.
+    This file is the Action guard runtime cache read by hook subprocesses.
     It holds everything the hook-side needs to make decisions without
     re-parsing guard.yaml: behavior rules, policy hash, and audit
     configuration. The historical filename ``policy.json`` was

--- a/tests/integration/test_action_guard_e2e.py
+++ b/tests/integration/test_action_guard_e2e.py
@@ -1,6 +1,6 @@
-"""Integration tests for Phase 2 Enforcer end-to-end (WP2.4).
+"""Integration tests for Phase 2 Action guard end-to-end (WP2.4).
 
-Verifies Enforcer pipeline, Hook template integration, audit logging,
+Verifies Action guard pipeline, Hook template integration, audit logging,
 and error recovery scenarios using real file I/O.
 """
 
@@ -12,10 +12,10 @@ from pathlib import Path
 import yaml
 from typer.testing import CliRunner
 
+from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.matcher import Decision
 from ac_guard.audit import append_record, prune_by_age
 from ac_guard.cli.main import app
-from ac_guard.enforcer.engine import evaluate
-from ac_guard.enforcer.matcher import Decision
 
 runner = CliRunner()
 
@@ -28,8 +28,8 @@ def _init_and_install(tmp_path: Path, agents: str = "claude-code") -> None:
     runner.invoke(app, ["install", "--agent", agents, "--config", str(config)])
 
 
-class TestEnforcerPipeline:
-    """Enforcer evaluate() with real runtime.json from install."""
+class TestActionGuardPipeline:
+    """Action guard evaluate() with real runtime.json from install."""
 
     def test_install_then_evaluate(self, tmp_path: Path) -> None:
         """install generates runtime.json that evaluate() can use."""
@@ -87,24 +87,24 @@ class TestEnforcerPipeline:
         assert result.matched_rule.reason == "secrets"
 
 
-class TestHookEnforcerIntegration:
-    """Hook templates correctly reference Enforcer."""
+class TestHookActionGuardIntegration:
+    """Hook templates correctly reference Action guard."""
 
-    def test_claude_code_hook_has_enforcer(self, tmp_path: Path) -> None:
-        """Claude Code hook script imports enforcer.engine."""
+    def test_claude_code_hook_has_action_guard(self, tmp_path: Path) -> None:
+        """Claude Code hook script imports action_guard.engine."""
         _init_and_install(tmp_path)
         hook_path = tmp_path / ".claude" / "hooks" / "interceptor.py"
         assert hook_path.is_file()
         content = hook_path.read_text(encoding="utf-8")
-        assert "from ac_guard.enforcer.engine import evaluate" in content
+        assert "from ac_guard.action_guard.engine import evaluate" in content
 
-    def test_cursor_hook_calls_enforcer(self, tmp_path: Path) -> None:
-        """Cursor hook script calls python3 -m ac_guard.enforcer."""
+    def test_cursor_hook_calls_action_guard(self, tmp_path: Path) -> None:
+        """Cursor hook script calls python3 -m ac_guard.action_guard."""
         _init_and_install(tmp_path, agents="cursor")
         hook_path = tmp_path / ".cursor" / "hooks" / "check.sh"
         assert hook_path.is_file()
         content = hook_path.read_text(encoding="utf-8")
-        assert "python3 -m ac_guard.enforcer" in content
+        assert "python3 -m ac_guard.action_guard" in content
 
     def test_multi_agent_hooks(self, tmp_path: Path) -> None:
         """Multi-agent install generates hooks for each agent."""
@@ -114,7 +114,7 @@ class TestHookEnforcerIntegration:
 
 
 class TestAuditLoggingE2E:
-    """Audit logging with real Enforcer decisions."""
+    """Audit logging with real Action guard decisions."""
 
     def test_evaluate_then_audit(self, tmp_path: Path) -> None:
         """evaluate() auto-audits when audit is enabled (standard preset)."""

--- a/tests/integration/test_code_gate_e2e.py
+++ b/tests/integration/test_code_gate_e2e.py
@@ -1,4 +1,4 @@
-"""Integration tests for Phase 3 Checker end-to-end (WP3.4).
+"""Integration tests for Phase 3 code_gate end-to-end (WP3.4).
 
 Test matrix dimensions:
 - CLI commands: check / verify / run / gate
@@ -18,8 +18,8 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
-from ac_guard.checker.models import CheckResult, StageOutcome
 from ac_guard.cli.main import app
+from ac_guard.code_gate.models import CheckResult, StageOutcome
 from ac_guard.reporter.formatting import format_markdown
 
 runner = CliRunner()
@@ -91,18 +91,18 @@ class TestFullCheckLifecycle:
         assert r.exit_code == 0
 
         # check (commit stage)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
 
         # verify (push stage)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["verify", "-c", str(config)])
         assert r.exit_code == 0
 
         # gate run (commit)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(
                 app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
             )
@@ -121,7 +121,7 @@ class TestFullCheckLifecycle:
         (tmp_path / ".git").mkdir()
         runner.invoke(app, ["install", "-a", "claude-code", "-c", str(config)])
 
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
 
@@ -129,7 +129,7 @@ class TestFullCheckLifecycle:
         _config_with_checks(tmp_path, fail=True)
         runner.invoke(app, ["update", "-c", str(config)])
 
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 1
         assert "FAILED" in r.output
@@ -146,7 +146,7 @@ class TestCheckCommand:
     def test_default_config_passes(self, tmp_path: Path) -> None:
         """B1: Default config with no files → all checks pass."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
@@ -154,7 +154,7 @@ class TestCheckCommand:
     def test_custom_check_fails(self, tmp_path: Path) -> None:
         """B2: Failing custom check → exit 1 + FAILED."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 1
         assert "FAILED" in r.output
@@ -163,7 +163,7 @@ class TestCheckCommand:
     def test_explicit_files(self, tmp_path: Path) -> None:
         """B3: --files passes explicit file list."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.shutil.which", return_value=None):
+        with patch("ac_guard.code_gate.core.shutil.which", return_value=None):
             r = runner.invoke(app, ["check", "--files", "a.py", "-c", str(config)])
         assert r.exit_code == 0
 
@@ -184,14 +184,14 @@ class TestVerifyCommand:
     def test_push_all_pass(self, tmp_path: Path) -> None:
         """C1: Push stage all passing → exit 0."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["verify", "-c", str(config)])
         assert r.exit_code == 0
 
     def test_commit_fail_fast(self, tmp_path: Path) -> None:
         """C2: Commit failure → push not reached."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["verify", "-c", str(config)])
         assert r.exit_code == 1
         # Push-only check should NOT appear (fail-fast)
@@ -200,7 +200,7 @@ class TestVerifyCommand:
     def test_skip_build(self, tmp_path: Path) -> None:
         """C3: --skip-build skips build step."""
         config = _write_config(tmp_path, {"build": {"command": "exit 1"}})
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["verify", "--skip-build", "-c", str(config)])
         assert r.exit_code == 0
 
@@ -216,7 +216,7 @@ class TestVerifyCommand:
                 },
             },
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["verify", "-c", str(config)])
         assert r.exit_code == 0
         assert "build" in r.output.lower()
@@ -248,7 +248,7 @@ class TestVerifyCommand:
                 },
             },
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]):
             r = runner.invoke(app, ["verify", "-c", str(config), "--format", "json"])
         assert r.exit_code == 1
         data = json_mod.loads(r.output)
@@ -271,14 +271,14 @@ class TestRunCommand:
     def test_builtin_format(self, tmp_path: Path) -> None:
         """D1: Running built-in format (skipped with no files)."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "format", "-c", str(config)])
         assert r.exit_code == 0
 
     def test_custom_check_pass(self, tmp_path: Path) -> None:
         """D2: Running a passing custom check."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "custom-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "custom-commit" in r.output
@@ -286,7 +286,7 @@ class TestRunCommand:
     def test_custom_check_fail(self, tmp_path: Path) -> None:
         """D3: Running a failing custom check."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "custom-commit", "-c", str(config)])
         assert r.exit_code == 1
 
@@ -309,7 +309,7 @@ class TestGateCommand:
     def test_commit_passed(self, tmp_path: Path) -> None:
         """E1: Commit stage pass → minimal 'passed' + exit 0."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(
                 app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
             )
@@ -321,7 +321,7 @@ class TestGateCommand:
     def test_commit_failed(self, tmp_path: Path) -> None:
         """E2: Commit stage fail → minimal 'FAILED' + exit 1."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(
                 app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
             )
@@ -331,7 +331,7 @@ class TestGateCommand:
     def test_push_passed(self, tmp_path: Path) -> None:
         """E3: Push stage pass → exit 0."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["gate", "run", "-s", "pre-push", "-c", str(config)])
         assert r.exit_code == 0
 
@@ -367,11 +367,11 @@ class TestMultiLanguageE2E:
             ),
             encoding="utf-8",
         )
-        with patch("ac_guard.checker.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
             stub = CheckResult(name="stub", passed=True, duration_ms=0)
             mock_run.return_value = stub
             with patch(
-                "ac_guard.checker.core.get_changed_files", return_value=["a.py"]
+                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
             ):
                 r = runner.invoke(app, ["verify", "-c", str(config)])
         assert r.exit_code == 0
@@ -386,10 +386,10 @@ class TestMultiLanguageE2E:
     def test_single_language_auto_populated(self, tmp_path: Path) -> None:
         """Only project.language configured → auto-populate fills defaults."""
         config = _write_config(tmp_path)  # project.language: python, no languages
-        with patch("ac_guard.checker.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
             mock_run.return_value = CheckResult(name="stub", passed=True, duration_ms=0)
             with patch(
-                "ac_guard.checker.core.get_changed_files", return_value=["a.py"]
+                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
             ):
                 r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
@@ -505,7 +505,7 @@ class TestLocalePropagation:
                 },
             },
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
         assert "阶段: pre-commit — 通过" in r.output
@@ -514,7 +514,7 @@ class TestLocalePropagation:
 
     def test_default_locale_keeps_english_output(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)  # no locale → defaults to en
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
@@ -528,7 +528,7 @@ class TestReportFormats:
     def test_terminal_has_details(self, tmp_path: Path) -> None:
         """F1: Terminal output includes check details and counts."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             r = runner.invoke(app, ["check", "-c", str(config)])
         assert "FAIL" in r.output
         assert "custom-commit" in r.output

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -2,7 +2,7 @@
 
 Three dimensions covering M5's output-side extensions:
 
-    D1: PR Report — Checker → Markdown → Channel.send (mock HTTP)
+    D1: PR Report — code_gate → Markdown → Channel.send (mock HTTP)
     D2: JSON Output — CLI --format json → valid machine-readable JSON
     D3: Validation — guard.yaml → validation list/report reflects config
 """
@@ -16,8 +16,8 @@ from unittest.mock import MagicMock, patch
 import yaml
 from typer.testing import CliRunner
 
-from ac_guard.checker.core import run_stage
 from ac_guard.cli.main import app
+from ac_guard.code_gate.core import run_stage
 from ac_guard.reporter import (
     ChannelError,
     GitPlatformCfg,
@@ -87,14 +87,14 @@ def _write_config_with_checks(tmp_path: Path) -> Path:
 
 
 class TestPrReportFlow:
-    """D1: Checker outcome → report() with GitPlatformCfg → HTTP POST."""
+    """D1: code_gate outcome → report() with GitPlatformCfg → HTTP POST."""
 
     def test_report_outcome_to_git_platform(self, tmp_path: Path) -> None:
         """D1-1: Real StageOutcome → report() via GitPlatformCfg (mock HTTP)."""
         config = _init_and_install(tmp_path)
         resolved_config = _resolve(config)
 
-        # Run real checker
+        # Run real code_gate
         outcome = run_stage("pre-commit", resolved_config.code, tmp_path)
 
         # Markdown should render without error (sanity check the formatter)
@@ -317,7 +317,7 @@ class TestCliPrReportIntegration:
         """D4-1: guard check with pr_report.enabled=true → Channel.send called."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,
@@ -335,7 +335,7 @@ class TestCliPrReportIntegration:
         """D4-2: guard gate run with pr_report.enabled=true → Channel.send called."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,
@@ -350,7 +350,7 @@ class TestCliPrReportIntegration:
         """D4-3: NoPrContextError from channel.send → no stderr warning."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output",
                 side_effect=NoPrContextError("Cannot determine PR number"),
@@ -372,7 +372,7 @@ class TestCliPrReportIntegration:
         """D4-4: Non-NoPrContext ChannelError → stderr warning preserved."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output",
                 side_effect=ChannelError("GitHub API returned 500"),
@@ -395,7 +395,7 @@ class TestCliPrReportIntegration:
         """D4-5: pr_report.enabled=false → channel.send never invoked."""
         config = _write_config_pr_report(tmp_path, enabled=False)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,

--- a/tests/integration/test_ruleset_lifecycle.py
+++ b/tests/integration/test_ruleset_lifecycle.py
@@ -2,7 +2,7 @@
 
 Verifies Ruleset management end-to-end across four dimensions:
     D1: Lifecycle stages (fetch → install → update → uninstall)
-    D2: Rule merging correctness (Enforcer evaluates ruleset rules)
+    D2: Rule merging correctness (Action guard evaluates ruleset rules)
     D3: File copy completeness (files/ and checks/ survive update)
     D4: Multi-ruleset interaction (merge order, file aggregation)
 """
@@ -16,9 +16,9 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
+from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.matcher import Decision
 from ac_guard.cli.main import app
-from ac_guard.enforcer.engine import evaluate
-from ac_guard.enforcer.matcher import Decision
 from ac_guard.generator.models import STATE_FILE
 
 runner = CliRunner()
@@ -208,10 +208,10 @@ class TestLifecycleStages:
 
 
 class TestRuleMergingCorrectness:
-    """D2: Enforcer evaluates ruleset rules correctly."""
+    """D2: Action guard evaluates ruleset rules correctly."""
 
     def test_ruleset_rule_enforced(self, tmp_path: Path) -> None:
-        """D2-1: Ruleset adds read.forbidden → Enforcer denies."""
+        """D2-1: Ruleset adds read.forbidden → Action guard denies."""
         (tmp_path / ".git").mkdir()
         url = _create_bare_repo(
             tmp_path / "repos",
@@ -349,7 +349,7 @@ class TestMultiRulesetInteraction:
     """D4: Multiple rulesets merge correctly."""
 
     def test_both_ruleset_rules_enforced(self, tmp_path: Path) -> None:
-        """D4-1: Rules from both rulesets are active in Enforcer."""
+        """D4-1: Rules from both rulesets are active in Action guard."""
         (tmp_path / ".git").mkdir()
 
         url_a = _create_bare_repo(

--- a/tests/unit/test_action_guard/test___main__.py
+++ b/tests/unit/test_action_guard/test___main__.py
@@ -1,8 +1,8 @@
-"""Tests for enforcer __main__ module."""
+"""Tests for action_guard __main__ module."""
 
 from __future__ import annotations
 
-from ac_guard.enforcer.__main__ import main
+from ac_guard.action_guard.__main__ import main
 
 
 class TestMain:

--- a/tests/unit/test_action_guard/test_classifier.py
+++ b/tests/unit/test_action_guard/test_classifier.py
@@ -1,8 +1,8 @@
-"""Tests for Enforcer tool call classifier (E2)."""
+"""Tests for Action guard tool call classifier (E2)."""
 
 from __future__ import annotations
 
-from ac_guard.enforcer.classifier import classify
+from ac_guard.action_guard.classifier import classify
 
 
 class TestClassifyReadOps:

--- a/tests/unit/test_action_guard/test_cli.py
+++ b/tests/unit/test_action_guard/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for Enforcer CLI entry point."""
+"""Tests for Action guard CLI entry point."""
 
 from __future__ import annotations
 
@@ -8,11 +8,11 @@ import sys
 from pathlib import Path
 
 
-def _run_enforcer(input_data: dict, project_root: Path) -> dict:
-    """Run enforcer CLI via subprocess and return parsed output."""
+def _run_action_guard(input_data: dict, project_root: Path) -> dict:
+    """Run action_guard CLI via subprocess and return parsed output."""
     input_data["project_root"] = str(project_root)
     result = subprocess.run(
-        [sys.executable, "-m", "ac_guard.enforcer"],
+        [sys.executable, "-m", "ac_guard.action_guard"],
         input=json.dumps(input_data),
         capture_output=True,
         text=True,
@@ -56,12 +56,12 @@ def _standard_policy() -> dict:
     }
 
 
-class TestEnforcerCli:
-    """Tests for python3 -m ac_guard.enforcer."""
+class TestActionGuardCli:
+    """Tests for python3 -m ac_guard.action_guard."""
 
     def test_no_policy_allows(self, tmp_path: Path) -> None:
         """No runtime.json returns allow."""
-        result = _run_enforcer(
+        result = _run_action_guard(
             {"tool_name": "Write", "tool_input": {"file_path": ".git/config"}},
             tmp_path,
         )
@@ -70,7 +70,7 @@ class TestEnforcerCli:
     def test_forbidden_denies(self, tmp_path: Path) -> None:
         """Forbidden pattern returns deny with reason."""
         _write_policy(tmp_path, _standard_policy())
-        result = _run_enforcer(
+        result = _run_action_guard(
             {"tool_name": "Write", "tool_input": {"file_path": ".git/config"}},
             tmp_path,
         )
@@ -80,7 +80,7 @@ class TestEnforcerCli:
     def test_allowed_allows(self, tmp_path: Path) -> None:
         """Allowed pattern returns allow."""
         _write_policy(tmp_path, _standard_policy())
-        result = _run_enforcer(
+        result = _run_action_guard(
             {"tool_name": "Write", "tool_input": {"file_path": "src/main.py"}},
             tmp_path,
         )
@@ -89,7 +89,7 @@ class TestEnforcerCli:
     def test_invalid_json_denies(self, tmp_path: Path) -> None:
         """Invalid JSON input returns deny (fail-closed)."""
         result = subprocess.run(
-            [sys.executable, "-m", "ac_guard.enforcer"],
+            [sys.executable, "-m", "ac_guard.action_guard"],
             input="not json{{{",
             capture_output=True,
             text=True,
@@ -100,7 +100,7 @@ class TestEnforcerCli:
         assert output["decision"] == "deny"
 
 
-class TestEnforcerCliAudit:
+class TestActionGuardCliAudit:
     """Regression for #75: subprocess entry threads agent into audit."""
 
     def test_agent_from_stdin_is_recorded(self, tmp_path: Path) -> None:
@@ -111,7 +111,7 @@ class TestEnforcerCliAudit:
             "retention_days": 30,
         }
         _write_policy(tmp_path, policy)
-        _run_enforcer(
+        _run_action_guard(
             {
                 "tool_name": "Write",
                 "tool_input": {"file_path": ".git/config"},

--- a/tests/unit/test_action_guard/test_engine.py
+++ b/tests/unit/test_action_guard/test_engine.py
@@ -1,4 +1,4 @@
-"""Tests for Enforcer engine — top-level evaluate() (E1+E2+E3/E4)."""
+"""Tests for Action guard engine — top-level evaluate() (E1+E2+E3/E4)."""
 
 from __future__ import annotations
 
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from ac_guard.enforcer.engine import evaluate
-from ac_guard.enforcer.matcher import Decision, PolicyDecision
+from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.matcher import Decision, PolicyDecision
 
 
 def _write_policy(project_root: Path, policy_data: dict) -> None:

--- a/tests/unit/test_action_guard/test_exceptions.py
+++ b/tests/unit/test_action_guard/test_exceptions.py
@@ -1,17 +1,17 @@
-"""Tests for Enforcer exception types."""
+"""Tests for Action guard exception types."""
 
 from __future__ import annotations
 
-from ac_guard.enforcer.exceptions import EnforcerError, PolicyCorruptError
+from ac_guard.action_guard.exceptions import ActionGuardError, PolicyCorruptError
 
 
 class TestPolicyCorruptError:
     """Tests for PolicyCorruptError."""
 
-    def test_inherits_enforcer_error(self) -> None:
-        """PolicyCorruptError is an EnforcerError."""
+    def test_inherits_action_guard_error(self) -> None:
+        """PolicyCorruptError is an ActionGuardError."""
         err = PolicyCorruptError("/path/runtime.json", "bad json")
-        assert isinstance(err, EnforcerError)
+        assert isinstance(err, ActionGuardError)
 
     def test_attributes(self) -> None:
         """PolicyCorruptError stores path and detail."""
@@ -25,9 +25,9 @@ class TestPolicyCorruptError:
         assert "/path/runtime.json" in str(err)
 
 
-class TestEnforcerError:
-    """Tests for EnforcerError base class."""
+class TestActionGuardError:
+    """Tests for ActionGuardError base class."""
 
     def test_is_exception(self) -> None:
-        """EnforcerError is an Exception."""
-        assert issubclass(EnforcerError, Exception)
+        """ActionGuardError is an Exception."""
+        assert issubclass(ActionGuardError, Exception)

--- a/tests/unit/test_action_guard/test_matcher.py
+++ b/tests/unit/test_action_guard/test_matcher.py
@@ -1,4 +1,4 @@
-"""Tests for Enforcer pattern matching engine (WP2.1a)."""
+"""Tests for Action guard pattern matching engine (WP2.1a)."""
 
 from __future__ import annotations
 
@@ -6,8 +6,7 @@ import re
 
 import pytest
 
-from ac_guard.config.models import OperationRules, Rule
-from ac_guard.enforcer.matcher import (
+from ac_guard.action_guard.matcher import (
     VALID_SCHEMES,
     Decision,
     evaluate_rules,
@@ -15,6 +14,7 @@ from ac_guard.enforcer.matcher import (
     matches,
     parse_pattern,
 )
+from ac_guard.config.models import OperationRules, Rule
 
 # ---------------------------------------------------------------------------
 # TestParsePattern

--- a/tests/unit/test_action_guard/test_policy.py
+++ b/tests/unit/test_action_guard/test_policy.py
@@ -1,4 +1,4 @@
-"""Tests for Enforcer policy loader (E1)."""
+"""Tests for Action guard policy loader (E1)."""
 
 from __future__ import annotations
 
@@ -7,9 +7,9 @@ from pathlib import Path
 
 import pytest
 
+from ac_guard.action_guard.exceptions import PolicyCorruptError
+from ac_guard.action_guard.policy import load_policy
 from ac_guard.config.models import BehaviorConfig
-from ac_guard.enforcer.exceptions import PolicyCorruptError
-from ac_guard.enforcer.policy import load_policy
 
 
 def _write_policy(project_root: Path, policy_data: dict) -> None:

--- a/tests/unit/test_adapters/test_hooks.py
+++ b/tests/unit/test_adapters/test_hooks.py
@@ -15,7 +15,7 @@ class TestClaudeCodeHook:
     def test_renders_python_script(self) -> None:
         """Claude Code hook renders a Python script."""
         content = render_hook("claude_code", BehaviorConfig.empty())
-        assert "from ac_guard.enforcer.engine import evaluate" in content
+        assert "from ac_guard.action_guard.engine import evaluate" in content
 
     def test_contains_main_entry(self) -> None:
         """Claude Code hook has main() entry point."""
@@ -71,10 +71,10 @@ class TestCursorHook:
         content = render_hook("cursor", BehaviorConfig.empty())
         assert content.startswith("#!/bin/bash")
 
-    def test_calls_enforcer_subprocess(self) -> None:
-        """Cursor hook calls Python enforcer via subprocess."""
+    def test_calls_action_guard_subprocess(self) -> None:
+        """Cursor hook calls Python action_guard via subprocess."""
         content = render_hook("cursor", BehaviorConfig.empty())
-        assert "python3 -m ac_guard.enforcer" in content
+        assert "python3 -m ac_guard.action_guard" in content
 
     def test_outputs_permission_format(self) -> None:
         """Cursor hook outputs permission JSON."""
@@ -95,10 +95,10 @@ class TestOpenCodeHook:
         content = render_hook("opencode", BehaviorConfig.empty())
         assert "export function intercept" in content
 
-    def test_calls_enforcer_subprocess(self) -> None:
-        """OpenCode hook calls Python enforcer via subprocess."""
+    def test_calls_action_guard_subprocess(self) -> None:
+        """OpenCode hook calls Python action_guard via subprocess."""
         content = render_hook("opencode", BehaviorConfig.empty())
-        assert "python3 -m ac_guard.enforcer" in content
+        assert "python3 -m ac_guard.action_guard" in content
 
     def test_throws_on_deny(self) -> None:
         """OpenCode hook throws Error on deny."""

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -67,7 +67,7 @@ class TestCheckCommand:
     def test_check_passed(self, tmp_path: Path) -> None:
         """Passing checks return exit 0 and PASSED."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(app, ["check", "--config", str(config)])
         assert result.exit_code == 0
         assert "PASSED" in result.output
@@ -92,7 +92,7 @@ class TestCheckCommand:
             ),
             encoding="utf-8",
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(app, ["check", "--config", str(config)])
         assert result.exit_code == 1
         assert "FAILED" in result.output
@@ -104,11 +104,11 @@ class TestCheckCommand:
         assert result.exit_code == 1
 
     def test_check_with_files(self, tmp_path: Path) -> None:
-        """--files option passes files to checker."""
+        """--files option passes files to code_gate."""
         config = _write_config(tmp_path)
         # With format/naming enabled and explicit files, pre-commit will
         # be called but skip (no pre-commit config in tmp_path)
-        with patch("ac_guard.checker.core.shutil.which", return_value=None):
+        with patch("ac_guard.code_gate.core.shutil.which", return_value=None):
             result = runner.invoke(
                 app,
                 [
@@ -135,7 +135,7 @@ class TestVerifyCommand:
     def test_verify_passed(self, tmp_path: Path) -> None:
         """Passing verify returns exit 0."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(app, ["verify", "--config", str(config)])
         assert result.exit_code == 0
         assert "PASSED" in result.output
@@ -143,7 +143,7 @@ class TestVerifyCommand:
     def test_verify_skip_build(self, tmp_path: Path) -> None:
         """--skip-build skips build step."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app, ["verify", "--skip-build", "--config", str(config)]
             )
@@ -161,7 +161,7 @@ class TestRunCommand:
     def test_run_builtin_format(self, tmp_path: Path) -> None:
         """Running built-in format check."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(app, ["run", "format", "--config", str(config)])
         # pre-commit skipped (no files) → passed
         assert result.exit_code == 0
@@ -169,7 +169,7 @@ class TestRunCommand:
     def test_run_custom_check(self, tmp_path: Path) -> None:
         """Running a custom check by name."""
         config = _write_config_with_checks(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])
         assert result.exit_code == 0
 
@@ -192,7 +192,7 @@ class TestGateRunCommand:
     def test_gate_commit_passed(self, tmp_path: Path) -> None:
         """Gate run with passing checks outputs minimal text."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
             )
@@ -218,7 +218,7 @@ class TestGateRunCommand:
             ),
             encoding="utf-8",
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
             )
@@ -228,7 +228,7 @@ class TestGateRunCommand:
     def test_gate_push(self, tmp_path: Path) -> None:
         """Gate run push stage works."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app, ["gate", "run", "--stage", "pre-push", "--config", str(config)]
             )
@@ -244,7 +244,7 @@ class TestJsonOutput:
         import json
 
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app, ["check", "--config", str(config), "--format", "json"]
             )
@@ -259,7 +259,7 @@ class TestJsonOutput:
         import json
 
         config = _write_config(tmp_path)
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             result = runner.invoke(
                 app,
                 [
@@ -315,7 +315,7 @@ class TestCliAutoPostPrComment:
         """check dispatches post_pr_comment with report + pr_report + locale."""
         config = _write_config_with_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(app, ["check", "--config", str(config)])
@@ -333,7 +333,7 @@ class TestCliAutoPostPrComment:
         """Even when disabled, CLI calls post_pr_comment (primitive self-gates)."""
         config = _write_config_with_pr_report(tmp_path, enabled=False)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(app, ["check", "--config", str(config)])
@@ -347,7 +347,7 @@ class TestCliAutoPostPrComment:
         """verify also dispatches post_pr_comment at end."""
         config = _write_config_with_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(
@@ -363,7 +363,7 @@ class TestCliAutoPostPrComment:
         """gate run also dispatches post_pr_comment at end."""
         config = _write_config_with_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(
@@ -383,7 +383,7 @@ class TestCliAutoPostPrComment:
         """
         config = _write_config_with_checks(tmp_path)
         with (
-            patch("ac_guard.checker.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])

--- a/tests/unit/test_code_gate/test_core.py
+++ b/tests/unit/test_code_gate/test_core.py
@@ -1,11 +1,11 @@
-"""Tests for Checker core orchestration (K2-K6)."""
+"""Tests for code_gate core orchestration (K2-K6)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import patch
 
-from ac_guard.checker.core import (
+from ac_guard.code_gate.core import (
     StageOptions,
     _filter_files_by_type,
     get_changed_files,
@@ -21,7 +21,7 @@ class TestGetChangedFiles:
 
     def test_commit_stage_command(self, tmp_path: Path) -> None:
         """Commit stage uses git diff --cached."""
-        with patch("ac_guard.checker.core.subprocess.run") as mock_run:
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "a.py\nb.py\n"
             files = get_changed_files("pre-commit", tmp_path)
@@ -31,7 +31,7 @@ class TestGetChangedFiles:
 
     def test_push_stage_command(self, tmp_path: Path) -> None:
         """Push stage uses git diff origin/main..HEAD."""
-        with patch("ac_guard.checker.core.subprocess.run") as mock_run:
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "c.py\n"
             files = get_changed_files("pre-push", tmp_path)
@@ -41,7 +41,7 @@ class TestGetChangedFiles:
 
     def test_empty_output(self, tmp_path: Path) -> None:
         """Empty git output returns empty list."""
-        with patch("ac_guard.checker.core.subprocess.run") as mock_run:
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = ""
             files = get_changed_files("pre-commit", tmp_path)
@@ -49,7 +49,7 @@ class TestGetChangedFiles:
 
     def test_git_error_returns_empty(self, tmp_path: Path) -> None:
         """Git error returns empty list."""
-        with patch("ac_guard.checker.core.subprocess.run") as mock_run:
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 1
             mock_run.return_value.stdout = ""
             files = get_changed_files("pre-commit", tmp_path)
@@ -142,7 +142,7 @@ class TestRunStage:
     def test_commit_stage_runs_checks(self, tmp_path: Path) -> None:
         """pre-commit stage runs format + custom checks."""
         config = CodeConfig(pre_commit=StageBucket(format=True))
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             report = run_stage("pre-commit", config, tmp_path)
         assert report.stage == "pre-commit"
         # Format and naming are pre-commit hooks — skipped with no files
@@ -156,7 +156,7 @@ class TestRunStage:
                 checks={"echo": CheckItem(command="echo ok")},
             ),
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             report = run_stage("pre-commit", config, tmp_path)
         assert report.passed is True
         assert any(r.name == "echo" for r in report.results)
@@ -168,7 +168,7 @@ class TestRunStage:
                 checks={"fail": CheckItem(command="exit 1")},
             ),
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             report = run_stage("pre-push", config, tmp_path)
         assert report.stage == "pre-push"
         assert report.passed is False
@@ -178,7 +178,7 @@ class TestRunStage:
         config = CodeConfig(
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=False)
         )
-        with patch("ac_guard.checker.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
             report = run_stage(
                 "pre-push",
                 config,
@@ -191,7 +191,7 @@ class TestRunStage:
     def test_format_iterates_per_language(self, tmp_path: Path) -> None:
         """commit_format=True emits one pre-commit call per configured language."""
         config = CodeConfig(pre_commit=StageBucket(format=True))
-        with patch("ac_guard.checker.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
             mock_run.return_value.passed = True
             mock_run.return_value.name = "stub"
             mock_run.return_value.duration_ms = 0
@@ -216,7 +216,7 @@ class TestRunStage:
         config = CodeConfig(
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=True)
         )
-        with patch("ac_guard.checker.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
             mock_run.return_value.passed = True
             mock_run.return_value.name = "stub"
             mock_run.return_value.duration_ms = 0
@@ -224,7 +224,7 @@ class TestRunStage:
             mock_run.return_value.violations = []
             mock_run.return_value.output = ""
             with patch(
-                "ac_guard.checker.core.get_changed_files", return_value=["a.py"]
+                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
             ):
                 run_stage(
                     "pre-push",
@@ -237,7 +237,7 @@ class TestRunStage:
         assert "lint-typescript" in hook_ids
 
     # D8: ``commit_naming`` flag removed in schema v2 (#123). Shim in
-    # CodeConfig always returns False, so the checker's naming branch
+    # CodeConfig always returns False, so the code_gate's naming branch
     # is now unreachable. The dedicated "naming returns skipped" test
     # is obsolete; ruff N-rules (via ``lint: true``) replaced it.
 
@@ -247,15 +247,15 @@ class TestRunStage:
             pre_commit=StageBucket(format=True), pre_push=StageBucket(lint=True)
         )
         with (
-            patch("ac_guard.checker.core.run_precommit") as mock_run,
-            patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core.run_precommit") as mock_run,
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
         ):
             run_stage("pre-push", config, tmp_path, options=StageOptions(languages=[]))
         mock_run.assert_not_called()
 
     def test_push_build_failure_skips_lint_and_checks(self, tmp_path: Path) -> None:
         """#77: a failing build must mark lint + push.checks as skipped."""
-        from ac_guard.checker.models import CheckResult
+        from ac_guard.code_gate.models import CheckResult
 
         config = CodeConfig(
             pre_commit=StageBucket(format=False),
@@ -269,11 +269,11 @@ class TestRunStage:
         )
         with (
             patch(
-                "ac_guard.checker.core.run_build", return_value=failing_build
+                "ac_guard.code_gate.core.run_build", return_value=failing_build
             ) as build_mock,
-            patch("ac_guard.checker.core.run_precommit") as precommit_mock,
-            patch("ac_guard.checker.core.run_check") as check_mock,
-            patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core.run_precommit") as precommit_mock,
+            patch("ac_guard.code_gate.core.run_check") as check_mock,
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
         ):
             report = run_stage(
                 "pre-push",
@@ -285,7 +285,7 @@ class TestRunStage:
                 ),
             )
 
-        # Build ran once, downstream checkers never invoked
+        # Build ran once, downstream stages never invoked
         assert build_mock.call_count == 1
         precommit_mock.assert_not_called()
         check_mock.assert_not_called()
@@ -301,7 +301,7 @@ class TestRunStage:
 
     def test_push_build_success_runs_downstream(self, tmp_path: Path) -> None:
         """Build success preserves the existing downstream execution path."""
-        from ac_guard.checker.models import CheckResult
+        from ac_guard.code_gate.models import CheckResult
 
         config = CodeConfig(
             pre_commit=StageBucket(format=False),
@@ -312,10 +312,10 @@ class TestRunStage:
         )
         passing_build = CheckResult(name="build", passed=True, duration_ms=10)
         with (
-            patch("ac_guard.checker.core.run_build", return_value=passing_build),
-            patch("ac_guard.checker.core.run_precommit") as precommit_mock,
-            patch("ac_guard.checker.core.run_check") as check_mock,
-            patch("ac_guard.checker.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core.run_build", return_value=passing_build),
+            patch("ac_guard.code_gate.core.run_precommit") as precommit_mock,
+            patch("ac_guard.code_gate.core.run_check") as check_mock,
+            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
         ):
             precommit_mock.return_value = CheckResult(
                 name="pre-commit:lint-python", passed=True, duration_ms=1

--- a/tests/unit/test_code_gate/test_models.py
+++ b/tests/unit/test_code_gate/test_models.py
@@ -1,8 +1,8 @@
-"""Tests for Checker data models."""
+"""Tests for code_gate data models."""
 
 from __future__ import annotations
 
-from ac_guard.checker.models import CheckResult, StageOutcome, Violation
+from ac_guard.code_gate.models import CheckResult, StageOutcome, Violation
 
 
 class TestViolation:

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ac_guard.checker.models import CheckResult, StageOutcome, Violation
+from ac_guard.code_gate.models import CheckResult, StageOutcome, Violation
 from ac_guard.reporter.formatting import (
     format_json,
     format_markdown,


### PR DESCRIPTION
## Summary

Renames the two core modules so their names tell the truth about what they do:

- `ac_guard.checker` → `ac_guard.code_gate` — git hook-time code quality **gate** (pass/fail)
- `ac_guard.enforcer` → `ac_guard.action_guard` — agent hook-time runtime **guard** (allow/deny/ask)
- `EnforcerError` → `ActionGuardError`

`checker` vs `enforcer` was an ambiguous pair (both could mean "the thing that checks" or "the thing that enforces"). `code_gate` + `action_guard` split the responsibility by domain (code vs action) and verdict shape (binary vs ternary), and pair cleanly with the product name `ac-guard`.

## Breaking changes

**No backward-compat shim** — by design. Downstream impact:

| Old | New |
|---|---|
| `from ac_guard.checker ...` | `from ac_guard.code_gate ...` |
| `from ac_guard.enforcer ...` | `from ac_guard.action_guard ...` |
| `python3 -m ac_guard.enforcer` | `python3 -m ac_guard.action_guard` |
| `EnforcerError` | `ActionGuardError` |

**Action required for users:** re-run `ac-guard install` so generated hook scripts (`.claude/hooks/*`, `.cursor/hooks/*`, `opencode` integration) point at the new module paths. Previously generated hooks still `import ac_guard.enforcer` and will fail with `ModuleNotFoundError` after upgrading.

`guard.yaml` schema and CLI surface (`ac-guard check / verify / run / gate run / install / status`) are unchanged.

## Structure

Single PR, two commits:

1. `refactor(checker)!: rename ac_guard.checker -> ac_guard.code_gate`
2. `refactor(enforcer)!: rename ac_guard.enforcer -> ac_guard.action_guard`

Each commit leaves the repo green (pytest + import-linter + pre-commit). `.importlinter` layer + config-encapsulation contracts updated. `CHANGELOG.md` gets a BREAKING entry.

## Test plan

- [x] `pytest` — 1049 passed
- [x] `lint-imports --config .importlinter` — 2 kept, 0 broken
- [x] `pre-commit run --all-files` — clean
- [x] Smoke install in fresh tmp repo: `ac-guard install --agent claude-code` and `--agent cursor` both produced hook scripts referencing `ac_guard.action_guard`, zero references to `ac_guard.enforcer`
- [x] `rg 'ac_guard\.enforcer|ac_guard\.checker|EnforcerError'` zero hits outside CHANGELOG history entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)