### PR TITLE
refactor(code_gate): relocate D3b passthrough to cli and drop BUCKET_AWARE_STAGES

### DIFF
--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -6,10 +6,10 @@ the code_gate module for execution and Reporter for output formatting.
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 from ac_guard.code_gate import (
-    BUCKET_AWARE_STAGES,
     StageOptions,
     get_changed_files,
     run_check,
@@ -41,6 +41,13 @@ _NAMING_NOT_IMPLEMENTED_MSG = (
     "Naming check is not yet implemented — tracked in "
     "https://github.com/ikroal/ai-code-guard/issues/95"
 )
+
+# Stages where ac-guard provides bucket-aware orchestration (format/lint
+# shortcuts, build command, StageOutcome for reporter/audit). Other
+# gating stages delegate to ``pre-commit run --hook-stage`` via
+# ``_run_precommit_stage``. ``cli/status.py`` (doctor) imports this
+# constant for its stage-semantic-fit diagnostic.
+BUCKET_AWARE_STAGES: frozenset[str] = frozenset({"pre-commit", "pre-push"})
 
 
 def check_command(
@@ -238,15 +245,35 @@ def gate_run_command(
     # pre-commit's native stage runner; it reads the generated
     # .pre-commit-config.yaml and executes hooks declared for this
     # stage via their ``stages:`` field.
-    import subprocess
+    raise SystemExit(_run_precommit_stage(stage, project_root, argv=argv))
 
+
+def _run_precommit_stage(
+    stage: str,
+    project_root: Path,
+    *,
+    argv: list[str] | None = None,
+) -> int:
+    """Delegate to ``pre-commit run --hook-stage <stage>`` and return its exit code.
+
+    Used by :func:`gate_run_command` for gating stages that ac-guard does
+    not model in its bucket-aware code_gate (``commit-msg`` /
+    ``pre-merge-commit`` / ``pre-rebase``). pre-commit reads the
+    generated ``.pre-commit-config.yaml`` and runs hooks declared at the
+    given stage via their ``stages:`` field; its stdout/stderr are not
+    captured so the user sees pre-commit's native output.
+
+    For ``commit-msg``, the first positional argv entry (the message
+    file path passed by git as ``$1``) is forwarded as
+    ``--commit-msg-filename``. Other stages always use ``--all-files``.
+    """
     cmd = ["pre-commit", "run", "--hook-stage", stage]
     if stage == "commit-msg" and argv:
         cmd.extend(["--commit-msg-filename", argv[0]])
     else:
         cmd.append("--all-files")
     result = subprocess.run(cmd, cwd=project_root, check=False)
-    raise SystemExit(result.returncode)
+    return result.returncode
 
 
 def _report_to_terminal(outcome: StageOutcome, output_format: str, locale: str) -> None:

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
-from ac_guard.code_gate import BUCKET_AWARE_STAGES
+from ac_guard.cli.check import BUCKET_AWARE_STAGES
 from ac_guard.config import ConfigError, load_config, resolve_config
 from ac_guard.domain.languages import detect_language
 from ac_guard.generator.core import read_state

--- a/src/ac_guard/code_gate/__init__.py
+++ b/src/ac_guard/code_gate/__init__.py
@@ -7,7 +7,6 @@ white-box tests of internal helpers.
 """
 
 from ac_guard.code_gate.core import (
-    BUCKET_AWARE_STAGES,
     StageOptions,
     get_changed_files,
     run_build,
@@ -17,7 +16,6 @@ from ac_guard.code_gate.core import (
 )
 
 __all__ = [
-    "BUCKET_AWARE_STAGES",
     "StageOptions",
     "get_changed_files",
     "run_build",

--- a/src/ac_guard/code_gate/core.py
+++ b/src/ac_guard/code_gate/core.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from ac_guard.config import CheckItem, CodeConfig
 
 __all__ = [
-    "BUCKET_AWARE_STAGES",
     "StageOptions",
     "get_changed_files",
     "run_build",
@@ -55,12 +54,6 @@ class StageOptions:
 
 
 _DEFAULT_STAGE_OPTIONS = StageOptions()
-
-
-# Stages where ac-guard provides bucket-aware orchestration (format/lint
-# shortcuts, build command, StageOutcome for reporter/audit). Other gating
-# stages delegate to ``pre-commit run --hook-stage`` via cli/check.py.
-BUCKET_AWARE_STAGES: frozenset[str] = frozenset({"pre-commit", "pre-push"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -236,6 +236,95 @@ class TestGateRunCommand:
         assert "PASSED" in result.output
 
 
+class TestRunPrecommitStage:
+    """White-box tests for cli/check.py _run_precommit_stage helper.
+
+    Covers the D3b passthrough path used by gate_run_command for stages
+    not in BUCKET_AWARE_STAGES (commit-msg / pre-merge-commit /
+    pre-rebase). The helper delegates to ``pre-commit run --hook-stage``
+    and propagates its exit code.
+    """
+
+    def test_returns_subprocess_returncode(self, tmp_path: Path) -> None:
+        """Exit code from the pre-commit subprocess propagates verbatim."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=42)
+            assert _run_precommit_stage("pre-rebase", tmp_path) == 42
+
+    def test_invokes_pre_commit_with_hook_stage(self, tmp_path: Path) -> None:
+        """Command starts with `pre-commit run --hook-stage <stage>`."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _run_precommit_stage("pre-merge-commit", tmp_path)
+            cmd = mock_run.call_args.args[0]
+            assert cmd[:4] == [
+                "pre-commit",
+                "run",
+                "--hook-stage",
+                "pre-merge-commit",
+            ]
+
+    def test_commit_msg_argv_forwarded(self, tmp_path: Path) -> None:
+        """commit-msg with argv passes msg file via --commit-msg-filename."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _run_precommit_stage("commit-msg", tmp_path, argv=["/tmp/msg-file"])
+            cmd = mock_run.call_args.args[0]
+            assert "--commit-msg-filename" in cmd
+            assert "/tmp/msg-file" in cmd
+            assert "--all-files" not in cmd
+
+    def test_commit_msg_no_argv_falls_back_to_all_files(self, tmp_path: Path) -> None:
+        """commit-msg without argv falls back to --all-files."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _run_precommit_stage("commit-msg", tmp_path, argv=None)
+            cmd = mock_run.call_args.args[0]
+            assert "--all-files" in cmd
+            assert "--commit-msg-filename" not in cmd
+
+    def test_non_commit_msg_uses_all_files_even_with_argv(self, tmp_path: Path) -> None:
+        """Non-commit-msg stages always use --all-files; argv is ignored."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _run_precommit_stage("pre-rebase", tmp_path, argv=["arg1"])
+            cmd = mock_run.call_args.args[0]
+            assert "--all-files" in cmd
+            assert "--commit-msg-filename" not in cmd
+
+    def test_passes_cwd_and_check_false(self, tmp_path: Path) -> None:
+        """project_root is forwarded as cwd; check=False so we own exit code."""
+        from subprocess import CompletedProcess
+
+        from ac_guard.cli.check import _run_precommit_stage
+
+        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _run_precommit_stage("pre-merge-commit", tmp_path)
+            assert mock_run.call_args.kwargs["cwd"] == tmp_path
+            assert mock_run.call_args.kwargs["check"] is False
+
+
 class TestJsonOutput:
     """Tests for --format json output."""
 


### PR DESCRIPTION
## Summary

Final PR of the three-PR sequence under #109 (PR #143 and #144 already merged into main). After this lands, **`ac_guard.code_gate` is exclusively the bucket-aware check execution surface**: the passthrough to pre-commit's native stage runner — used by `commit-msg` / `pre-merge-commit` / `pre-rebase` git hooks — moves to the CLI layer where it belongs. The `code_gate` facade settles at its final 6-symbol form. **No behaviour change.**

## What changes

- **New private `cli/check.py:_run_precommit_stage`** — absorbs the inline subprocess logic that previously lived inside `gate_run_command`. Contract: spawn `pre-commit run --hook-stage <stage>` with stdout/stderr inherited (so the user sees pre-commit's native output) and return its exit code. `commit-msg` with non-empty argv forwards `argv[0]` as `--commit-msg-filename`; other stages always use `--all-files`.
- **`gate_run_command` simplified** — the 5-line inline `subprocess.run(...)` block plus its function-local `import subprocess` collapses into `raise SystemExit(_run_precommit_stage(stage, project_root, argv=argv))`. `subprocess` is now a top-level import.
- **`BUCKET_AWARE_STAGES` moves to `cli/check.py`** — the constant only existed to support the D3a/D3b dispatch decision, which is now entirely a CLI concern. It has no remaining caller inside `code_gate`. `cli/status.py` (doctor's stage-semantic-fit diagnostic) imports it from `cli/check.py` instead.
- **`code_gate` facade tightens to 6 exports**: `run_stage` / `StageOptions` / `get_changed_files` / `run_precommit` / `run_check` / `run_build` — six primitives that are exclusively about executing ac-guard-controlled checks. `code_gate.core.__all__` matches.
- **6 new white-box tests** under `TestRunPrecommitStage` cover exit-code propagation, the `commit-msg` argv → `--commit-msg-filename` forwarding, the `--all-files` fallback when `argv` is empty, that non-`commit-msg` stages always use `--all-files` (argv ignored), and that the subprocess receives `cwd=project_root` and `check=False`.

## Final code_gate API

After this PR lands the package façade is locked at:

```python
from ac_guard.code_gate import (
    run_stage,           # D3a stage-level orchestration → StageOutcome
    StageOptions,        # run_stage's optional refinements
    get_changed_files,   # D1 git-diff scope探测
    run_precommit,       # D2 single pre-commit hook execution
    run_check,           # D2 single custom command execution
    run_build,           # D2 single build command execution
)
```

The earlier dimensional analysis (see #144 PR body for the full table) characterized this as the package's intrinsic responsibility surface. Language metadata (`detect_language`, `TYPE_EXTENSIONS`) and stage-classification metadata (`BUCKET_AWARE_STAGES`) and the passthrough delegation are all now hosted by their natural owners (`domain.languages`, `cli.check`).

## Why this works

The D3b passthrough does **no** ac-guard work — it does not consume `CodeConfig`, does not produce `CheckResult` / `StageOutcome`, does not touch reporter or audit. It's a pure proxy to pre-commit's CLI. Per the audit conclusion in #109, code that purely proxies to pre-commit belongs at the CLI seam, not in the check-execution module.

The 5 generated git hook templates (in `generator/_templates/git_hooks/*.j2`) **continue to call `ac-guard gate run --stage <X>` uniformly** — the central CLI entry point pattern is preserved. What changes is only where inside ac-guard the dispatch and passthrough logic lives.

## What this PR does NOT change

- Hook script templates — they still all call `ac-guard gate run --stage <X>` (uniform CLI entry).
- D3a behaviour (pre-commit / pre-push) — `run_stage`'s logic is unchanged.
- D3b behaviour (commit-msg / pre-merge-commit / pre-rebase) — same `pre-commit run --hook-stage` invocation, same exit-code propagation, same stdout/stderr semantics; just relocated.
- `cli/status.py:doctor`'s stage-semantic-fit check — same logic, now importing `BUCKET_AWARE_STAGES` from `cli.check` instead of `code_gate`.
- The "unify all 5 stages with reporter integration" question — that's a separate RFC tracked under #109 (changes user-visible output for commit-msg / pre-merge-commit / pre-rebase, requires UX design input).

## Test plan

- [x] `uv run pytest tests/ -q` — **1078/1078** (1072 from PR #144 + 6 new for `_run_precommit_stage`)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pre-commit run --all-files` — clean (interrogate, import-linter, bandit)
- [x] Boundary greps:
  - `BUCKET_AWARE_STAGES` no longer defined in `src/ac_guard/code_gate/`
  - `cli/check.py:50` defines the constant; `cli/status.py:20` imports from `cli.check`
  - `code_gate.__all__` is exactly the 6 execution primitives
  - `subprocess` is imported once at the top of `cli/check.py` (no function-local import)
- [x] CLI smoke on a fresh `mktemp` project root with `ac-guard install --agent claude-code`:
  - `ac-guard gate run --stage pre-commit` — D3a, exit 0, ac-guard reporter (`1/1 checks passed`)
  - `ac-guard gate run --stage commit-msg <msg-file>` — D3b passthrough, exit 0, argv forwarded, no ac-guard reporter line
  - `ac-guard gate run --stage pre-rebase` — D3b passthrough, exit 0, `--all-files`
  - `ac-guard doctor` — section "7. Stage Semantic Fit" still resolves correctly with `BUCKET_AWARE_STAGES` from its new home

## Refs

- Refs #109 (residuals tracker — checks off the "code_gate D3b passthrough relocation" item, completing the code_gate dimension)
- Part of #133 (M6 architecture & engineering optimization epic)
- Follows #143 (facade cleanup) and #144 (language metadata migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)