### PR TITLE
refactor(code_gate): migrate language registry to domain.languages

### DIFF
--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -17,8 +17,9 @@ from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
-from ac_guard.code_gate import BUCKET_AWARE_STAGES, detect_language
+from ac_guard.code_gate import BUCKET_AWARE_STAGES
 from ac_guard.config import ConfigError, load_config, resolve_config
+from ac_guard.domain.languages import detect_language
 from ac_guard.generator.core import read_state
 
 if TYPE_CHECKING:

--- a/src/ac_guard/code_gate/__init__.py
+++ b/src/ac_guard/code_gate/__init__.py
@@ -9,7 +9,6 @@ white-box tests of internal helpers.
 from ac_guard.code_gate.core import (
     BUCKET_AWARE_STAGES,
     StageOptions,
-    detect_language,
     get_changed_files,
     run_build,
     run_check,
@@ -20,7 +19,6 @@ from ac_guard.code_gate.core import (
 __all__ = [
     "BUCKET_AWARE_STAGES",
     "StageOptions",
-    "detect_language",
     "get_changed_files",
     "run_build",
     "run_check",

--- a/src/ac_guard/code_gate/core.py
+++ b/src/ac_guard/code_gate/core.py
@@ -13,6 +13,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ac_guard.domain.languages import TYPE_EXTENSIONS
 from ac_guard.domain.models import CheckResult, StageOutcome
 
 if TYPE_CHECKING:
@@ -23,7 +24,6 @@ if TYPE_CHECKING:
 __all__ = [
     "BUCKET_AWARE_STAGES",
     "StageOptions",
-    "detect_language",
     "get_changed_files",
     "run_build",
     "run_check",
@@ -61,34 +61,6 @@ _DEFAULT_STAGE_OPTIONS = StageOptions()
 # shortcuts, build command, StageOutcome for reporter/audit). Other gating
 # stages delegate to ``pre-commit run --hook-stage`` via cli/check.py.
 BUCKET_AWARE_STAGES: frozenset[str] = frozenset({"pre-commit", "pre-push"})
-
-
-# Maps ac-guard language identifier → set of file extensions. Shared by
-# the file-type filter and by ``doctor``'s language coverage check.
-TYPE_EXTENSIONS: dict[str, frozenset[str]] = {
-    "python": frozenset({".py", ".pyi"}),
-    "javascript": frozenset({".js", ".jsx", ".mjs"}),
-    "typescript": frozenset({".ts", ".tsx", ".mts"}),
-    "go": frozenset({".go"}),
-    "rust": frozenset({".rs"}),
-    "java": frozenset({".java"}),
-    "c": frozenset({".c", ".h"}),
-    "cpp": frozenset({".cpp", ".cc", ".cxx", ".hpp", ".hh"}),
-}
-
-
-def detect_language(path: str) -> str | None:
-    """Return the ac-guard language name for a file path, or None.
-
-    Uses the extension → language map in ``TYPE_EXTENSIONS``. Returns
-    ``None`` for paths with no matching extension (configs, text files,
-    binaries, etc.).
-    """
-    lower = path.lower()
-    for lang, exts in TYPE_EXTENSIONS.items():
-        if any(lower.endswith(ext) for ext in exts):
-            return lang
-    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/ac_guard/domain/__init__.py
+++ b/src/ac_guard/domain/__init__.py
@@ -41,7 +41,7 @@ Admission criteria for **Domain Services** (own sub-module, e.g.
    at a lower level.
 """
 
-from ac_guard.domain import managed_block
+from ac_guard.domain import languages, managed_block
 from ac_guard.domain.models import CheckResult, FileSpec, StageOutcome, Violation
 
 __all__ = [
@@ -49,5 +49,6 @@ __all__ = [
     "FileSpec",
     "StageOutcome",
     "Violation",
+    "languages",
     "managed_block",
 ]

--- a/src/ac_guard/domain/languages.py
+++ b/src/ac_guard/domain/languages.py
@@ -1,0 +1,66 @@
+"""Domain Service for the ac-guard language registry.
+
+ac-guard recognizes a finite set of programming languages; each is
+identified by a short language name (e.g. ``python``) and associated
+with one or more file extensions. This module owns that mapping as a
+single source of truth across the project.
+
+Two queries are derived from the registry:
+
+    detect_language(path)        # path → language (extension lookup, case-insensitive)
+    TYPE_EXTENSIONS              # language → its extensions (as a frozenset[str])
+
+Both are pure functions / static data — no I/O, no external dependencies.
+The table is exposed publicly because consumers like code_gate's
+file-type filter need the language → extensions direction with a
+local fallback (treat unknown type names as literal extensions); the
+fallback semantics live with that consumer rather than here.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "TYPE_EXTENSIONS",
+    "detect_language",
+]
+
+
+# ---------------------------------------------------------------------------
+# Public registry
+# ---------------------------------------------------------------------------
+
+# Maps ac-guard language identifier → file extensions associated with
+# that language. Drives both the path → language detection below and
+# the bucket-aware format/lint shortcut emission in the generator
+# (per-language hook IDs like ``format-python`` / ``lint-typescript``).
+TYPE_EXTENSIONS: dict[str, frozenset[str]] = {
+    "python": frozenset({".py", ".pyi"}),
+    "javascript": frozenset({".js", ".jsx", ".mjs"}),
+    "typescript": frozenset({".ts", ".tsx", ".mts"}),
+    "go": frozenset({".go"}),
+    "rust": frozenset({".rs"}),
+    "java": frozenset({".java"}),
+    "c": frozenset({".c", ".h"}),
+    "cpp": frozenset({".cpp", ".cc", ".cxx", ".hpp", ".hh"}),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public operations
+# ---------------------------------------------------------------------------
+
+
+def detect_language(path: str) -> str | None:
+    """Return the ac-guard language name for ``path``, or None if unrecognized.
+
+    Matches by file-extension suffix against :data:`TYPE_EXTENSIONS`.
+    The match is case-insensitive (so ``.PY`` resolves the same as
+    ``.py``). Returns ``None`` for paths whose extension is not in
+    the registry — config files, plain text, binaries, files without
+    an extension, etc.
+    """
+    lower = path.lower()
+    for lang, exts in TYPE_EXTENSIONS.items():
+        if any(lower.endswith(ext) for ext in exts):
+            return lang
+    return None

--- a/tests/unit/test_domain/test_languages.py
+++ b/tests/unit/test_domain/test_languages.py
@@ -1,0 +1,156 @@
+"""Tests for ac_guard.domain.languages — Domain Service for the
+ac-guard language registry (path → language and the underlying
+extension table).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ac_guard.domain import languages
+
+# Snapshot of the registered languages. The data table is a domain
+# contract: any change must come with a deliberate code review,
+# because format/lint shortcut emission and doctor's language
+# coverage diagnostic both depend on this set.
+_EXPECTED_LANGUAGES = frozenset(
+    {
+        "python",
+        "javascript",
+        "typescript",
+        "go",
+        "rust",
+        "java",
+        "c",
+        "cpp",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# A. TYPE_EXTENSIONS shape and contents
+# ---------------------------------------------------------------------------
+
+
+class TestTypeExtensionsShape:
+    """The registry is a dict[str, frozenset[str]] keyed on language name."""
+
+    def test_keys_match_expected_languages(self) -> None:
+        assert frozenset(languages.TYPE_EXTENSIONS) == _EXPECTED_LANGUAGES
+
+    def test_values_are_frozenset_of_str(self) -> None:
+        for lang, exts in languages.TYPE_EXTENSIONS.items():
+            assert isinstance(exts, frozenset), (
+                f"{lang}: expected frozenset, got {type(exts).__name__}"
+            )
+            assert exts, f"{lang}: extension set is empty"
+            for ext in exts:
+                assert isinstance(ext, str)
+                assert ext.startswith("."), f"{lang}: {ext!r} missing leading dot"
+
+    def test_extensions_are_lowercase(self) -> None:
+        """detect_language lowercases input; the table must be lowercase too."""
+        for lang, exts in languages.TYPE_EXTENSIONS.items():
+            for ext in exts:
+                assert ext == ext.lower(), f"{lang}: {ext!r} not lowercase"
+
+    def test_no_extension_collisions_across_languages(self) -> None:
+        """Each extension belongs to exactly one language."""
+        seen: dict[str, str] = {}
+        for lang, exts in languages.TYPE_EXTENSIONS.items():
+            for ext in exts:
+                if ext in seen:
+                    pytest.fail(
+                        f"{ext!r} registered for both {seen[ext]!r} and {lang!r}"
+                    )
+                seen[ext] = lang
+
+
+# ---------------------------------------------------------------------------
+# B. detect_language — path → language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguageRegistered:
+    """Every registered language is detectable via at least one extension."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("foo.py", "python"),
+            ("foo.pyi", "python"),
+            ("foo.js", "javascript"),
+            ("foo.jsx", "javascript"),
+            ("foo.mjs", "javascript"),
+            ("foo.ts", "typescript"),
+            ("foo.tsx", "typescript"),
+            ("foo.mts", "typescript"),
+            ("foo.go", "go"),
+            ("foo.rs", "rust"),
+            ("foo.java", "java"),
+            ("foo.c", "c"),
+            ("foo.h", "c"),
+            ("foo.cpp", "cpp"),
+            ("foo.cc", "cpp"),
+            ("foo.cxx", "cpp"),
+            ("foo.hpp", "cpp"),
+            ("foo.hh", "cpp"),
+        ],
+    )
+    def test_known_extension_resolves(self, path: str, expected: str) -> None:
+        assert languages.detect_language(path) == expected
+
+
+class TestDetectLanguageEdgeCases:
+    """detect_language handles real-world path shapes."""
+
+    def test_uppercase_extension_matched(self) -> None:
+        """``.PY``-style extensions still map to python (case-insensitive)."""
+        assert languages.detect_language("MAIN.PY") == "python"
+
+    def test_mixed_case_extension_matched(self) -> None:
+        assert languages.detect_language("Main.Java") == "java"
+
+    def test_path_prefix_ignored(self) -> None:
+        """Directory components don't affect detection."""
+        assert languages.detect_language("a/b/c/d.py") == "python"
+        assert languages.detect_language("/abs/path/to/script.go") == "go"
+
+    def test_unknown_extension_returns_none(self) -> None:
+        assert languages.detect_language("README.md") is None
+        assert languages.detect_language("Cargo.toml") is None
+        assert languages.detect_language("config.yaml") is None
+
+    def test_no_extension_returns_none(self) -> None:
+        assert languages.detect_language("Makefile") is None
+        assert languages.detect_language("/etc/hosts") is None
+        assert languages.detect_language("") is None
+
+    def test_dotfile_with_known_extension_matches(self) -> None:
+        """A dotfile-like path whose tail matches an extension still resolves."""
+        # Pathological but consistent: detect_language is suffix-based.
+        assert languages.detect_language(".py") == "python"
+
+    def test_extension_must_be_at_end(self) -> None:
+        """Mid-path occurrences of extension-like substrings don't match."""
+        # ".py" appears mid-path but the file ext is .txt → unknown.
+        assert languages.detect_language("a.py.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# C. Module surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    """The module's public contract is exactly TYPE_EXTENSIONS + detect_language."""
+
+    def test_all_lists_both(self) -> None:
+        assert set(languages.__all__) == {"TYPE_EXTENSIONS", "detect_language"}
+
+    def test_re_exported_from_domain_package(self) -> None:
+        """`from ac_guard.domain import languages` resolves to this module."""
+        from ac_guard import domain
+
+        assert "languages" in domain.__all__
+        assert domain.languages is languages

--- a/tests/unit/test_domain/test_models.py
+++ b/tests/unit/test_domain/test_models.py
@@ -56,7 +56,7 @@ class TestValueObjectExports:
 
 
 class TestPackageApi:
-    """Domain package exposes VOs + managed_block Domain Service namespace."""
+    """Domain package exposes VOs + Domain Service sub-modules."""
 
     def test_domain_all(self) -> None:
         import ac_guard.domain as domain
@@ -66,6 +66,7 @@ class TestPackageApi:
             "FileSpec",
             "StageOutcome",
             "Violation",
+            "languages",
             "managed_block",
         }
 


### PR DESCRIPTION
## Summary

Second PR of the three-PR sequence under #109 (PR #143 already merged into main). Extracts the language registry (`TYPE_EXTENSIONS` + `detect_language`) out of `ac_guard.code_gate` and into a new `ac_guard.domain.languages` Domain Service, mirroring the convention already established by `ac_guard.domain.managed_block`. **No behaviour change.**

## What changes

- **New `src/ac_guard/domain/languages.py`** — Domain Service with closed-loop API:
  - `TYPE_EXTENSIONS: dict[str, frozenset[str]]` — the canonical language → extensions table (8 languages: python / javascript / typescript / go / rust / java / c / cpp). Public because consumers need direct access for fallback semantics that don't belong here.
  - `detect_language(path) -> str | None` — case-insensitive suffix match. Returns `None` for unrecognized extensions or paths without one.
- **`domain/__init__.py`** re-exports `languages` alongside `managed_block`, so `from ac_guard.domain import languages` resolves naturally.
- **`code_gate/core.py`** drops the data table and query function; `_filter_files_by_type` now imports `TYPE_EXTENSIONS` from `ac_guard.domain.languages`. `detect_language` leaves `core.__all__`.
- **`code_gate/__init__.py`** facade tightens from 8 exports to 7 (removes `detect_language`). The package no longer touches language metadata.
- **`cli/status.py`** imports `detect_language` from `ac_guard.domain.languages` directly. Doctor's language coverage diagnostic behaviour unchanged.
- **New `tests/unit/test_domain/test_languages.py`** (31 tests) covers data-shape invariants (8 expected languages, frozenset values, lowercase extensions, no cross-language collisions, every registered extension resolves) plus query semantics (case-insensitive, path-prefix tolerant, unknown / missing extensions return `None`, suffix-only matching).
- **`tests/unit/test_domain/test_models.py`** updates the package-API snapshot test to include `languages`.

## Why

After PR #143 collapsed `code_gate/__init__.py` into a real facade, the next step in #109's residual cleanup is making `code_gate`'s job purely *executing* ac-guard-controlled checks. Language metadata (the extension table, the path → language query) is a cross-module **fact**, not part of check execution — `cli/status.py:doctor` consumes it for the language-coverage diagnostic with no involvement from the check pipeline. Per `ac_guard.domain.__init__`'s admission criteria for Domain Services, language detection qualifies: stateless, stdlib-only, multi-consumer, closed-loop API.

Decision note: `TYPE_EXTENSIONS` is exposed publicly (no underscore) rather than kept private. `_filter_files_by_type` in `code_gate/core.py` needs direct dict access to implement its fallback semantics (treat unknown type names as literal extensions) — a fallback that belongs with the consumer, not with the language registry. Wrapping the table behind a query function would either bake the fallback into the language module (wrong layer) or force the consumer to do `dict(TYPE_EXTENSIONS).get(...)` workarounds. Public data is the cleaner choice.

## What's intentionally NOT in this PR

- D3b passthrough relocation (`gate_run_command`'s inline `subprocess.run(["pre-commit", "run", "--hook-stage", …])` block) — that's **PR3**.
- `BUCKET_AWARE_STAGES` removal from the facade — also PR3.
- Any other #109 dimension (action_guard / generator / config / workflows / adapters) — separate follow-up PRs.

## Test plan

- [x] `uv run pytest tests/ -q` — **1072/1072** (1041 from PR #143 + 31 new for `domain.languages`)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pre-commit run --all-files` — clean (interrogate, import-linter, bandit)
- [x] Boundary greps confirm:
  - `TYPE_EXTENSIONS` and `detect_language` are no longer defined inside `code_gate/`
  - `cli/status.py` imports `detect_language` from `ac_guard.domain.languages`
  - `code_gate/__init__.py` facade is 7 symbols (down from 8)
  - `domain/languages.py` is the single source of truth

## Refs

- Refs #109 (residuals tracker — checks off the "code_gate language metadata migration" item)
- Part of #133 (M6 architecture & engineering optimization epic)
- Follows #143 (code_gate facade cleanup, already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)