### PR TITLE
refactor(code_gate): collapse API surface, unify CLI to run, introduce strategy pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ pip install ac-guard
 ## Quick Start
 
 ```bash
-ac-guard init --language python          # create guard.yaml
-ac-guard install --agent claude-code     # generate rules + hooks
-ac-guard check                           # run quality checks
-ac-guard check --format json             # machine-readable output for CI
-ac-guard ruleset fetch <url>#v1.0        # fetch shared ruleset
+ac-guard init --language python                       # create guard.yaml
+ac-guard install --agent claude-code                  # generate rules + hooks
+ac-guard run --stage pre-commit                       # run commit-stage checks
+ac-guard run --stage pre-push                         # run push-stage checks (with build)
+ac-guard run --stage pre-commit --format json         # machine-readable output for CI
+ac-guard run mypy                                     # run a single check by name
+ac-guard ruleset fetch <url>#v1.0                     # fetch shared ruleset
 ```
 
 New here? Walk through the full flow in the
@@ -84,10 +86,8 @@ See [guard.yaml reference](design/AI_GUARD_SYSTEM_DESIGN.md) for full schema.
 | `ac-guard install --agent <name>` | Generate rules, hooks, and configs |
 | `ac-guard update` | Regenerate after config changes |
 | `ac-guard uninstall` | Remove generated artifacts |
-| `ac-guard check` | Run commit-stage checks |
-| `ac-guard verify` | Run push-stage validation |
-| `ac-guard run <name>` | Run a single check |
-| `ac-guard gate run --stage <s>` | Git hook entry point |
+| `ac-guard run --stage <s>` | Run all checks for a gating stage (also the entry point invoked by generated git hooks) |
+| `ac-guard run <name>` | Run a single check by name (developer iteration) |
 | `ac-guard status` | Installation state and drift detection |
 | `ac-guard doctor` | Environment diagnostics |
 | `ac-guard agents` | Agent capability matrix |
@@ -98,7 +98,7 @@ See [guard.yaml reference](design/AI_GUARD_SYSTEM_DESIGN.md) for full schema.
 | `ac-guard validation list` | List configured checks by stage |
 | `ac-guard validation report` | Check configuration report table |
 
-All check commands (`check`, `verify`, `status`) support `--format json` for machine-readable output in CI/CD pipelines.
+`ac-guard run` and `ac-guard status` support `--format json` for machine-readable output in CI/CD pipelines.
 
 ## How It Works
 
@@ -108,7 +108,7 @@ When the agent runs, its hook script loads the pre-built policy and matches each
 
 At commit and push time, pre-commit hooks run format, lint, naming, and custom checks. The agent cannot skip these because `git commit --no-verify` is itself a forbidden pattern.
 
-Check results can be posted as PR comments on GitHub, GitLab, Gitea, and Bitbucket via the `output.pr_report` configuration. When `enabled: true`, `check`, `verify`, and `gate run` automatically publish a comment on the associated PR after execution. If no PR can be identified in the current context (e.g. local branch, no PR open yet), the dispatch is silently skipped — no noise in local development.
+Check results can be posted as PR comments on GitHub, GitLab, Gitea, and Bitbucket via the `output.pr_report` configuration. When `enabled: true`, full-stage runs (`ac-guard run --stage <s>`, including hook-driven invocations) automatically publish a comment on the associated PR after execution. Single-check runs (`ac-guard run <name>`) deliberately skip PR posting to avoid noise during developer iteration. If no PR can be identified in the current context (e.g. local branch, no PR open yet), the dispatch is silently skipped — no noise in local development either.
 
 ## Roadmap
 
@@ -148,7 +148,7 @@ uv run ac-guard install --agent claude-code    # materialises runtime.json + Cla
 ```
 
 That's it — `ac-guard install` writes its own `.git/hooks/pre-commit` wrapper
-that delegates to `ac-guard gate run --stage commit`, so no separate
+that delegates to `ac-guard run --stage pre-commit`, so no separate
 `pre-commit install` step is needed. The committed [`guard.yaml`](guard.yaml)
 and [`CLAUDE.md`](CLAUDE.md) are the source of truth for agent behavior rules;
 everything under `.claude/hooks/`, `.ac-guard/`, and `.git/hooks/` is

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,11 +25,13 @@ pip install ac-guard
 ## 快速开始
 
 ```bash
-ac-guard init --language python          # 创建 guard.yaml
-ac-guard install --agent claude-code     # 生成规则 + hooks
-ac-guard check                           # 运行质量检查
-ac-guard check --format json             # CI 机器可读输出
-ac-guard ruleset fetch <url>#v1.0        # 拉取共享规则集
+ac-guard init --language python                       # 创建 guard.yaml
+ac-guard install --agent claude-code                  # 生成规则 + hooks
+ac-guard run --stage pre-commit                       # 运行提交阶段检查
+ac-guard run --stage pre-push                         # 运行推送阶段检查（含 build）
+ac-guard run --stage pre-commit --format json         # CI 机器可读输出
+ac-guard run mypy                                     # 按名运行单项检查
+ac-guard ruleset fetch <url>#v1.0                     # 拉取共享规则集
 ```
 
 第一次用？按
@@ -84,10 +86,8 @@ code:
 | `ac-guard install --agent <name>` | 生成规则、Hook 和配置 |
 | `ac-guard update` | 配置变更后重新生成 |
 | `ac-guard uninstall` | 移除生成的产物 |
-| `ac-guard check` | 运行提交阶段检查 |
-| `ac-guard verify` | 运行推送阶段验证 |
-| `ac-guard run <name>` | 运行单项检查 |
-| `ac-guard gate run --stage <s>` | Git Hook 入口 |
+| `ac-guard run --stage <s>` | 运行某个时刻的全部检查（也是生成的 git hook 调用入口）|
+| `ac-guard run <name>` | 按名运行单项检查（开发期迭代）|
 | `ac-guard status` | 安装状态与漂移检测 |
 | `ac-guard doctor` | 环境诊断 |
 | `ac-guard agents` | Agent 能力矩阵 |
@@ -98,7 +98,7 @@ code:
 | `ac-guard validation list` | 按阶段列出已配置的检查项 |
 | `ac-guard validation report` | 检查项配置报告表格 |
 
-所有检查命令（`check`、`verify`、`status`）支持 `--format json` 输出，用于 CI/CD 管道的机器可读格式。
+`ac-guard run` 和 `ac-guard status` 支持 `--format json` 输出，用于 CI/CD 管道的机器可读格式。
 
 ## 工作原理
 
@@ -108,7 +108,7 @@ Agent 工作时，Hook 脚本加载预构建的策略文件，将每个操作与
 
 提交和推送时，pre-commit Hook 运行格式化、Lint、命名和自定义检查。Agent 无法跳过这些检查，因为 `git commit --no-verify` 本身就是被禁止的模式。
 
-检查结果可通过 `output.pr_report` 配置自动发布到 GitHub、GitLab、Gitea 和 Bitbucket 的 PR 评论。开启 `enabled: true` 后，`check`、`verify`、`gate run` 执行结束会自动在关联 PR 上评论；当前环境识别不到 PR 时（例如本地分支、尚未开 PR），会静默跳过——本地开发无噪声。
+检查结果可通过 `output.pr_report` 配置自动发布到 GitHub、GitLab、Gitea 和 Bitbucket 的 PR 评论。开启 `enabled: true` 后，全 stage 跑（`ac-guard run --stage <s>`，含 git hook 触发的调用）执行结束会自动在关联 PR 上评论；单项检查（`ac-guard run <name>`）刻意不发，避免开发期迭代造成噪声。当前环境识别不到 PR 时（例如本地分支、尚未开 PR），会静默跳过——本地开发也无噪声。
 
 ## 路线图
 
@@ -148,7 +148,7 @@ uv run ac-guard install --agent claude-code    # 生成 runtime.json + Claude Co
 ```
 
 两条命令即可。`ac-guard install` 会写一个 `.git/hooks/pre-commit` 包装脚本
-（内部调用 `ac-guard gate run --stage commit`），不需要再单独 `pre-commit install`。
+（内部调用 `ac-guard run --stage pre-commit`），不需要再单独 `pre-commit install`。
 入库的 [`guard.yaml`](guard.yaml) 与 [`CLAUDE.md`](CLAUDE.md) 是 agent 行为规则的
 source of truth；`.claude/hooks/`、`.ac-guard/`、`.git/hooks/` 下的产物
 都是 per-machine 本地生成。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,8 +165,8 @@ your-python-project/
 │   └── runtime.json             # runtime policy cache
 ├── .claude/hooks/interceptor.py  # Claude Code pre_tool_use hook
 └── .git/hooks/
-    ├── pre-commit              # → ac-guard gate run --stage commit
-    └── pre-push                # → ac-guard gate run --stage push
+    ├── pre-commit              # → ac-guard run --stage pre-commit
+    └── pre-push                # → ac-guard run --stage pre-push
 ```
 
 Every file above is **managed**: re-running `ac-guard install` or
@@ -203,7 +203,7 @@ still receive the behavior rules as soft constraints in their rule document.
 
 ```bash
 git add -A
-ac-guard check
+ac-guard run --stage pre-commit
 ```
 
 On a clean codebase:
@@ -227,7 +227,7 @@ Stage and re-run:
 
 ```bash
 git add -A
-ac-guard check
+ac-guard run --stage pre-commit
 ```
 
 ```
@@ -241,7 +241,7 @@ Stage: pre-commit — FAILED
 For the actual violations, switch to the machine-readable format:
 
 ```bash
-ac-guard check --format json
+ac-guard run --stage pre-commit --format json
 ```
 
 ```json
@@ -265,7 +265,7 @@ ac-guard check --format json
 ```
 
 Delete `src/bad.py` and re-check — you're green again. The same
-`ac-guard check` runs automatically when you `git commit`, because the
+`ac-guard run --stage pre-commit` runs automatically when you `git commit`, because the
 generated `.git/hooks/pre-commit` invokes it. Agents also cannot bypass the
 gate with `git commit --no-verify`: ac-guard injects that pattern (and its
 `git push` counterpart) into `execute.forbidden` by default, so the

--- a/docs/getting-started_zh.md
+++ b/docs/getting-started_zh.md
@@ -158,8 +158,8 @@ your-python-project/
 │   └── runtime.json               # 运行时策略缓存
 ├── .claude/hooks/interceptor.py  # Claude Code pre_tool_use hook
 └── .git/hooks/
-    ├── pre-commit                # → ac-guard gate run --stage commit
-    └── pre-push                  # → ac-guard gate run --stage push
+    ├── pre-commit                # → ac-guard run --stage pre-commit
+    └── pre-push                  # → ac-guard run --stage pre-push
 ```
 
 上面每个文件都是 **由工具管理** 的：重跑 `ac-guard install` 或
@@ -193,7 +193,7 @@ opencode      yes     yes     AGENTS.md                         -
 
 ```bash
 git add -A
-ac-guard check
+ac-guard run --stage pre-commit
 ```
 
 干净代码上的输出：
@@ -217,7 +217,7 @@ def bad( x,y ):
 
 ```bash
 git add -A
-ac-guard check
+ac-guard run --stage pre-commit
 ```
 
 ```
@@ -231,7 +231,7 @@ Stage: pre-commit — FAILED
 想看具体违规，用机器可读格式：
 
 ```bash
-ac-guard check --format json
+ac-guard run --stage pre-commit --format json
 ```
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,11 @@ known-first-party = ["ac_guard"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "ANN", "ARG", "PLR0913", "C408", "TC"]  # relax requirements for tests
+# Typer CLI commands map each flag to a parameter, so commands that subsume
+# multiple modes (e.g. `run` covering single-check + full-stage) naturally
+# exceed max-args. The dataclass-bundle pattern (RunRequest in cli.check)
+# applies to the business layer; the Typer surface itself cannot use it.
+"src/ac_guard/cli/main.py" = ["PLR0913"]
 
 [tool.ruff.lint.pep8-naming]
 # Private conventions inherited from the retired scripts/checks/_config.py:

--- a/src/ac_guard/cli/check.py
+++ b/src/ac_guard/cli/check.py
@@ -1,23 +1,24 @@
-"""check, verify, run, and gate command implementations for AI Code Guard CLI.
+"""Unified ``ac-guard run`` command implementation.
 
-Provides CLI entry points for code quality checking, delegating to
-the code_gate module for execution and Reporter for output formatting.
+Thin rendering layer over ``ac_guard.code_gate``:
+
+- Positional ``<name>`` present → single-check path (``gate_check``);
+  no PR comment side effect.
+- ``<name>`` absent → full-stage path (``gate_stage``); posts PR
+  comment when configured.
+
+Both modes share argument parsing, config loading, and reporter
+plumbing. Side effects are determined by **scope** (single check vs
+full stage), not by command name.
 """
 
 from __future__ import annotations
 
-import subprocess
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ac_guard.code_gate import (
-    StageOptions,
-    get_changed_files,
-    run_check,
-    run_precommit,
-    run_stage,
-)
+from ac_guard.code_gate import GateOptions, gate_check, gate_stage
 from ac_guard.config import ConfigError, resolve_config
-from ac_guard.domain.models import CheckResult, StageOutcome
 from ac_guard.reporter import (
     FormatKind,
     GitPlatformCfg,
@@ -29,261 +30,111 @@ from ac_guard.reporter import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-__all__ = [
-    "check_command",
-    "gate_run_command",
-    "run_command",
-    "verify_command",
-]
+    from ac_guard.domain.models import StageOutcome
 
-_BUILTIN_CHECKS = frozenset({"format", "naming", "lint"})
-_NAMING_NOT_IMPLEMENTED_MSG = (
-    "Naming check is not yet implemented — tracked in "
-    "https://github.com/ikroal/ai-code-guard/issues/95"
-)
-
-# Stages where ac-guard provides bucket-aware orchestration (format/lint
-# shortcuts, build command, StageOutcome for reporter/audit). Other
-# gating stages delegate to ``pre-commit run --hook-stage`` via
-# ``_run_precommit_stage``. ``cli/status.py`` (doctor) imports this
-# constant for its stage-semantic-fit diagnostic.
-BUCKET_AWARE_STAGES: frozenset[str] = frozenset({"pre-commit", "pre-push"})
+__all__ = ["RunRequest", "run_command"]
 
 
-def check_command(
-    files: list[str],
-    config_path: Path,
-    *,
-    output_format: str = "text",
-) -> None:
-    """Execute the check command (commit-stage checks).
+@dataclass(frozen=True)
+class RunRequest:
+    """Bundle of inputs that drive a single ``ac-guard run`` invocation.
 
-    Args:
-        files: Explicit file list, or empty for auto-detect.
+    Bundling keeps :func:`run_command` within the project's argument-count
+    limits and makes the dispatch criteria (``name`` present? what stage?)
+    explicit at call sites.
+
+    Attributes:
+        name: Check name to run, or ``None`` for full-stage mode.
+        stage: Stage selector. In full-stage mode this is the gating
+            stage to run; in single-check mode this is a hint that
+            drives file collection.
+        files: Explicit file list (empty for auto-detect).
         config_path: Path to guard.yaml.
-        output_format: Output format (``"text"`` or ``"json"``).
+        skip_build: Suppress the build step (only meaningful when
+            ``stage == "pre-push"`` in full-stage mode).
+        output_format: ``"text"`` or ``"json"``.
+        argv: Stage-specific positional args forwarded by git hooks
+            (commit-msg uses it for the message file path). Only
+            consumed in full-stage mode.
     """
-    resolved = _load_config(config_path)
-    project_root = config_path.parent.resolve()
-    file_list = files or None
 
-    outcome = run_stage(
-        "pre-commit",
-        resolved.code,
-        project_root,
-        options=StageOptions(
-            files=file_list,
-            languages=list(resolved.languages),
-        ),
-    )
-
-    _report_to_terminal(outcome, output_format, resolved.output.locale)
-    _maybe_post_pr(outcome, resolved.output.pr_report, resolved.output.locale)
-    raise SystemExit(0 if outcome.passed else 1)
+    name: str | None
+    stage: str
+    files: list[str]
+    config_path: Path
+    skip_build: bool = False
+    output_format: str = "text"
+    argv: list[str] | None = None
 
 
-def verify_command(
-    skip_build: bool,
-    config_path: Path,
-    *,
-    output_format: str = "text",
-) -> None:
-    """Execute the verify command (push-stage validation).
+def run_command(request: RunRequest) -> None:
+    """Run quality checks (single check by name, or full stage via stage).
 
-    Args:
-        skip_build: Whether to skip the build step.
-        config_path: Path to guard.yaml.
-        output_format: Output format (``"text"`` or ``"json"``).
+    Dispatches to :func:`gate_check` or :func:`gate_stage` based on
+    whether ``request.name`` is set, and renders the resulting
+    ``StageOutcome`` via the reporter. Always raises ``SystemExit``.
     """
-    resolved = _load_config(config_path)
-    project_root = config_path.parent.resolve()
-    build_cmd = None if skip_build else resolved.build_command
+    resolved = _load_config(request.config_path)
+    project_root = request.config_path.parent.resolve()
 
-    outcome = run_stage(
-        "pre-push",
-        resolved.code,
-        project_root,
-        options=StageOptions(
-            build_command=build_cmd,
-            languages=list(resolved.languages),
-        ),
-    )
-
-    _report_to_terminal(outcome, output_format, resolved.output.locale)
-    _maybe_post_pr(outcome, resolved.output.pr_report, resolved.output.locale)
-    raise SystemExit(0 if outcome.passed else 1)
-
-
-def run_command(
-    name: str,
-    stage: str,
-    files: list[str],
-    config_path: Path,
-) -> None:
-    """Execute the run command (single check item).
-
-    Args:
-        name: Check name to run.
-        stage: Check stage ("pre-commit" or "pre-push").
-        files: Explicit file list, or empty for auto-detect.
-        config_path: Path to guard.yaml.
-    """
-    resolved = _load_config(config_path)
-    project_root = config_path.parent.resolve()
-    file_list = files or get_changed_files(stage, project_root)
-
-    # Built-in pre-commit shortcuts (format / naming / lint)
-    results: list = []
-    if name in _BUILTIN_CHECKS:
-        if name == "naming":
-            results.append(
-                CheckResult(
-                    name="naming",
-                    passed=True,
-                    skipped=True,
-                    output=_NAMING_NOT_IMPLEMENTED_MSG,
-                )
-            )
-        else:  # format or lint — iterate languages
-            results.extend(
-                run_precommit(f"{name}-{lang}", file_list, project_root)
-                for lang in resolved.languages
-            )
-            if not results:
-                # No languages configured — nothing to run
-                results.append(
-                    CheckResult(
-                        name=name,
-                        passed=True,
-                        skipped=True,
-                        output="No languages configured",
-                    )
-                )
+    if request.name is None:
+        outcome = _run_full_stage(request, resolved, project_root)
+        _report_to_terminal(outcome, request.output_format, resolved.output.locale)
+        _maybe_post_pr(outcome, resolved.output.pr_report, resolved.output.locale)
     else:
-        # Search custom checks across every gating stage bucket. A check
-        # ID is unique across the config; first hit wins.
-        check_item = None
-        for _stage_name, bucket in resolved.code.buckets():
-            if name in bucket.checks:
-                check_item = bucket.checks[name]
-                break
-        if check_item is None:
-            print(f"Error: Check '{name}' not found.")
-            available = [
-                check_name
-                for _stage_name, bucket in resolved.code.buckets()
-                for check_name in bucket.checks
-            ]
-            if available:
-                print(f"Available checks: {', '.join(available)}")
-            raise SystemExit(1)
-        results.append(run_check(name, check_item, file_list, project_root))
+        outcome = _run_single_check(request, resolved, project_root)
+        _report_to_terminal(outcome, request.output_format, resolved.output.locale)
 
-    passed = all(r.passed for r in results)
-    duration = sum(r.duration_ms for r in results)
-    outcome = StageOutcome(
-        stage=stage,
-        passed=passed,
-        results=results,
-        duration_ms=duration,
-    )
-
-    _report_to_terminal(outcome, "text", resolved.output.locale)
     raise SystemExit(0 if outcome.passed else 1)
 
 
-_GATING_STAGES = frozenset(
-    {"pre-commit", "commit-msg", "pre-merge-commit", "pre-push", "pre-rebase"}
-)
-
-
-def gate_run_command(
-    stage: str,
-    config_path: Path,
-    *,
-    argv: list[str] | None = None,
-) -> None:
-    """Execute the gate run command (Git Hook entry).
-
-    Args:
-        stage: One of the five pre-commit gating stages
-            (``pre-commit`` / ``commit-msg`` / ``pre-merge-commit`` /
-            ``pre-push`` / ``pre-rebase``). Schema-v1 values
-            (``commit`` / ``push``) are rejected.
-        config_path: Path to guard.yaml.
-        argv: Pass-through positional args (e.g. commit-msg hook
-            receives the message file path as $1).
-    """
-    if stage not in _GATING_STAGES:
-        print(
-            f"Error: unknown stage '{stage}'. Expected one of "
-            f"{sorted(_GATING_STAGES)}.",
-            flush=True,
-        )
-        raise SystemExit(2)
-
-    resolved = _load_config(config_path)
-    project_root = config_path.parent.resolve()
-
-    if stage in BUCKET_AWARE_STAGES:
-        build_cmd = resolved.build_command if stage == "pre-push" else None
-        outcome = run_stage(
-            stage,
+def _run_full_stage(request: RunRequest, resolved, project_root: Path) -> StageOutcome:
+    """Dispatch to ``gate_stage``, mapping ``ValueError`` to exit 2."""
+    build_command = (
+        None
+        if request.skip_build or request.stage != "pre-push"
+        else resolved.build_command
+    )
+    try:
+        return gate_stage(
+            request.stage,
             resolved.code,
             project_root,
-            options=StageOptions(
-                build_command=build_cmd,
+            options=GateOptions(
+                argv=request.argv,
+                build_command=build_command,
+                files=request.files or None,
                 languages=list(resolved.languages),
             ),
         )
-        _report_to_terminal(outcome, "text", resolved.output.locale)
-        _maybe_post_pr(outcome, resolved.output.pr_report, resolved.output.locale)
-        raise SystemExit(0 if outcome.passed else 1)
-
-    # commit-msg / pre-merge-commit / pre-rebase — ac-guard doesn't
-    # yet model these in its bucket-aware code_gate. Delegate to
-    # pre-commit's native stage runner; it reads the generated
-    # .pre-commit-config.yaml and executes hooks declared for this
-    # stage via their ``stages:`` field.
-    raise SystemExit(_run_precommit_stage(stage, project_root, argv=argv))
+    except ValueError as e:
+        print(f"Error: {e}", flush=True)
+        raise SystemExit(2) from None
 
 
-def _run_precommit_stage(
-    stage: str,
-    project_root: Path,
-    *,
-    argv: list[str] | None = None,
-) -> int:
-    """Delegate to ``pre-commit run --hook-stage <stage>`` and return its exit code.
-
-    Used by :func:`gate_run_command` for gating stages that ac-guard does
-    not model in its bucket-aware code_gate (``commit-msg`` /
-    ``pre-merge-commit`` / ``pre-rebase``). pre-commit reads the
-    generated ``.pre-commit-config.yaml`` and runs hooks declared at the
-    given stage via their ``stages:`` field; its stdout/stderr are not
-    captured so the user sees pre-commit's native output.
-
-    For ``commit-msg``, the first positional argv entry (the message
-    file path passed by git as ``$1``) is forwarded as
-    ``--commit-msg-filename``. Other stages always use ``--all-files``.
-    """
-    cmd = ["pre-commit", "run", "--hook-stage", stage]
-    if stage == "commit-msg" and argv:
-        cmd.extend(["--commit-msg-filename", argv[0]])
-    else:
-        cmd.append("--all-files")
-    result = subprocess.run(cmd, cwd=project_root, check=False)
-    return result.returncode
+def _run_single_check(
+    request: RunRequest, resolved, project_root: Path
+) -> StageOutcome:
+    """Dispatch to ``gate_check``, mapping ``KeyError`` to exit 1."""
+    try:
+        return gate_check(
+            request.name,
+            resolved.code,
+            project_root,
+            stage_hint=request.stage,
+            options=GateOptions(
+                files=request.files or None,
+                languages=list(resolved.languages),
+            ),
+        )
+    except KeyError as e:
+        message = e.args[0] if e.args else str(e)
+        print(f"Error: {message}")
+        raise SystemExit(1) from None
 
 
 def _report_to_terminal(outcome: StageOutcome, output_format: str, locale: str) -> None:
-    """Dispatch ``outcome`` to stdout via the reporter.
-
-    Args:
-        outcome: The check outcome.
-        output_format: ``"text"`` or ``"json"``.
-        locale: Label locale for text rendering (ignored for JSON).
-    """
+    """Dispatch ``outcome`` to stdout via the reporter."""
     fmt = FormatKind.JSON if output_format == "json" else FormatKind.TEXT
     report(
         outcome,
@@ -292,12 +143,7 @@ def _report_to_terminal(outcome: StageOutcome, output_format: str, locale: str) 
 
 
 def _maybe_post_pr(outcome: StageOutcome, pr_report, locale: str) -> None:
-    """Post the outcome to the configured Git platform if enabled.
-
-    Short-circuits when ``pr_report.enabled`` is ``False``. Otherwise
-    dispatches via :func:`reporter.report` with ``non_blocking=True`` so
-    HTTP/auth failures never affect the caller's exit code.
-    """
+    """Post the outcome to the configured Git platform if enabled."""
     if not pr_report.enabled:
         return
     report(
@@ -316,14 +162,7 @@ def _maybe_post_pr(outcome: StageOutcome, pr_report, locale: str) -> None:
 
 
 def _load_config(config_path: Path):
-    """Load and resolve config, handling errors.
-
-    Args:
-        config_path: Path to guard.yaml.
-
-    Returns:
-        ResolvedConfig.
-    """
+    """Load and resolve config, handling errors."""
     try:
         return resolve_config(config_path)
     except ConfigError as e:

--- a/src/ac_guard/cli/main.py
+++ b/src/ac_guard/cli/main.py
@@ -301,12 +301,12 @@ def run_cmd(
         typer.Option("--format", help="Output format: text or json"),
     ] = "text",
     message_file: Annotated[
-        Path | None,
+        str | None,
         typer.Option(
             "--message-file",
             help=(
                 "Commit message file path (commit-msg stage only; forwarded "
-                "to the managed framework as the inspection target)."
+                "verbatim to the managed framework as the inspection target)."
             ),
         ),
     ] = None,
@@ -320,7 +320,7 @@ def run_cmd(
             config_path=config,
             skip_build=skip_build,
             output_format=output_format,
-            argv=[str(message_file)] if message_file else None,
+            argv=[message_file] if message_file else None,
         )
     )
 

--- a/src/ac_guard/cli/main.py
+++ b/src/ac_guard/cli/main.py
@@ -6,12 +6,7 @@ from typing import Annotated
 import typer
 
 from ac_guard import __version__
-from ac_guard.cli.check import (
-    check_command,
-    gate_run_command,
-    run_command,
-    verify_command,
-)
+from ac_guard.cli.check import RunRequest, run_command
 from ac_guard.cli.init import init_command
 from ac_guard.cli.install import install_command, uninstall_command, update_command
 from ac_guard.cli.ruleset import (
@@ -268,55 +263,23 @@ def agents() -> None:
     agents_command(project_root=project_root)
 
 
-@app.command()
-def check(
-    files: Annotated[
-        list[str] | None,
-        typer.Option(
-            "--files",
-            help="Explicit file paths to check (default: staged files)",
-        ),
-    ] = None,
-    config: Annotated[
-        Path,
-        typer.Option("--config", "-c", help="Path to guard.yaml"),
-    ] = Path("guard.yaml"),
-    output_format: Annotated[
-        str,
-        typer.Option("--format", help="Output format: text or json"),
-    ] = "text",
-) -> None:
-    """Run commit-stage quality checks."""
-    check_command(files=files or [], config_path=config, output_format=output_format)
-
-
-@app.command()
-def verify(
-    skip_build: Annotated[
-        bool,
-        typer.Option("--skip-build", help="Skip the build step"),
-    ] = False,
-    config: Annotated[
-        Path,
-        typer.Option("--config", "-c", help="Path to guard.yaml"),
-    ] = Path("guard.yaml"),
-    output_format: Annotated[
-        str,
-        typer.Option("--format", help="Output format: text or json"),
-    ] = "text",
-) -> None:
-    """Run full push-stage validation (includes commit checks)."""
-    verify_command(
-        skip_build=skip_build, config_path=config, output_format=output_format
-    )
-
-
 @app.command(name="run")
-def run_single(
-    name: Annotated[str, typer.Argument(help="Check name to run")],
+def run_cmd(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Check name (omit for full-stage mode)"),
+    ] = None,
     stage: Annotated[
         str,
-        typer.Option("--stage", "-s", help="Check stage (pre-commit or pre-push)"),
+        typer.Option(
+            "--stage",
+            "-s",
+            help=(
+                "Gating stage. With <name>: file-collection hint "
+                "(pre-commit uses staged diff, others use origin/main..HEAD). "
+                "Without <name>: stage to run end-to-end."
+            ),
+        ),
     ] = "pre-commit",
     files: Annotated[
         list[str] | None,
@@ -326,42 +289,41 @@ def run_single(
         Path,
         typer.Option("--config", "-c", help="Path to guard.yaml"),
     ] = Path("guard.yaml"),
-) -> None:
-    """Run a single named check item."""
-    run_command(name=name, stage=stage, files=files or [], config_path=config)
-
-
-# gate subcommand group
-gate_app = typer.Typer(name="gate", help="Git Hook entry points.")
-
-
-@gate_app.command(
-    name="run",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-)
-def gate_run(
-    ctx: typer.Context,
-    stage: Annotated[
-        str,
+    skip_build: Annotated[
+        bool,
         typer.Option(
-            "--stage",
-            "-s",
+            "--skip-build",
+            help="Skip the build step (full-stage pre-push mode only)",
+        ),
+    ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: text or json"),
+    ] = "text",
+    message_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--message-file",
             help=(
-                "pre-commit gating stage (pre-commit / commit-msg / "
-                "pre-merge-commit / pre-push / pre-rebase)"
+                "Commit message file path (commit-msg stage only; forwarded "
+                "to the managed framework as the inspection target)."
             ),
         ),
-    ] = "pre-commit",
-    config: Annotated[
-        Path,
-        typer.Option("--config", "-c", help="Path to guard.yaml"),
-    ] = Path("guard.yaml"),
+    ] = None,
 ) -> None:
-    """Internal entry point for Git hooks."""
-    gate_run_command(stage=stage, config_path=config, argv=ctx.args)
+    """Run quality checks (single check by name, or full stage via --stage)."""
+    run_command(
+        RunRequest(
+            name=name,
+            stage=stage,
+            files=files or [],
+            config_path=config,
+            skip_build=skip_build,
+            output_format=output_format,
+            argv=[str(message_file)] if message_file else None,
+        )
+    )
 
-
-app.add_typer(gate_app)
 
 # ruleset subcommand group
 ruleset_app = typer.Typer(name="ruleset", help="Manage external rulesets.")

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
-from ac_guard.cli.check import BUCKET_AWARE_STAGES
+from ac_guard.code_gate import is_modeled_stage
 from ac_guard.config import ConfigError, load_config, resolve_config
 from ac_guard.domain.languages import detect_language
 from ac_guard.generator.core import read_state
@@ -534,7 +534,7 @@ def _check_stage_semantic_fit(resolved: ResolvedConfig, tally: _Tally) -> None:
     """
     offenders: list[tuple[str, str]] = []
     for stage_name, bucket in resolved.code.buckets():
-        if stage_name in BUCKET_AWARE_STAGES:
+        if is_modeled_stage(stage_name):
             continue
         if bucket.format:
             offenders.append((stage_name, "format"))

--- a/src/ac_guard/code_gate/__init__.py
+++ b/src/ac_guard/code_gate/__init__.py
@@ -1,25 +1,24 @@
-"""Code gate — git hook-time code quality orchestration (K2-K6).
+"""Code gate — git lifecycle code quality orchestration.
 
-Public API for running ac-guard-controlled code quality checks. This
-facade exposes the symbols that constitute the package's contract;
-importing from :mod:`ac_guard.code_gate.core` directly is reserved for
-white-box tests of internal helpers.
+Public contract: two domain operations (``gate_stage`` / ``gate_check``)
+that run a quality contract slice and return a verdict-bearing
+``StageOutcome``. Importing from :mod:`ac_guard.code_gate.core` is
+reserved for white-box tests of internal helpers.
 """
 
 from ac_guard.code_gate.core import (
-    StageOptions,
-    get_changed_files,
-    run_build,
-    run_check,
-    run_precommit,
-    run_stage,
+    GateOptions,
+    gate_check,
+    gate_stage,
+    is_modeled_stage,
 )
+from ac_guard.domain.models import CheckResult, StageOutcome
 
 __all__ = [
-    "StageOptions",
-    "get_changed_files",
-    "run_build",
-    "run_check",
-    "run_precommit",
-    "run_stage",
+    "CheckResult",
+    "GateOptions",
+    "StageOutcome",
+    "gate_check",
+    "gate_stage",
+    "is_modeled_stage",
 ]

--- a/src/ac_guard/code_gate/core.py
+++ b/src/ac_guard/code_gate/core.py
@@ -1,7 +1,32 @@
-"""Code gate core — check orchestration primitives (K2-K6).
+"""Code gate core — orchestration over git lifecycle moments.
 
-Orchestrates code quality checks across commit and push stages
-by delegating to pre-commit framework and custom check commands.
+Public API:
+    gate_stage(stage, config, project_root, *, options) -> StageOutcome
+        Run all checks configured for a git lifecycle moment.
+    gate_check(name, config, project_root, *, options) -> StageOutcome
+        Run a single named check (built-in shortcut or custom check).
+    is_modeled_stage(stage) -> bool
+        Whether ac-guard models the stage with a bucket-aware bucket
+        (vs. delegating to the underlying managed framework).
+    GateOptions
+        Optional refinements: explicit file list, language identifiers,
+        build command override.
+
+Internal layering:
+    Per-stage runtime processing is encapsulated in private strategy
+    objects (``_CommitStrategy`` / ``_PushStrategy`` / ``_DelegatedStrategy``)
+    behind the ``_StageStrategy`` Protocol. ``gate_stage`` is a one-line
+    dispatch into the strategy registry. Two execution backends sit
+    underneath: ``_run_managed_hook`` (single hook through the managed
+    framework) and ``_run_command`` (literal subprocess); a third
+    private path (``_delegate_managed_stage``) hands an entire stage
+    off to the managed framework for non-modeled stages.
+
+Errors:
+    ``gate_stage`` raises ``ValueError`` for unknown stage names.
+    ``gate_check`` raises ``KeyError`` (with available names listed)
+    when ``name`` is neither a built-in shortcut nor present in any
+    bucket. Callers (CLI / git hook scripts) decide how to render.
 """
 
 from __future__ import annotations
@@ -11,7 +36,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from ac_guard.domain.languages import TYPE_EXTENSIONS
 from ac_guard.domain.models import CheckResult, StageOutcome
@@ -19,103 +44,513 @@ from ac_guard.domain.models import CheckResult, StageOutcome
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from ac_guard.config import CheckItem, CodeConfig
+    from ac_guard.config import CheckItem, CodeConfig, StageBucket
 
 __all__ = [
-    "StageOptions",
-    "get_changed_files",
-    "run_build",
-    "run_check",
-    "run_precommit",
-    "run_stage",
+    "GateOptions",
+    "gate_check",
+    "gate_stage",
+    "is_modeled_stage",
 ]
 
 
-@dataclass(frozen=True)
-class StageOptions:
-    """Optional refinements for :func:`run_stage`.
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
 
-    Keeps the primary orchestration signature short while still allowing
-    callers to override the file list, language set, or build command
-    used by a stage run.
+
+@dataclass(frozen=True)
+class GateOptions:
+    """Optional refinements for :func:`gate_stage` and :func:`gate_check`.
 
     Attributes:
-        build_command: Shell command to execute for the build check
-            (``pre-push`` stage only). ``None`` disables the build.
+        argv: Stage-specific positional args forwarded by git hooks
+            (today only ``commit-msg`` uses it — git passes the
+            commit-message file path as ``$1``). Ignored for stages
+            ac-guard bucket-models.
+        build_command: Shell command for the build check (only used by
+            ``gate_stage("pre-push", ...)``). ``None`` disables the build.
         files: Explicit file list. ``None`` means auto-detect via git.
-        languages: Language identifiers used to resolve pre-commit hook
-            IDs (``format-<lang>`` / ``lint-<lang>``). ``None`` or empty
-            means format/lint shortcuts are silently skipped.
+        languages: Language identifiers used to expand ``format-<lang>``
+            and ``lint-<lang>`` hook IDs. ``None`` or empty means
+            format/lint shortcuts are silently skipped.
     """
 
+    argv: list[str] | None = None
     build_command: str | None = None
     files: list[str] | None = None
     languages: list[str] | None = None
 
 
-_DEFAULT_STAGE_OPTIONS = StageOptions()
+_DEFAULT_OPTIONS = GateOptions()
 
 
 # ---------------------------------------------------------------------------
-# K2: Get changed files
+# Constants
 # ---------------------------------------------------------------------------
 
 
-def get_changed_files(stage: str, project_root: Path) -> list[str]:
-    """Get list of changed files for the given stage.
+_BUILTIN_CHECKS: frozenset[str] = frozenset({"format", "naming", "lint"})
+_NAMING_NOT_IMPLEMENTED_MSG = (
+    "Naming check is not yet implemented — tracked in "
+    "https://github.com/ikroal/ai-code-guard/issues/95"
+)
+_BUILD_FAILED_SKIP_REASON = "Skipped: build failed"
+
+
+# ---------------------------------------------------------------------------
+# Stage strategies (private)
+# ---------------------------------------------------------------------------
+
+
+class _StageStrategy(Protocol):
+    """Per-stage runtime orchestration. Internal to code_gate."""
+
+    stage: str
+    is_modeled: bool
+
+    def run(
+        self,
+        config: CodeConfig,
+        project_root: Path,
+        options: GateOptions,
+    ) -> StageOutcome: ...
+
+
+class _CommitStrategy:
+    """pre-commit stage: format → lint → custom checks."""
+
+    stage = "pre-commit"
+    is_modeled = True
+
+    def run(
+        self,
+        config: CodeConfig,
+        project_root: Path,
+        options: GateOptions,
+    ) -> StageOutcome:
+        start = time.monotonic()
+        files = options.files
+        if files is None:
+            files = _get_changed_files(self.stage, project_root)
+        languages = list(options.languages or [])
+        results = _run_format_lint_checks(
+            config.pre_commit, files, project_root, languages
+        )
+        return _wrap_outcome(self.stage, results, start)
+
+
+class _PushStrategy:
+    """pre-push stage: pre-commit fail-fast → build → lint → custom checks."""
+
+    stage = "pre-push"
+    is_modeled = True
+
+    def __init__(self, commit_strategy: _CommitStrategy) -> None:
+        self._commit = commit_strategy
+
+    def run(
+        self,
+        config: CodeConfig,
+        project_root: Path,
+        options: GateOptions,
+    ) -> StageOutcome:
+        start = time.monotonic()
+        languages = list(options.languages or [])
+
+        # Phase 1: pre-commit fail-fast
+        commit_outcome = self._commit.run(
+            config,
+            project_root,
+            GateOptions(files=options.files, languages=languages),
+        )
+        if not commit_outcome.passed:
+            elapsed = int((time.monotonic() - start) * 1000)
+            return StageOutcome(
+                stage=self.stage,
+                passed=False,
+                results=commit_outcome.results,
+                duration_ms=elapsed,
+            )
+
+        # Phase 2: build → lint → custom checks
+        files = options.files
+        if files is None:
+            files = _get_changed_files(self.stage, project_root)
+        results = _run_push_checks(
+            config.pre_push, files, project_root, options.build_command, languages
+        )
+        return _wrap_outcome(self.stage, results, start)
+
+
+class _DelegatedStrategy:
+    """commit-msg / pre-merge-commit / pre-rebase: delegate to managed framework."""
+
+    is_modeled = False
+
+    def __init__(self, stage: str) -> None:
+        self.stage = stage
+
+    def run(
+        self,
+        config: CodeConfig,
+        project_root: Path,
+        options: GateOptions,
+    ) -> StageOutcome:
+        del config  # required by Protocol; delegated path doesn't read it
+        start = time.monotonic()
+        rc = _delegate_managed_stage(self.stage, project_root, argv=options.argv)
+        elapsed = int((time.monotonic() - start) * 1000)
+        return StageOutcome(
+            stage=self.stage,
+            passed=rc == 0,
+            results=[],
+            duration_ms=elapsed,
+        )
+
+
+# Module-private dispatch table
+_commit_strategy = _CommitStrategy()
+_STRATEGIES: dict[str, _StageStrategy] = {
+    "pre-commit": _commit_strategy,
+    "pre-push": _PushStrategy(_commit_strategy),
+    "commit-msg": _DelegatedStrategy("commit-msg"),
+    "pre-merge-commit": _DelegatedStrategy("pre-merge-commit"),
+    "pre-rebase": _DelegatedStrategy("pre-rebase"),
+}
+
+
+def _get_strategy(stage: str) -> _StageStrategy:
+    """Internal dispatch helper. Raises ValueError for unknown stages."""
+    if stage not in _STRATEGIES:
+        raise ValueError(
+            f"Unknown stage: {stage!r}. Expected one of {sorted(_STRATEGIES)}."
+        )
+    return _STRATEGIES[stage]
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoints
+# ---------------------------------------------------------------------------
+
+
+def is_modeled_stage(stage: str) -> bool:
+    """Return whether ``stage`` is a bucket-aware ac-guard stage.
+
+    Bucket-aware stages (``pre-commit`` / ``pre-push``) run through
+    ac-guard's own format/lint/check/build orchestration. Other gating
+    stages delegate to the underlying managed framework. Unknown stages
+    return ``False`` (total over all string inputs; doctor relies on
+    this for safe iteration).
+    """
+    strategy = _STRATEGIES.get(stage)
+    return strategy is not None and strategy.is_modeled
+
+
+def gate_stage(
+    stage: str,
+    config: CodeConfig,
+    project_root: Path,
+    *,
+    options: GateOptions = _DEFAULT_OPTIONS,
+) -> StageOutcome:
+    """Run all checks configured for a git lifecycle moment.
+
+    Dispatches to the per-stage strategy. Bucket-aware stages
+    (``pre-commit`` / ``pre-push``) run ac-guard's format/lint/check/build
+    orchestration; other gating stages delegate to the underlying managed
+    framework.
 
     Args:
-        stage: Check stage ("pre-commit" or "pre-push").
+        stage: One of ``pre-commit`` / ``commit-msg`` / ``pre-merge-commit``
+            / ``pre-push`` / ``pre-rebase``.
+        config: Code configuration tree with per-stage buckets.
         project_root: Path to project root directory.
+        options: Optional refinements (file list, languages, build command).
 
     Returns:
-        List of changed file paths relative to project root.
+        ``StageOutcome`` aggregating per-check results.
+
+    Raises:
+        ValueError: ``stage`` is not a known gating stage.
     """
-    if stage == "pre-commit":
-        cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
-    else:
-        # pre-push stage: diff against upstream
-        cmd = ["git", "diff", "origin/main..HEAD", "--name-only", "--diff-filter=ACMR"]
+    return _get_strategy(stage).run(config, project_root, options)
 
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=project_root,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
+
+def gate_check(
+    name: str,
+    config: CodeConfig,
+    project_root: Path,
+    *,
+    stage_hint: str = "pre-commit",
+    options: GateOptions = _DEFAULT_OPTIONS,
+) -> StageOutcome:
+    """Run a single named check (built-in shortcut or custom check).
+
+    Resolution order:
+        1. Built-in shortcuts: ``format`` / ``lint`` / ``naming``.
+            ``format`` and ``lint`` expand to per-language managed-hook
+            calls (``format-<lang>`` / ``lint-<lang>``) using
+            ``options.languages``. ``naming`` returns a single skipped
+            placeholder result (issue #95).
+        2. Custom checks: searches ``config.buckets()`` and runs the
+            first match as a literal command.
+
+    Args:
+        name: Check name (built-in or custom).
+        config: Code configuration tree.
+        project_root: Project root directory.
+        stage_hint: Stage to drive file collection when
+            ``options.files`` is ``None``. ``pre-commit`` uses the
+            staged diff; everything else uses ``origin/main..HEAD``.
+        options: Optional refinements (file list, languages).
+
+    Returns:
+        ``StageOutcome`` with ``stage="ad-hoc:<name>"``. Built-in
+        shortcuts may yield multiple per-language results.
+
+    Raises:
+        KeyError: ``name`` is neither a built-in shortcut nor a custom
+            check in any bucket. The message includes the available
+            check names so callers can render a useful error.
+    """
+    start = time.monotonic()
+    files = options.files
+    if files is None:
+        files = _get_changed_files(stage_hint, project_root)
+
+    results = _resolve_named_check(name, config, files, project_root, options)
+
+    elapsed = int((time.monotonic() - start) * 1000)
+    return StageOutcome(
+        stage=f"ad-hoc:{name}",
+        passed=all(r.passed for r in results),
+        results=results,
+        duration_ms=elapsed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bucket orchestration helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _wrap_outcome(stage: str, results: list[CheckResult], start: float) -> StageOutcome:
+    """Common helper: aggregate per-check results into a StageOutcome."""
+    elapsed = int((time.monotonic() - start) * 1000)
+    return StageOutcome(
+        stage=stage,
+        passed=all(r.passed for r in results),
+        results=results,
+        duration_ms=elapsed,
+    )
+
+
+def _run_format_lint_checks(
+    bucket: StageBucket,
+    files: list[str],
+    project_root: Path,
+    languages: list[str],
+) -> list[CheckResult]:
+    """Run a bucket: format → lint → custom checks.
+
+    Used by the pre-commit strategy. (pre-push has its own helper because
+    it injects build as a precondition and skips format.)
+    """
+    results: list[CheckResult] = []
+
+    if bucket.format:
+        results.extend(
+            _run_managed_hook(f"format-{lang}", files, project_root)
+            for lang in languages
         )
-        if result.returncode != 0:
-            return []
-        return [f for f in result.stdout.strip().split("\n") if f]
-    except (subprocess.TimeoutExpired, OSError):
-        return []
+
+    if bucket.lint:
+        results.extend(
+            _run_managed_hook(f"lint-{lang}", files, project_root) for lang in languages
+        )
+
+    for name, check_item in bucket.checks.items():
+        results.append(_run_check_item(name, check_item, files, project_root))
+
+    return results
+
+
+def _run_push_checks(
+    bucket: StageBucket,
+    files: list[str],
+    project_root: Path,
+    build_command: str | None,
+    languages: list[str],
+) -> list[CheckResult]:
+    """Run pre-push bucket: build → lint → custom (with build fail-fast).
+
+    Note: pre-push deliberately skips ``bucket.format`` — formatting is
+    expected to have happened during the pre-commit stage. Any
+    ``format: true`` on the pre-push bucket is silently ignored here.
+    """
+    results: list[CheckResult] = []
+
+    if build_command:
+        build_result = _run_build(build_command, project_root)
+        results.append(build_result)
+        if not build_result.passed:
+            _append_skipped_downstream(results, bucket, languages)
+            return results
+
+    if bucket.lint:
+        results.extend(
+            _run_managed_hook(f"lint-{lang}", files, project_root) for lang in languages
+        )
+
+    for name, check_item in bucket.checks.items():
+        results.append(_run_check_item(name, check_item, files, project_root))
+
+    return results
+
+
+def _append_skipped_downstream(
+    results: list[CheckResult],
+    bucket: StageBucket,
+    languages: list[str],
+) -> None:
+    """Mark lint + push.checks as skipped when build has already failed."""
+    if bucket.lint:
+        results.extend(
+            CheckResult(
+                name=f"pre-commit:lint-{lang}",
+                passed=True,
+                skipped=True,
+                output=_BUILD_FAILED_SKIP_REASON,
+            )
+            for lang in languages
+        )
+    results.extend(
+        CheckResult(
+            name=name,
+            passed=True,
+            skipped=True,
+            output=_BUILD_FAILED_SKIP_REASON,
+        )
+        for name in bucket.checks
+    )
 
 
 # ---------------------------------------------------------------------------
-# K3: Run pre-commit
+# Named-check resolution
 # ---------------------------------------------------------------------------
 
 
-def run_precommit(
+def _resolve_named_check(
+    name: str,
+    config: CodeConfig,
+    files: list[str],
+    project_root: Path,
+    options: GateOptions,
+) -> list[CheckResult]:
+    """Resolve ``name`` to one or more results.
+
+    Built-in shortcuts expand by language; custom checks resolve via
+    ``config.buckets()``. Raises ``KeyError`` if neither path matches.
+    """
+    if name == "naming":
+        return [
+            CheckResult(
+                name="naming",
+                passed=True,
+                skipped=True,
+                output=_NAMING_NOT_IMPLEMENTED_MSG,
+            )
+        ]
+
+    if name in {"format", "lint"}:
+        languages = list(options.languages or [])
+        if not languages:
+            return [
+                CheckResult(
+                    name=name,
+                    passed=True,
+                    skipped=True,
+                    output="No languages configured",
+                )
+            ]
+        return [
+            _run_managed_hook(f"{name}-{lang}", files, project_root)
+            for lang in languages
+        ]
+
+    for _stage_name, bucket in config.buckets():
+        if name in bucket.checks:
+            return [_run_check_item(name, bucket.checks[name], files, project_root)]
+
+    available = [
+        check_name
+        for _stage_name, bucket in config.buckets()
+        for check_name in bucket.checks
+    ]
+    raise KeyError(
+        f"Check {name!r} not found."
+        + (f" Available checks: {', '.join(available)}." if available else "")
+    )
+
+
+def _run_check_item(
+    name: str,
+    check_item: CheckItem,
+    files: list[str],
+    project_root: Path,
+) -> CheckResult:
+    """Adapt a ``CheckItem`` to ``_run_command``.
+
+    Owns CheckItem-specific concerns: ``enabled`` / ``types`` filtering,
+    ``pass_filenames`` substitution, and ``timeout`` selection. Then
+    hands a fully-rendered command to the literal-command runner.
+    """
+    if not check_item.enabled:
+        return CheckResult(name=name, passed=True, skipped=True, output="Disabled")
+
+    filtered = _filter_files_by_type(files, check_item.types)
+    if check_item.types and not filtered:
+        return CheckResult(
+            name=name, passed=True, skipped=True, output="No matching files"
+        )
+
+    rendered = check_item.command
+    if check_item.pass_filenames and filtered:
+        if "{files}" in rendered:
+            rendered = rendered.replace("{files}", " ".join(filtered))
+        else:
+            rendered = f"{rendered} {' '.join(filtered)}"
+
+    return _run_command(name, rendered, project_root, timeout=check_item.timeout)
+
+
+def _run_build(command: str, project_root: Path) -> CheckResult:
+    """Run the build command (literal shell, 600s timeout, fixed name)."""
+    return _run_command("build", command, project_root, timeout=600)
+
+
+# ---------------------------------------------------------------------------
+# Execution backends (private)
+# ---------------------------------------------------------------------------
+
+
+def _run_managed_hook(
     hook_id: str,
     files: list[str],
     project_root: Path,
 ) -> CheckResult:
-    """Run a pre-commit hook by ID.
+    """Run a single declarative hook through the managed framework.
 
-    Args:
-        hook_id: Pre-commit hook identifier (e.g., "ruff").
-        files: List of files to check.
-        project_root: Path to project root directory.
-
-    Returns:
-        CheckResult for the pre-commit hook run.
+    Today this calls the ``pre-commit`` Python framework. The function
+    name intentionally hides that — swapping the underlying runner
+    (Lefthook, custom runner) only touches this body.
     """
+    name = f"pre-commit:{hook_id}"
+
     if not shutil.which("pre-commit"):
         return CheckResult(
-            name=f"pre-commit:{hook_id}",
+            name=name,
             passed=True,
             skipped=True,
             output="pre-commit not installed",
@@ -123,7 +558,7 @@ def run_precommit(
 
     if not files:
         return CheckResult(
-            name=f"pre-commit:{hook_id}",
+            name=name,
             passed=True,
             skipped=True,
             output="No files to check",
@@ -143,7 +578,7 @@ def run_precommit(
         )
         elapsed = int((time.monotonic() - start) * 1000)
         return CheckResult(
-            name=f"pre-commit:{hook_id}",
+            name=name,
             passed=result.returncode == 0,
             duration_ms=elapsed,
             output=result.stdout + result.stderr,
@@ -151,64 +586,33 @@ def run_precommit(
     except subprocess.TimeoutExpired:
         elapsed = int((time.monotonic() - start) * 1000)
         return CheckResult(
-            name=f"pre-commit:{hook_id}",
+            name=name,
             passed=False,
             duration_ms=elapsed,
             output="Timed out after 120s",
         )
     except OSError as e:
         return CheckResult(
-            name=f"pre-commit:{hook_id}",
+            name=name,
             passed=False,
             output=str(e),
         )
 
 
-# ---------------------------------------------------------------------------
-# K4: Run custom check command
-# ---------------------------------------------------------------------------
-
-
-def run_check(
-    check_name: str,
-    check_item: CheckItem,
-    files: list[str],
+def _run_command(
+    name: str,
+    command: str,
     project_root: Path,
+    *,
+    timeout: int,
 ) -> CheckResult:
-    """Execute a custom check command.
+    """Run a literal shell command and capture its result.
 
-    Args:
-        check_name: Check identifier.
-        check_item: CheckItem with command, timeout, types.
-        files: List of changed files.
-        project_root: Path to project root directory.
-
-    Returns:
-        CheckResult for the command execution.
+    Pure subprocess wrapper: command construction (file substitution,
+    type filtering, etc.) is the caller's responsibility. Used by
+    ``_run_check_item`` (after rendering CheckItem fields) and
+    ``_run_build``.
     """
-    if not check_item.enabled:
-        return CheckResult(
-            name=check_name, passed=True, skipped=True, output="Disabled"
-        )
-
-    # Filter files by type if specified
-    filtered = _filter_files_by_type(files, check_item.types)
-    if check_item.types and not filtered:
-        return CheckResult(
-            name=check_name,
-            passed=True,
-            skipped=True,
-            output="No matching files",
-        )
-
-    # Build command
-    command = check_item.command
-    if check_item.pass_filenames and filtered:
-        if "{files}" in command:
-            command = command.replace("{files}", " ".join(filtered))
-        else:
-            command = f"{command} {' '.join(filtered)}"
-
     start = time.monotonic()
 
     try:
@@ -217,12 +621,12 @@ def run_check(
             cwd=project_root,
             capture_output=True,
             text=True,
-            timeout=check_item.timeout,
+            timeout=timeout,
             check=False,
         )
         elapsed = int((time.monotonic() - start) * 1000)
         return CheckResult(
-            name=check_name,
+            name=name,
             passed=result.returncode == 0,
             duration_ms=elapsed,
             output=result.stdout + result.stderr,
@@ -230,30 +634,74 @@ def run_check(
     except subprocess.TimeoutExpired:
         elapsed = int((time.monotonic() - start) * 1000)
         return CheckResult(
-            name=check_name,
+            name=name,
             passed=False,
             duration_ms=elapsed,
-            output=f"Timed out after {check_item.timeout}s",
+            output=f"Timed out after {timeout}s",
         )
     except OSError as e:
         return CheckResult(
-            name=check_name,
+            name=name,
             passed=False,
             output=str(e),
         )
 
 
-def _filter_files_by_type(files: list[str], types: list[str] | None) -> list[str]:
-    """Filter file list by type extensions.
+def _delegate_managed_stage(
+    stage: str,
+    project_root: Path,
+    *,
+    argv: list[str] | None = None,
+) -> int:
+    """Delegate an entire git stage to the managed framework.
 
-    Args:
-        files: List of file paths.
-        types: File type names (e.g., ["python", "typescript"]).
-            None means no filtering.
+    Used for stages ac-guard does not bucket-model (``commit-msg``,
+    ``pre-merge-commit``, ``pre-rebase``). Streams pre-commit's native
+    output (stdout/stderr not captured) and returns its exit code.
 
-    Returns:
-        Filtered file list.
+    For ``commit-msg``, the first ``argv`` entry (the message file path
+    that git passes as ``$1``) is forwarded as
+    ``--commit-msg-filename``. Other stages always use ``--all-files``.
     """
+    cmd = ["pre-commit", "run", "--hook-stage", stage]
+    if stage == "commit-msg" and argv:
+        cmd.extend(["--commit-msg-filename", argv[0]])
+    else:
+        cmd.append("--all-files")
+    result = subprocess.run(cmd, cwd=project_root, check=False)
+    return result.returncode
+
+
+# ---------------------------------------------------------------------------
+# File collection (private)
+# ---------------------------------------------------------------------------
+
+
+def _get_changed_files(stage: str, project_root: Path) -> list[str]:
+    """Return staged or push-range changed files via git."""
+    if stage == "pre-commit":
+        cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+    else:
+        cmd = ["git", "diff", "origin/main..HEAD", "--name-only", "--diff-filter=ACMR"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [f for f in result.stdout.strip().split("\n") if f]
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+
+
+def _filter_files_by_type(files: list[str], types: list[str] | None) -> list[str]:
+    """Filter ``files`` by file-type extensions (e.g. ``["python"]``)."""
     if types is None:
         return files
 
@@ -262,220 +710,3 @@ def _filter_files_by_type(files: list[str], types: list[str] | None) -> list[str
         valid_exts.update(TYPE_EXTENSIONS.get(t, frozenset({f".{t}"})))
 
     return [f for f in files if any(f.endswith(ext) for ext in valid_exts)]
-
-
-# ---------------------------------------------------------------------------
-# K5: Run build
-# ---------------------------------------------------------------------------
-
-
-def run_build(build_command: str, project_root: Path) -> CheckResult:
-    """Execute the build command.
-
-    Args:
-        build_command: Shell command to run.
-        project_root: Path to project root directory.
-
-    Returns:
-        CheckResult for the build execution.
-    """
-    start = time.monotonic()
-
-    try:
-        result = subprocess.run(
-            shlex.split(build_command),
-            cwd=project_root,
-            capture_output=True,
-            text=True,
-            timeout=600,
-            check=False,
-        )
-        elapsed = int((time.monotonic() - start) * 1000)
-        return CheckResult(
-            name="build",
-            passed=result.returncode == 0,
-            duration_ms=elapsed,
-            output=result.stdout + result.stderr,
-        )
-    except subprocess.TimeoutExpired:
-        elapsed = int((time.monotonic() - start) * 1000)
-        return CheckResult(
-            name="build",
-            passed=False,
-            duration_ms=elapsed,
-            output="Build timed out after 600s",
-        )
-    except OSError as e:
-        return CheckResult(
-            name="build",
-            passed=False,
-            output=str(e),
-        )
-
-
-# ---------------------------------------------------------------------------
-# K6: Run stage (orchestration)
-# ---------------------------------------------------------------------------
-
-
-def run_stage(
-    stage: str,
-    code_config: CodeConfig,
-    project_root: Path,
-    *,
-    options: StageOptions = _DEFAULT_STAGE_OPTIONS,
-) -> StageOutcome:
-    """Orchestrate all checks for a stage.
-
-    For pre-commit stage: format + lint + custom checks.
-    For pre-push stage: pre-commit first (fail-fast) + build + lint + custom.
-
-    Args:
-        stage: Check stage ("pre-commit" or "pre-push").
-        code_config: CodeConfig with enabled flags and checks.
-        project_root: Path to project root directory.
-        options: Optional refinements (build command, explicit file list,
-            language identifiers). See :class:`StageOptions`.
-
-    Returns:
-        StageOutcome with aggregated results.
-    """
-    start = time.monotonic()
-    langs = list(options.languages or [])
-
-    if stage == "pre-push":
-        # Fail-fast: run pre-commit stage first, propagating file/language
-        # overrides but suppressing the build command (pre-commit has no build).
-        commit_report = run_stage(
-            "pre-commit",
-            code_config,
-            project_root,
-            options=StageOptions(files=options.files, languages=langs),
-        )
-        if not commit_report.passed:
-            elapsed = int((time.monotonic() - start) * 1000)
-            return StageOutcome(
-                stage="pre-push",
-                passed=False,
-                results=commit_report.results,
-                duration_ms=elapsed,
-            )
-
-    files = options.files
-    if files is None:
-        files = get_changed_files(stage, project_root)
-    results: list[CheckResult] = []
-
-    if stage == "pre-commit":
-        results.extend(_run_commit_checks(code_config, files, project_root, langs))
-    else:
-        results.extend(
-            _run_push_checks(
-                code_config, files, project_root, options.build_command, langs
-            )
-        )
-
-    elapsed = int((time.monotonic() - start) * 1000)
-    passed = all(r.passed for r in results)
-
-    return StageOutcome(
-        stage=stage,
-        passed=passed,
-        results=results,
-        duration_ms=elapsed,
-    )
-
-
-_BUILD_FAILED_SKIP_REASON = "Skipped: build failed"
-
-
-def _run_commit_checks(
-    config: CodeConfig,
-    files: list[str],
-    project_root: Path,
-    languages: list[str],
-) -> list[CheckResult]:
-    """Run commit-stage (pre-commit bucket) checks.
-
-    Schema v2 (#123): reads ``config.pre_commit.*`` directly. The dead
-    ``naming`` shortcut (D8) is gone — ruff N-rules via ``lint: true``
-    replaced it.
-    """
-    results: list[CheckResult] = []
-    bucket = config.pre_commit
-
-    if bucket.format:
-        results.extend(
-            run_precommit(f"format-{lang}", files, project_root) for lang in languages
-        )
-
-    if bucket.lint:
-        results.extend(
-            run_precommit(f"lint-{lang}", files, project_root) for lang in languages
-        )
-
-    for name, check_item in bucket.checks.items():
-        results.append(run_check(name, check_item, files, project_root))
-
-    return results
-
-
-def _run_push_checks(
-    config: CodeConfig,
-    files: list[str],
-    project_root: Path,
-    build_command: str | None,
-    languages: list[str],
-) -> list[CheckResult]:
-    """Run push-stage (pre-push bucket) checks.
-
-    Build is a precondition: if it fails, lint and custom push checks
-    are not executed and are instead appended as ``skipped`` results
-    with a ``Skipped: build failed`` marker.
-    """
-    results: list[CheckResult] = []
-    bucket = config.pre_push
-
-    if build_command:
-        build_result = run_build(build_command, project_root)
-        results.append(build_result)
-        if not build_result.passed:
-            _append_skipped_downstream(results, config, languages)
-            return results
-
-    if bucket.lint:
-        results.extend(
-            run_precommit(f"lint-{lang}", files, project_root) for lang in languages
-        )
-
-    for name, check_item in bucket.checks.items():
-        results.append(run_check(name, check_item, files, project_root))
-
-    return results
-
-
-def _append_skipped_downstream(
-    results: list[CheckResult],
-    config: CodeConfig,
-    languages: list[str],
-) -> None:
-    """Mark lint + push.checks as skipped when build has already failed."""
-    if config.pre_push.lint:
-        results.extend(
-            CheckResult(
-                name=f"pre-commit:lint-{lang}",
-                passed=True,
-                skipped=True,
-                output=_BUILD_FAILED_SKIP_REASON,
-            )
-            for lang in languages
-        )
-    results.extend(
-        CheckResult(
-            name=name,
-            passed=True,
-            skipped=True,
-            output=_BUILD_FAILED_SKIP_REASON,
-        )
-        for name in config.pre_push.checks
-    )

--- a/src/ac_guard/generator/_templates/git_hooks/commit-msg.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/commit-msg.j2
@@ -6,4 +6,4 @@
 # Receives the commit message file path as $1; forward to the gate
 # runner so pre-commit hooks for the commit-msg stage can inspect it.
 
-ac-guard gate run --stage commit-msg "$@"
+ac-guard run --stage commit-msg --message-file "$1"

--- a/src/ac_guard/generator/_templates/git_hooks/pre-commit.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-commit.j2
@@ -3,4 +3,4 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
-ac-guard gate run --stage pre-commit
+ac-guard run --stage pre-commit

--- a/src/ac_guard/generator/_templates/git_hooks/pre-merge-commit.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-merge-commit.j2
@@ -3,4 +3,4 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
-ac-guard gate run --stage pre-merge-commit
+ac-guard run --stage pre-merge-commit

--- a/src/ac_guard/generator/_templates/git_hooks/pre-push.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-push.j2
@@ -3,4 +3,4 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
-ac-guard gate run --stage pre-push
+ac-guard run --stage pre-push

--- a/src/ac_guard/generator/_templates/git_hooks/pre-rebase.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-rebase.j2
@@ -3,4 +3,4 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
-ac-guard gate run --stage pre-rebase
+ac-guard run --stage pre-rebase

--- a/tests/integration/test_code_gate_e2e.py
+++ b/tests/integration/test_code_gate_e2e.py
@@ -91,21 +91,19 @@ class TestFullCheckLifecycle:
         assert r.exit_code == 0
 
         # check (commit stage)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
 
         # verify (push stage)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["verify", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-push", "-c", str(config)])
         assert r.exit_code == 0
 
         # gate run (commit)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(
-                app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
-            )
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
 
@@ -121,16 +119,16 @@ class TestFullCheckLifecycle:
         (tmp_path / ".git").mkdir()
         runner.invoke(app, ["install", "-a", "claude-code", "-c", str(config)])
 
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
 
         # Change to failing check
         _config_with_checks(tmp_path, fail=True)
         runner.invoke(app, ["update", "-c", str(config)])
 
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 1
         assert "FAILED" in r.output
 
@@ -146,16 +144,16 @@ class TestCheckCommand:
     def test_default_config_passes(self, tmp_path: Path) -> None:
         """B1: Default config with no files → all checks pass."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
 
     def test_custom_check_fails(self, tmp_path: Path) -> None:
         """B2: Failing custom check → exit 1 + FAILED."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 1
         assert "FAILED" in r.output
         assert "custom-commit" in r.output
@@ -164,12 +162,17 @@ class TestCheckCommand:
         """B3: --files passes explicit file list."""
         config = _write_config(tmp_path)
         with patch("ac_guard.code_gate.core.shutil.which", return_value=None):
-            r = runner.invoke(app, ["check", "--files", "a.py", "-c", str(config)])
+            r = runner.invoke(
+                app,
+                ["run", "--stage", "pre-commit", "--files", "a.py", "-c", str(config)],
+            )
         assert r.exit_code == 0
 
     def test_missing_config(self, tmp_path: Path) -> None:
         """B4: Missing guard.yaml → exit 1."""
-        r = runner.invoke(app, ["check", "-c", str(tmp_path / "guard.yaml")])
+        r = runner.invoke(
+            app, ["run", "--stage", "pre-commit", "-c", str(tmp_path / "guard.yaml")]
+        )
         assert r.exit_code == 1
 
 
@@ -184,15 +187,15 @@ class TestVerifyCommand:
     def test_push_all_pass(self, tmp_path: Path) -> None:
         """C1: Push stage all passing → exit 0."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["verify", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-push", "-c", str(config)])
         assert r.exit_code == 0
 
     def test_commit_fail_fast(self, tmp_path: Path) -> None:
         """C2: Commit failure → push not reached."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["verify", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-push", "-c", str(config)])
         assert r.exit_code == 1
         # Push-only check should NOT appear (fail-fast)
         assert "custom-push" not in r.output
@@ -200,8 +203,10 @@ class TestVerifyCommand:
     def test_skip_build(self, tmp_path: Path) -> None:
         """C3: --skip-build skips build step."""
         config = _write_config(tmp_path, {"build": {"command": "exit 1"}})
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["verify", "--skip-build", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(
+                app, ["run", "--stage", "pre-push", "--skip-build", "-c", str(config)]
+            )
         assert r.exit_code == 0
 
     def test_build_command_runs(self, tmp_path: Path) -> None:
@@ -216,8 +221,8 @@ class TestVerifyCommand:
                 },
             },
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["verify", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-push", "-c", str(config)])
         assert r.exit_code == 0
         assert "build" in r.output.lower()
 
@@ -248,8 +253,11 @@ class TestVerifyCommand:
                 },
             },
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]):
-            r = runner.invoke(app, ["verify", "-c", str(config), "--format", "json"])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]):
+            r = runner.invoke(
+                app,
+                ["run", "--stage", "pre-push", "-c", str(config), "--format", "json"],
+            )
         assert r.exit_code == 1
         data = json_mod.loads(r.output)
         names = {item["name"]: item for item in data["results"]}
@@ -271,14 +279,14 @@ class TestRunCommand:
     def test_builtin_format(self, tmp_path: Path) -> None:
         """D1: Running built-in format (skipped with no files)."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "format", "-c", str(config)])
         assert r.exit_code == 0
 
     def test_custom_check_pass(self, tmp_path: Path) -> None:
         """D2: Running a passing custom check."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "custom-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "custom-commit" in r.output
@@ -286,7 +294,7 @@ class TestRunCommand:
     def test_custom_check_fail(self, tmp_path: Path) -> None:
         """D3: Running a failing custom check."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "custom-commit", "-c", str(config)])
         assert r.exit_code == 1
 
@@ -309,10 +317,8 @@ class TestGateCommand:
     def test_commit_passed(self, tmp_path: Path) -> None:
         """E1: Commit stage pass → minimal 'passed' + exit 0."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(
-                app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
-            )
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
         # Gate output should be minimal (no PASS/FAIL indicators)
@@ -321,18 +327,16 @@ class TestGateCommand:
     def test_commit_failed(self, tmp_path: Path) -> None:
         """E2: Commit stage fail → minimal 'FAILED' + exit 1."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(
-                app, ["gate", "run", "-s", "pre-commit", "-c", str(config)]
-            )
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 1
         assert "FAILED" in r.output
 
     def test_push_passed(self, tmp_path: Path) -> None:
         """E3: Push stage pass → exit 0."""
         config = _config_with_checks(tmp_path, fail=False)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["gate", "run", "-s", "pre-push", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-push", "-c", str(config)])
         assert r.exit_code == 0
 
 
@@ -367,13 +371,15 @@ class TestMultiLanguageE2E:
             ),
             encoding="utf-8",
         )
-        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core._run_managed_hook") as mock_run:
             stub = CheckResult(name="stub", passed=True, duration_ms=0)
             mock_run.return_value = stub
             with patch(
-                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
+                "ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]
             ):
-                r = runner.invoke(app, ["verify", "-c", str(config)])
+                r = runner.invoke(
+                    app, ["run", "--stage", "pre-push", "-c", str(config)]
+                )
         assert r.exit_code == 0
         hook_ids = {call.args[0] for call in mock_run.call_args_list}
         assert {
@@ -386,12 +392,14 @@ class TestMultiLanguageE2E:
     def test_single_language_auto_populated(self, tmp_path: Path) -> None:
         """Only project.language configured → auto-populate fills defaults."""
         config = _write_config(tmp_path)  # project.language: python, no languages
-        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
+        with patch("ac_guard.code_gate.core._run_managed_hook") as mock_run:
             mock_run.return_value = CheckResult(name="stub", passed=True, duration_ms=0)
             with patch(
-                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
+                "ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]
             ):
-                r = runner.invoke(app, ["check", "-c", str(config)])
+                r = runner.invoke(
+                    app, ["run", "--stage", "pre-commit", "-c", str(config)]
+                )
         assert r.exit_code == 0
         hook_ids = [call.args[0] for call in mock_run.call_args_list]
         assert "format-python" in hook_ids
@@ -505,8 +513,8 @@ class TestLocalePropagation:
                 },
             },
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "阶段: pre-commit — 通过" in r.output
         assert "项检查通过" in r.output
@@ -514,8 +522,8 @@ class TestLocalePropagation:
 
     def test_default_locale_keeps_english_output(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)  # no locale → defaults to en
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
         assert "PASSED" in r.output
         assert "checks passed" in r.output
@@ -528,8 +536,8 @@ class TestReportFormats:
     def test_terminal_has_details(self, tmp_path: Path) -> None:
         """F1: Terminal output includes check details and counts."""
         config = _config_with_checks(tmp_path, fail=True)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            r = runner.invoke(app, ["check", "-c", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert "FAIL" in r.output
         assert "custom-commit" in r.output
         # Should have pass/fail count

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -17,7 +17,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ac_guard.cli.main import app
-from ac_guard.code_gate import run_stage
+from ac_guard.code_gate import gate_stage
 from ac_guard.reporter import (
     ChannelError,
     GitPlatformCfg,
@@ -95,7 +95,7 @@ class TestPrReportFlow:
         resolved_config = _resolve(config)
 
         # Run real code_gate
-        outcome = run_stage("pre-commit", resolved_config.code, tmp_path)
+        outcome = gate_stage("pre-commit", resolved_config.code, tmp_path)
 
         # Markdown should render without error (sanity check the formatter)
         markdown = format_markdown(outcome)
@@ -138,7 +138,7 @@ class TestPrReportFlow:
         """D1-2: report(non_blocking=True) → delivery failure does not raise."""
         config = _init_and_install(tmp_path)
         resolved_config = _resolve(config)
-        outcome = run_stage("pre-commit", resolved_config.code, tmp_path)
+        outcome = gate_stage("pre-commit", resolved_config.code, tmp_path)
 
         # No env vars → channel will fail. non_blocking=True must absorb it.
         with patch.dict("os.environ", {}, clear=False):
@@ -171,7 +171,16 @@ class TestJsonOutput:
         config = _init_and_install(tmp_path)
 
         result = runner.invoke(
-            app, ["check", "--config", str(config), "--format", "json"]
+            app,
+            [
+                "run",
+                "--stage",
+                "pre-commit",
+                "--config",
+                str(config),
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 0
 
@@ -216,7 +225,16 @@ class TestJsonOutput:
         )
 
         result = runner.invoke(
-            app, ["check", "--config", str(config), "--format", "json"]
+            app,
+            [
+                "run",
+                "--stage",
+                "pre-commit",
+                "--config",
+                str(config),
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 1
 
@@ -317,12 +335,14 @@ class TestCliPrReportIntegration:
         """D4-1: guard check with pr_report.enabled=true → Channel.send called."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,
         ):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 0
         assert mock_send.call_count == 1
         markdown_arg = mock_send.call_args[0][0]
@@ -335,13 +355,13 @@ class TestCliPrReportIntegration:
         """D4-2: guard gate run with pr_report.enabled=true → Channel.send called."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,
         ):
             result = runner.invoke(
-                app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
             )
         assert result.exit_code == 0
         assert mock_send.call_count == 1
@@ -350,14 +370,16 @@ class TestCliPrReportIntegration:
         """D4-3: NoPrContextError from channel.send → no stderr warning."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output",
                 side_effect=NoPrContextError("Cannot determine PR number"),
             ),
         ):
             result = runner.invoke(
-                app, ["check", "--config", str(config)], catch_exceptions=False
+                app,
+                ["run", "--stage", "pre-commit", "--config", str(config)],
+                catch_exceptions=False,
             )
         assert result.exit_code == 0
         combined = result.output + (
@@ -372,7 +394,7 @@ class TestCliPrReportIntegration:
         """D4-4: Non-NoPrContext ChannelError → stderr warning preserved."""
         config = _write_config_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output",
                 side_effect=ChannelError("GitHub API returned 500"),
@@ -380,7 +402,9 @@ class TestCliPrReportIntegration:
         ):
             # CliRunner merges stdout+stderr by default; check full output
             result = runner.invoke(
-                app, ["check", "--config", str(config)], catch_exceptions=False
+                app,
+                ["run", "--stage", "pre-commit", "--config", str(config)],
+                catch_exceptions=False,
             )
         assert result.exit_code == 0
         combined = result.output + (
@@ -395,12 +419,14 @@ class TestCliPrReportIntegration:
         """D4-5: pr_report.enabled=false → channel.send never invoked."""
         config = _write_config_pr_report(tmp_path, enabled=False)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch(
                 "ac_guard.reporter.channels.github.GitHubChannel.output"
             ) as mock_send,
         ):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 0
         assert mock_send.call_count == 0
 

--- a/tests/unit/test_cli/test_check.py
+++ b/tests/unit/test_cli/test_check.py
@@ -1,7 +1,15 @@
-"""Tests for check, verify, run, and gate commands (WP3.3)."""
+"""Tests for the unified ``ac-guard run`` command.
+
+Two operating modes share one command surface:
+
+- Single-check (positional ``<name>``) → ``gate_check``; no PR comment.
+- Full-stage (``--stage X`` only) → ``gate_stage``; posts PR comment
+  when configured.
+"""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -56,63 +64,134 @@ def _write_config_with_checks(tmp_path: Path) -> Path:
     return config
 
 
+def _write_failing_commit_config(tmp_path: Path) -> Path:
+    """Write guard.yaml with a single failing custom check on pre-commit."""
+    config = tmp_path / "guard.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "project": {"name": "test", "language": "python"},
+                "code": {
+                    "pre-commit": {
+                        "format": False,
+                        "checks": {"fail": {"command": "exit 1"}},
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
 # ---------------------------------------------------------------------------
-# TestCheckCommand
+# TestRunFullStage — full-stage mode (no <name>, --stage required)
 # ---------------------------------------------------------------------------
 
 
-class TestCheckCommand:
-    """Tests for guard check command."""
+class TestRunFullStage:
+    """``ac-guard run --stage X`` (full-stage mode)."""
 
-    def test_check_passed(self, tmp_path: Path) -> None:
-        """Passing checks return exit 0 and PASSED."""
+    def test_pre_commit_passed(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 0
         assert "PASSED" in result.output
 
-    def test_check_failed(self, tmp_path: Path) -> None:
-        """Failing checks return exit 1 and FAILED."""
-        config = _write_config_with_checks(tmp_path)
-        # Add a failing check to commit stage
-        config.write_text(
-            yaml.dump(
-                {
-                    "version": 1,
-                    "project": {"name": "test", "language": "python"},
-                    "code": {
-                        "pre-commit": {
-                            "format": False,
-                            "checks": {"fail": {"command": "exit 1"}},
-                        },
-                    },
-                },
-                default_flow_style=False,
-            ),
-            encoding="utf-8",
-        )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+    def test_pre_commit_failed(self, tmp_path: Path) -> None:
+        config = _write_failing_commit_config(tmp_path)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 1
         assert "FAILED" in result.output
 
-    def test_check_no_config(self, tmp_path: Path) -> None:
+    def test_pre_push_passed(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-push", "--config", str(config)]
+            )
+        assert result.exit_code == 0
+        assert "PASSED" in result.output
+
+    def test_pre_push_skip_build(self, tmp_path: Path) -> None:
+        """--skip-build suppresses the build step on pre-push."""
+        config = _write_config(tmp_path)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(
+                app,
+                [
+                    "run",
+                    "--stage",
+                    "pre-push",
+                    "--skip-build",
+                    "--config",
+                    str(config),
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_unknown_stage_exits_2(self, tmp_path: Path) -> None:
+        """gate_stage raises ValueError for unknown stages → exit 2."""
+        config = _write_config(tmp_path)
+        result = runner.invoke(
+            app, ["run", "--stage", "post-commit", "--config", str(config)]
+        )
+        assert result.exit_code == 2
+        assert "Unknown stage" in result.output
+
+    def test_no_config_exits_1(self, tmp_path: Path) -> None:
         """Missing guard.yaml exits with error."""
         config = tmp_path / "guard.yaml"
-        result = runner.invoke(app, ["check", "--config", str(config)])
+        result = runner.invoke(
+            app, ["run", "--stage", "pre-commit", "--config", str(config)]
+        )
         assert result.exit_code == 1
 
-    def test_check_with_files(self, tmp_path: Path) -> None:
-        """--files option passes files to code_gate."""
+
+# ---------------------------------------------------------------------------
+# TestRunSingleCheck — single-check mode (positional <name>)
+# ---------------------------------------------------------------------------
+
+
+class TestRunSingleCheck:
+    """``ac-guard run <name>`` (single-check mode)."""
+
+    def test_run_builtin_format(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)
-        # With format/naming enabled and explicit files, pre-commit will
-        # be called but skip (no pre-commit config in tmp_path)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["run", "format", "--config", str(config)])
+        assert result.exit_code == 0
+
+    def test_run_custom_check(self, tmp_path: Path) -> None:
+        config = _write_config_with_checks(tmp_path)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])
+        assert result.exit_code == 0
+
+    def test_run_not_found_exits_1(self, tmp_path: Path) -> None:
+        """gate_check raises KeyError → exit 1 with available names."""
+        config = _write_config_with_checks(tmp_path)
+        result = runner.invoke(app, ["run", "nonexistent", "--config", str(config)])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_run_with_explicit_files(self, tmp_path: Path) -> None:
+        """--files overrides auto-detection."""
+        config = _write_config(tmp_path)
         with patch("ac_guard.code_gate.core.shutil.which", return_value=None):
             result = runner.invoke(
                 app,
                 [
-                    "check",
+                    "run",
+                    "format",
                     "--files",
                     "a.py",
                     "--files",
@@ -123,236 +202,93 @@ class TestCheckCommand:
             )
         assert result.exit_code == 0
 
-
-# ---------------------------------------------------------------------------
-# TestVerifyCommand
-# ---------------------------------------------------------------------------
-
-
-class TestVerifyCommand:
-    """Tests for guard verify command."""
-
-    def test_verify_passed(self, tmp_path: Path) -> None:
-        """Passing verify returns exit 0."""
-        config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(app, ["verify", "--config", str(config)])
-        assert result.exit_code == 0
-        assert "PASSED" in result.output
-
-    def test_verify_skip_build(self, tmp_path: Path) -> None:
-        """--skip-build skips build step."""
-        config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(
-                app, ["verify", "--skip-build", "--config", str(config)]
-            )
-        assert result.exit_code == 0
-
-
-# ---------------------------------------------------------------------------
-# TestRunCommand
-# ---------------------------------------------------------------------------
-
-
-class TestRunCommand:
-    """Tests for guard run <name> command."""
-
-    def test_run_builtin_format(self, tmp_path: Path) -> None:
-        """Running built-in format check."""
-        config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(app, ["run", "format", "--config", str(config)])
-        # pre-commit skipped (no files) → passed
-        assert result.exit_code == 0
-
-    def test_run_custom_check(self, tmp_path: Path) -> None:
-        """Running a custom check by name."""
+    def test_run_stage_hint_routes_file_diff(self, tmp_path: Path) -> None:
+        """--stage hint changes the diff range used for file collection."""
         config = _write_config_with_checks(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])
-        assert result.exit_code == 0
-
-    def test_run_not_found(self, tmp_path: Path) -> None:
-        """Running non-existent check exits with error."""
-        config = _write_config(tmp_path)
-        result = runner.invoke(app, ["run", "nonexistent", "--config", str(config)])
-        assert result.exit_code == 1
-        assert "not found" in result.output
+        with patch(
+            "ac_guard.code_gate.core._get_changed_files", return_value=[]
+        ) as mock_get:
+            runner.invoke(
+                app,
+                [
+                    "run",
+                    "echo-test",
+                    "--stage",
+                    "pre-push",
+                    "--config",
+                    str(config),
+                ],
+            )
+        assert mock_get.call_args.args[0] == "pre-push"
 
 
 # ---------------------------------------------------------------------------
-# TestGateRunCommand
+# TestRunArgvPassthrough — commit-msg argv via `--`
 # ---------------------------------------------------------------------------
 
 
-class TestGateRunCommand:
-    """Tests for guard gate run command."""
+class TestRunArgvPassthrough:
+    """commit-msg hook forwards ``$1`` via ``--message-file``."""
 
-    def test_gate_commit_passed(self, tmp_path: Path) -> None:
-        """Gate run with passing checks outputs minimal text."""
+    def test_commit_msg_forwards_argv_to_delegation(self, tmp_path: Path) -> None:
+        """``run --stage commit-msg --message-file X`` reaches _delegate_managed_stage."""
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch(
+            "ac_guard.code_gate.core._delegate_managed_stage", return_value=0
+        ) as mock_delegate:
             result = runner.invoke(
-                app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
+                app,
+                [
+                    "run",
+                    "--stage",
+                    "commit-msg",
+                    "--config",
+                    str(config),
+                    "--message-file",
+                    "/tmp/COMMIT_EDITMSG",
+                ],
             )
         assert result.exit_code == 0
-        assert "PASSED" in result.output
+        assert mock_delegate.call_args.kwargs["argv"] == ["/tmp/COMMIT_EDITMSG"]
 
-    def test_gate_commit_failed(self, tmp_path: Path) -> None:
-        """Gate run with failing checks exits 1."""
-        config = tmp_path / "guard.yaml"
-        config.write_text(
-            yaml.dump(
-                {
-                    "version": 1,
-                    "project": {"name": "test", "language": "python"},
-                    "code": {
-                        "pre-commit": {
-                            "format": False,
-                            "checks": {"fail": {"command": "exit 1"}},
-                        },
-                    },
-                },
-                default_flow_style=False,
-            ),
-            encoding="utf-8",
-        )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(
-                app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
-            )
-        assert result.exit_code == 1
-        assert "FAILED" in result.output
 
-    def test_gate_push(self, tmp_path: Path) -> None:
-        """Gate run push stage works."""
+# ---------------------------------------------------------------------------
+# TestRunJsonOutput — --format json (full-stage mode)
+# ---------------------------------------------------------------------------
+
+
+class TestRunJsonOutput:
+    """``--format json`` produces machine-readable output for full-stage runs."""
+
+    def test_pre_commit_json(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             result = runner.invoke(
-                app, ["gate", "run", "--stage", "pre-push", "--config", str(config)]
-            )
-        assert result.exit_code == 0
-        assert "PASSED" in result.output
-
-
-class TestRunPrecommitStage:
-    """White-box tests for cli/check.py _run_precommit_stage helper.
-
-    Covers the D3b passthrough path used by gate_run_command for stages
-    not in BUCKET_AWARE_STAGES (commit-msg / pre-merge-commit /
-    pre-rebase). The helper delegates to ``pre-commit run --hook-stage``
-    and propagates its exit code.
-    """
-
-    def test_returns_subprocess_returncode(self, tmp_path: Path) -> None:
-        """Exit code from the pre-commit subprocess propagates verbatim."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=42)
-            assert _run_precommit_stage("pre-rebase", tmp_path) == 42
-
-    def test_invokes_pre_commit_with_hook_stage(self, tmp_path: Path) -> None:
-        """Command starts with `pre-commit run --hook-stage <stage>`."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=0)
-            _run_precommit_stage("pre-merge-commit", tmp_path)
-            cmd = mock_run.call_args.args[0]
-            assert cmd[:4] == [
-                "pre-commit",
-                "run",
-                "--hook-stage",
-                "pre-merge-commit",
-            ]
-
-    def test_commit_msg_argv_forwarded(self, tmp_path: Path) -> None:
-        """commit-msg with argv passes msg file via --commit-msg-filename."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=0)
-            _run_precommit_stage("commit-msg", tmp_path, argv=["/tmp/msg-file"])
-            cmd = mock_run.call_args.args[0]
-            assert "--commit-msg-filename" in cmd
-            assert "/tmp/msg-file" in cmd
-            assert "--all-files" not in cmd
-
-    def test_commit_msg_no_argv_falls_back_to_all_files(self, tmp_path: Path) -> None:
-        """commit-msg without argv falls back to --all-files."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=0)
-            _run_precommit_stage("commit-msg", tmp_path, argv=None)
-            cmd = mock_run.call_args.args[0]
-            assert "--all-files" in cmd
-            assert "--commit-msg-filename" not in cmd
-
-    def test_non_commit_msg_uses_all_files_even_with_argv(self, tmp_path: Path) -> None:
-        """Non-commit-msg stages always use --all-files; argv is ignored."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=0)
-            _run_precommit_stage("pre-rebase", tmp_path, argv=["arg1"])
-            cmd = mock_run.call_args.args[0]
-            assert "--all-files" in cmd
-            assert "--commit-msg-filename" not in cmd
-
-    def test_passes_cwd_and_check_false(self, tmp_path: Path) -> None:
-        """project_root is forwarded as cwd; check=False so we own exit code."""
-        from subprocess import CompletedProcess
-
-        from ac_guard.cli.check import _run_precommit_stage
-
-        with patch("ac_guard.cli.check.subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess([], returncode=0)
-            _run_precommit_stage("pre-merge-commit", tmp_path)
-            assert mock_run.call_args.kwargs["cwd"] == tmp_path
-            assert mock_run.call_args.kwargs["check"] is False
-
-
-class TestJsonOutput:
-    """Tests for --format json output."""
-
-    def test_check_json_output(self, tmp_path: Path) -> None:
-        """check --format json outputs valid JSON."""
-        import json
-
-        config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            result = runner.invoke(
-                app, ["check", "--config", str(config), "--format", "json"]
+                app,
+                [
+                    "run",
+                    "--stage",
+                    "pre-commit",
+                    "--config",
+                    str(config),
+                    "--format",
+                    "json",
+                ],
             )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["stage"] == "pre-commit"
         assert data["passed"] is True
-        assert "results" in data
 
-    def test_verify_json_output(self, tmp_path: Path) -> None:
-        """verify --format json outputs valid JSON."""
-        import json
-
+    def test_pre_push_json(self, tmp_path: Path) -> None:
         config = _write_config(tmp_path)
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             result = runner.invoke(
                 app,
                 [
-                    "verify",
+                    "run",
+                    "--stage",
+                    "pre-push",
                     "--skip-build",
                     "--config",
                     str(config),
@@ -363,11 +299,10 @@ class TestJsonOutput:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["stage"] == "pre-push"
-        assert "results" in data
 
 
 # ---------------------------------------------------------------------------
-# TestCliAutoPostPrComment — WP6.1 / Issue #66
+# TestCliAutoPostPrComment — PR auto-post fires for full-stage only
 # ---------------------------------------------------------------------------
 
 
@@ -396,83 +331,66 @@ def _write_config_with_pr_report(tmp_path: Path, *, enabled: bool) -> Path:
 
 
 class TestCliAutoPostPrComment:
-    """check / verify / gate run auto-trigger post_pr_comment (WP6.1)."""
+    """PR comment posting: full-stage runs fire it, single-check does not."""
 
-    def test_check_calls_post_pr_comment_with_resolved_config(
-        self, tmp_path: Path
-    ) -> None:
-        """check dispatches post_pr_comment with report + pr_report + locale."""
+    def test_full_stage_pre_commit_calls_post_pr(self, tmp_path: Path) -> None:
         config = _write_config_with_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 0
         assert mock_post.call_count == 1
-        pos_args, _kw_args = mock_post.call_args
-        report_arg, pr_config_arg, locale_arg = pos_args
+        report_arg, pr_config_arg, locale_arg = mock_post.call_args.args
         assert report_arg.stage == "pre-commit"
-        assert report_arg.passed is True
         assert pr_config_arg.enabled is True
-        assert pr_config_arg.platform == "github"
         assert locale_arg == "zh-CN"
 
-    def test_check_passes_disabled_config_through(self, tmp_path: Path) -> None:
-        """Even when disabled, CLI calls post_pr_comment (primitive self-gates)."""
+    def test_full_stage_disabled_pr_still_invokes(self, tmp_path: Path) -> None:
+        """``_maybe_post_pr`` self-gates on pr_report.enabled (primitive call)."""
         config = _write_config_with_pr_report(tmp_path, enabled=False)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
-            result = runner.invoke(app, ["check", "--config", str(config)])
+            result = runner.invoke(
+                app, ["run", "--stage", "pre-commit", "--config", str(config)]
+            )
         assert result.exit_code == 0
         assert mock_post.call_count == 1
-        pos_args, _ = mock_post.call_args
-        _report, pr_config_arg, _locale = pos_args
+        _report, pr_config_arg, _locale = mock_post.call_args.args
         assert pr_config_arg.enabled is False
 
-    def test_verify_calls_post_pr_comment(self, tmp_path: Path) -> None:
-        """verify also dispatches post_pr_comment at end."""
+    def test_full_stage_pre_push_calls_post_pr(self, tmp_path: Path) -> None:
         config = _write_config_with_pr_report(tmp_path, enabled=True)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(
-                app, ["verify", "--skip-build", "--config", str(config)]
+                app,
+                [
+                    "run",
+                    "--stage",
+                    "pre-push",
+                    "--skip-build",
+                    "--config",
+                    str(config),
+                ],
             )
         assert result.exit_code == 0
         assert mock_post.call_count == 1
-        pos_args, _ = mock_post.call_args
-        report_arg, _, _ = pos_args
+        report_arg, _, _ = mock_post.call_args.args
         assert report_arg.stage == "pre-push"
 
-    def test_gate_run_calls_post_pr_comment(self, tmp_path: Path) -> None:
-        """gate run also dispatches post_pr_comment at end."""
-        config = _write_config_with_pr_report(tmp_path, enabled=True)
-        with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
-            patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
-        ):
-            result = runner.invoke(
-                app, ["gate", "run", "--stage", "pre-commit", "--config", str(config)]
-            )
-        assert result.exit_code == 0
-        assert mock_post.call_count == 1
-        pos_args, _ = mock_post.call_args
-        report_arg, _, _ = pos_args
-        assert report_arg.stage == "pre-commit"
-
-    def test_run_does_not_call_post_pr_comment(self, tmp_path: Path) -> None:
-        """run is intentionally out of scope (WP6.1): single-check runner.
-
-        Fixates the decision: enabling per-check runs would create PR noise
-        (one comment per check). Re-evaluate in a follow-up issue if needed.
-        """
+    def test_single_check_does_not_call_post_pr(self, tmp_path: Path) -> None:
+        """Single-check mode is a developer iteration tool — no PR noise."""
         config = _write_config_with_checks(tmp_path)
         with (
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=[]),
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
             patch("ac_guard.cli.check._maybe_post_pr") as mock_post,
         ):
             result = runner.invoke(app, ["run", "echo-test", "--config", str(config)])

--- a/tests/unit/test_code_gate/test_core.py
+++ b/tests/unit/test_code_gate/test_core.py
@@ -1,30 +1,38 @@
-"""Tests for code_gate core orchestration (K2-K6)."""
+"""Tests for code_gate orchestration: gate_stage / gate_check + private helpers."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
+import pytest
+
 from ac_guard.code_gate.core import (
-    StageOptions,
+    GateOptions,
+    _delegate_managed_stage,
     _filter_files_by_type,
-    get_changed_files,
-    run_build,
-    run_check,
-    run_stage,
+    _get_changed_files,
+    _run_build,
+    _run_check_item,
+    _run_command,
+    gate_check,
+    gate_stage,
+    is_modeled_stage,
 )
 from ac_guard.config.models import CheckItem, CodeConfig, StageBucket
+from ac_guard.domain.models import CheckResult
 
 
 class TestGetChangedFiles:
-    """Tests for get_changed_files (K2)."""
+    """File collection via git diff."""
 
     def test_commit_stage_command(self, tmp_path: Path) -> None:
         """Commit stage uses git diff --cached."""
         with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "a.py\nb.py\n"
-            files = get_changed_files("pre-commit", tmp_path)
+            files = _get_changed_files("pre-commit", tmp_path)
             assert files == ["a.py", "b.py"]
             cmd = mock_run.call_args[0][0]
             assert "--cached" in cmd
@@ -34,7 +42,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "c.py\n"
-            files = get_changed_files("pre-push", tmp_path)
+            files = _get_changed_files("pre-push", tmp_path)
             assert files == ["c.py"]
             cmd = mock_run.call_args[0][0]
             assert "origin/main..HEAD" in cmd
@@ -44,7 +52,7 @@ class TestGetChangedFiles:
         with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = ""
-            files = get_changed_files("pre-commit", tmp_path)
+            files = _get_changed_files("pre-commit", tmp_path)
             assert files == []
 
     def test_git_error_returns_empty(self, tmp_path: Path) -> None:
@@ -52,194 +60,209 @@ class TestGetChangedFiles:
         with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 1
             mock_run.return_value.stdout = ""
-            files = get_changed_files("pre-commit", tmp_path)
+            files = _get_changed_files("pre-commit", tmp_path)
             assert files == []
 
 
-class TestRunCheck:
-    """Tests for run_check (K4)."""
+class TestRunCheckItem:
+    """Adapter from CheckItem to _run_command."""
 
     def test_successful_command(self, tmp_path: Path) -> None:
         """Successful command returns passed=True."""
         check = CheckItem(command="echo ok", timeout=10)
-        result = run_check("echo-test", check, [], tmp_path)
+        result = _run_check_item("echo-test", check, [], tmp_path)
         assert result.passed is True
         assert result.name == "echo-test"
 
     def test_failing_command(self, tmp_path: Path) -> None:
         """Failing command returns passed=False."""
         check = CheckItem(command="exit 1", timeout=10)
-        result = run_check("fail-test", check, [], tmp_path)
+        result = _run_check_item("fail-test", check, [], tmp_path)
         assert result.passed is False
 
     def test_timeout(self, tmp_path: Path) -> None:
         """Command timeout returns passed=False."""
         check = CheckItem(command="sleep 10", timeout=1)
-        result = run_check("timeout-test", check, [], tmp_path)
+        result = _run_check_item("timeout-test", check, [], tmp_path)
         assert result.passed is False
         assert "Timed out" in result.output
 
     def test_disabled_check_skipped(self, tmp_path: Path) -> None:
         """Disabled check is skipped."""
         check = CheckItem(command="exit 1", enabled=False)
-        result = run_check("disabled", check, [], tmp_path)
+        result = _run_check_item("disabled", check, [], tmp_path)
         assert result.passed is True
         assert result.skipped is True
 
     def test_no_matching_files_skipped(self, tmp_path: Path) -> None:
         """Check with types filter and no matching files is skipped."""
         check = CheckItem(command="ruff check", types=["python"])
-        result = run_check("ruff", check, ["main.js"], tmp_path)
+        result = _run_check_item("ruff", check, ["main.js"], tmp_path)
         assert result.passed is True
         assert result.skipped is True
 
     def test_pass_filenames(self, tmp_path: Path) -> None:
         """Files are appended when pass_filenames is True."""
         check = CheckItem(command="echo", types=["python"])
-        result = run_check("echo", check, ["a.py", "b.py"], tmp_path)
+        result = _run_check_item("echo", check, ["a.py", "b.py"], tmp_path)
         assert result.passed is True
         assert "a.py" in result.output
 
 
 class TestRunBuild:
-    """Tests for run_build (K5)."""
+    """Build adapter (literal command + 600s timeout + fixed name)."""
 
     def test_successful_build(self, tmp_path: Path) -> None:
-        """Successful build returns passed=True."""
-        result = run_build("echo build-ok", tmp_path)
+        result = _run_build("echo build-ok", tmp_path)
         assert result.passed is True
         assert result.name == "build"
 
     def test_failing_build(self, tmp_path: Path) -> None:
-        """Failing build returns passed=False."""
-        result = run_build("exit 1", tmp_path)
+        result = _run_build("exit 1", tmp_path)
         assert result.passed is False
 
 
-class TestFilterFilesByType:
-    """Tests for _filter_files_by_type helper."""
+class TestRunCommand:
+    """Pure literal-command runner (the shared subprocess backend)."""
 
+    def test_naming_passthrough(self, tmp_path: Path) -> None:
+        """The ``name`` argument is preserved on the result."""
+        result = _run_command("custom-name", "echo ok", tmp_path, timeout=5)
+        assert result.name == "custom-name"
+        assert result.passed is True
+
+    def test_failing_command_marks_failed(self, tmp_path: Path) -> None:
+        result = _run_command("fail", "exit 3", tmp_path, timeout=5)
+        assert result.passed is False
+
+
+class TestRunCheckItemSubstitution:
+    """File-list substitution / type filtering live in _run_check_item."""
+
+    def test_files_substituted_when_placeholder_present(self, tmp_path: Path) -> None:
+        check = CheckItem(
+            command="echo prefix {files} suffix",
+            types=["python"],
+            pass_filenames=True,
+        )
+        result = _run_check_item("echo-sub", check, ["a.py"], tmp_path)
+        assert "prefix a.py suffix" in result.output
+
+
+class TestFilterFilesByType:
     def test_python_filter(self) -> None:
-        """Python type filter matches .py files."""
         files = ["a.py", "b.js", "c.py"]
         assert _filter_files_by_type(files, ["python"]) == ["a.py", "c.py"]
 
     def test_no_filter(self) -> None:
-        """None types returns all files."""
         files = ["a.py", "b.js"]
         assert _filter_files_by_type(files, None) == files
 
     def test_multiple_types(self) -> None:
-        """Multiple type filters combined."""
         files = ["a.py", "b.ts", "c.go", "d.txt"]
-        result = _filter_files_by_type(files, ["python", "typescript"])
-        assert result == ["a.py", "b.ts"]
+        assert _filter_files_by_type(files, ["python", "typescript"]) == [
+            "a.py",
+            "b.ts",
+        ]
 
 
-class TestRunStage:
-    """Tests for run_stage orchestration (K6)."""
+class TestIsModeledStage:
+    def test_modeled(self) -> None:
+        assert is_modeled_stage("pre-commit") is True
+        assert is_modeled_stage("pre-push") is True
+
+    def test_not_modeled(self) -> None:
+        assert is_modeled_stage("commit-msg") is False
+        assert is_modeled_stage("pre-merge-commit") is False
+        assert is_modeled_stage("pre-rebase") is False
+
+    def test_unknown(self) -> None:
+        """Unknown stages are not modeled."""
+        assert is_modeled_stage("post-commit") is False
+
+
+class TestGateStage:
+    """Bucket-aware orchestration via gate_stage."""
 
     def test_commit_stage_runs_checks(self, tmp_path: Path) -> None:
-        """pre-commit stage runs format + custom checks."""
         config = CodeConfig(pre_commit=StageBucket(format=True))
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            report = run_stage("pre-commit", config, tmp_path)
-        assert report.stage == "pre-commit"
-        # Format and naming are pre-commit hooks — skipped with no files
-        assert report.passed is True
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = gate_stage("pre-commit", config, tmp_path)
+        assert outcome.stage == "pre-commit"
+        assert outcome.passed is True
 
     def test_commit_stage_with_custom_checks(self, tmp_path: Path) -> None:
-        """Commit stage runs custom checks."""
         config = CodeConfig(
             pre_commit=StageBucket(
                 format=False,
                 checks={"echo": CheckItem(command="echo ok")},
             ),
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            report = run_stage("pre-commit", config, tmp_path)
-        assert report.passed is True
-        assert any(r.name == "echo" for r in report.results)
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = gate_stage("pre-commit", config, tmp_path)
+        assert outcome.passed is True
+        assert any(r.name == "echo" for r in outcome.results)
 
     def test_push_stage_fail_fast(self, tmp_path: Path) -> None:
-        """Push stage fails fast if commit stage fails."""
         config = CodeConfig(
             pre_commit=StageBucket(
                 checks={"fail": CheckItem(command="exit 1")},
             ),
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            report = run_stage("pre-push", config, tmp_path)
-        assert report.stage == "pre-push"
-        assert report.passed is False
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = gate_stage("pre-push", config, tmp_path)
+        assert outcome.stage == "pre-push"
+        assert outcome.passed is False
 
     def test_push_stage_with_build(self, tmp_path: Path) -> None:
-        """Push stage runs build command."""
         config = CodeConfig(
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=False)
         )
-        with patch("ac_guard.code_gate.core.get_changed_files", return_value=[]):
-            report = run_stage(
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = gate_stage(
                 "pre-push",
                 config,
                 tmp_path,
-                options=StageOptions(build_command="echo build"),
+                options=GateOptions(build_command="echo build"),
             )
-        assert report.passed is True
-        assert any(r.name == "build" for r in report.results)
+        assert outcome.passed is True
+        assert any(r.name == "build" for r in outcome.results)
 
     def test_format_iterates_per_language(self, tmp_path: Path) -> None:
-        """commit_format=True emits one pre-commit call per configured language."""
         config = CodeConfig(pre_commit=StageBucket(format=True))
-        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
-            mock_run.return_value.passed = True
-            mock_run.return_value.name = "stub"
-            mock_run.return_value.duration_ms = 0
-            mock_run.return_value.skipped = False
-            mock_run.return_value.violations = []
-            mock_run.return_value.output = ""
-            run_stage(
+        with patch("ac_guard.code_gate.core._run_managed_hook") as mock_hook:
+            mock_hook.return_value = CheckResult(name="stub", passed=True)
+            gate_stage(
                 "pre-commit",
                 config,
                 tmp_path,
-                options=StageOptions(
+                options=GateOptions(
                     files=["a.py"],
                     languages=["python", "typescript"],
                 ),
             )
-        hook_ids = [call.args[0] for call in mock_run.call_args_list]
+        hook_ids = [call.args[0] for call in mock_hook.call_args_list]
         assert "format-python" in hook_ids
         assert "format-typescript" in hook_ids
 
     def test_lint_iterates_per_language(self, tmp_path: Path) -> None:
-        """push_lint=True emits one pre-commit call per configured language."""
         config = CodeConfig(
             pre_commit=StageBucket(format=False), pre_push=StageBucket(lint=True)
         )
-        with patch("ac_guard.code_gate.core.run_precommit") as mock_run:
-            mock_run.return_value.passed = True
-            mock_run.return_value.name = "stub"
-            mock_run.return_value.duration_ms = 0
-            mock_run.return_value.skipped = False
-            mock_run.return_value.violations = []
-            mock_run.return_value.output = ""
-            with patch(
-                "ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]
-            ):
-                run_stage(
-                    "pre-push",
-                    config,
-                    tmp_path,
-                    options=StageOptions(languages=["python", "typescript"]),
-                )
-        hook_ids = [call.args[0] for call in mock_run.call_args_list]
+        with (
+            patch("ac_guard.code_gate.core._run_managed_hook") as mock_hook,
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]),
+        ):
+            mock_hook.return_value = CheckResult(name="stub", passed=True)
+            gate_stage(
+                "pre-push",
+                config,
+                tmp_path,
+                options=GateOptions(languages=["python", "typescript"]),
+            )
+        hook_ids = [call.args[0] for call in mock_hook.call_args_list]
         assert "lint-python" in hook_ids
         assert "lint-typescript" in hook_ids
-
-    # D8: ``commit_naming`` flag removed in schema v2 (#123). Shim in
-    # CodeConfig always returns False, so the code_gate's naming branch
-    # is now unreachable. The dedicated "naming returns skipped" test
-    # is obsolete; ruff N-rules (via ``lint: true``) replaced it.
 
     def test_no_languages_skips_format_and_lint(self, tmp_path: Path) -> None:
         """Empty languages list silently skips format/lint shortcuts."""
@@ -247,16 +270,14 @@ class TestRunStage:
             pre_commit=StageBucket(format=True), pre_push=StageBucket(lint=True)
         )
         with (
-            patch("ac_guard.code_gate.core.run_precommit") as mock_run,
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core._run_managed_hook") as mock_hook,
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]),
         ):
-            run_stage("pre-push", config, tmp_path, options=StageOptions(languages=[]))
-        mock_run.assert_not_called()
+            gate_stage("pre-push", config, tmp_path, options=GateOptions(languages=[]))
+        mock_hook.assert_not_called()
 
     def test_push_build_failure_skips_lint_and_checks(self, tmp_path: Path) -> None:
-        """#77: a failing build must mark lint + push.checks as skipped."""
-        from ac_guard.domain.models import CheckResult
-
+        """A failing build marks lint + push.checks as skipped."""
         config = CodeConfig(
             pre_commit=StageBucket(format=False),
             pre_push=StageBucket(
@@ -269,30 +290,28 @@ class TestRunStage:
         )
         with (
             patch(
-                "ac_guard.code_gate.core.run_build", return_value=failing_build
+                "ac_guard.code_gate.core._run_build", return_value=failing_build
             ) as build_mock,
-            patch("ac_guard.code_gate.core.run_precommit") as precommit_mock,
-            patch("ac_guard.code_gate.core.run_check") as check_mock,
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core._run_managed_hook") as hook_mock,
+            patch("ac_guard.code_gate.core._run_check_item") as check_mock,
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]),
         ):
-            report = run_stage(
+            outcome = gate_stage(
                 "pre-push",
                 config,
                 tmp_path,
-                options=StageOptions(
+                options=GateOptions(
                     build_command="make build",
                     languages=["python"],
                 ),
             )
 
-        # Build ran once, downstream stages never invoked
         assert build_mock.call_count == 1
-        precommit_mock.assert_not_called()
+        hook_mock.assert_not_called()
         check_mock.assert_not_called()
 
-        # Report is failed because build failed
-        assert report.passed is False
-        names = {r.name: r for r in report.results}
+        assert outcome.passed is False
+        names = {r.name: r for r in outcome.results}
         assert names["build"].passed is False
         assert names["pre-commit:lint-python"].skipped is True
         assert "build failed" in names["pre-commit:lint-python"].output.lower()
@@ -300,9 +319,7 @@ class TestRunStage:
         assert "build failed" in names["custom"].output.lower()
 
     def test_push_build_success_runs_downstream(self, tmp_path: Path) -> None:
-        """Build success preserves the existing downstream execution path."""
-        from ac_guard.domain.models import CheckResult
-
+        """Build success preserves downstream execution."""
         config = CodeConfig(
             pre_commit=StageBucket(format=False),
             pre_push=StageBucket(
@@ -312,25 +329,379 @@ class TestRunStage:
         )
         passing_build = CheckResult(name="build", passed=True, duration_ms=10)
         with (
-            patch("ac_guard.code_gate.core.run_build", return_value=passing_build),
-            patch("ac_guard.code_gate.core.run_precommit") as precommit_mock,
-            patch("ac_guard.code_gate.core.run_check") as check_mock,
-            patch("ac_guard.code_gate.core.get_changed_files", return_value=["a.py"]),
+            patch("ac_guard.code_gate.core._run_build", return_value=passing_build),
+            patch("ac_guard.code_gate.core._run_managed_hook") as hook_mock,
+            patch("ac_guard.code_gate.core._run_check_item") as check_mock,
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=["a.py"]),
         ):
-            precommit_mock.return_value = CheckResult(
+            hook_mock.return_value = CheckResult(
                 name="pre-commit:lint-python", passed=True, duration_ms=1
             )
             check_mock.return_value = CheckResult(
                 name="custom", passed=True, duration_ms=1
             )
-            run_stage(
+            gate_stage(
                 "pre-push",
                 config,
                 tmp_path,
-                options=StageOptions(
+                options=GateOptions(
                     build_command="make build",
                     languages=["python"],
                 ),
             )
-        precommit_mock.assert_called()
+        hook_mock.assert_called()
         check_mock.assert_called()
+
+    def test_unknown_stage_raises_value_error(self, tmp_path: Path) -> None:
+        """Stage outside the 5 gating moments raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown stage"):
+            gate_stage("post-commit", CodeConfig(), tmp_path)
+
+    def test_non_modeled_stage_delegates(self, tmp_path: Path) -> None:
+        """Non-modeled stages route through _delegate_managed_stage."""
+        with patch(
+            "ac_guard.code_gate.core._delegate_managed_stage", return_value=0
+        ) as delegate_mock:
+            outcome = gate_stage("commit-msg", CodeConfig(), tmp_path)
+        assert delegate_mock.call_count == 1
+        assert outcome.stage == "commit-msg"
+        assert outcome.passed is True
+        assert outcome.results == []
+
+    def test_non_modeled_stage_failed_delegation(self, tmp_path: Path) -> None:
+        """Non-zero delegation rc maps to passed=False."""
+        with patch("ac_guard.code_gate.core._delegate_managed_stage", return_value=42):
+            outcome = gate_stage("pre-rebase", CodeConfig(), tmp_path)
+        assert outcome.passed is False
+
+    def test_non_modeled_stage_argv_forwarded(self, tmp_path: Path) -> None:
+        """commit-msg argv is forwarded through GateOptions to delegation."""
+        with patch(
+            "ac_guard.code_gate.core._delegate_managed_stage", return_value=0
+        ) as delegate_mock:
+            gate_stage(
+                "commit-msg",
+                CodeConfig(),
+                tmp_path,
+                options=GateOptions(argv=["/tmp/msg-file"]),
+            )
+        assert delegate_mock.call_args.kwargs["argv"] == ["/tmp/msg-file"]
+
+
+class TestGateCheck:
+    """Single named-check resolution and execution."""
+
+    def test_format_expands_per_language(self, tmp_path: Path) -> None:
+        with patch("ac_guard.code_gate.core._run_managed_hook") as mock_hook:
+            mock_hook.return_value = CheckResult(name="stub", passed=True)
+            gate_check(
+                "format",
+                CodeConfig(),
+                tmp_path,
+                options=GateOptions(
+                    files=["a.py"],
+                    languages=["python", "typescript"],
+                ),
+            )
+        hook_ids = [call.args[0] for call in mock_hook.call_args_list]
+        assert hook_ids == ["format-python", "format-typescript"]
+
+    def test_lint_expands_per_language(self, tmp_path: Path) -> None:
+        with patch("ac_guard.code_gate.core._run_managed_hook") as mock_hook:
+            mock_hook.return_value = CheckResult(name="stub", passed=True)
+            gate_check(
+                "lint",
+                CodeConfig(),
+                tmp_path,
+                options=GateOptions(
+                    files=["a.py"],
+                    languages=["python"],
+                ),
+            )
+        hook_ids = [call.args[0] for call in mock_hook.call_args_list]
+        assert hook_ids == ["lint-python"]
+
+    def test_format_with_no_languages_skipped(self, tmp_path: Path) -> None:
+        outcome = gate_check(
+            "format",
+            CodeConfig(),
+            tmp_path,
+            options=GateOptions(files=["a.py"], languages=[]),
+        )
+        assert outcome.passed is True
+        assert len(outcome.results) == 1
+        assert outcome.results[0].skipped is True
+
+    def test_naming_returns_skipped_placeholder(self, tmp_path: Path) -> None:
+        outcome = gate_check(
+            "naming",
+            CodeConfig(),
+            tmp_path,
+            options=GateOptions(files=["a.py"]),
+        )
+        assert outcome.passed is True
+        assert outcome.results[0].skipped is True
+        assert "Naming check is not yet implemented" in outcome.results[0].output
+
+    def test_custom_check_resolved_across_buckets(self, tmp_path: Path) -> None:
+        """A custom check from any bucket is found by name."""
+        config = CodeConfig(
+            pre_push=StageBucket(checks={"mypy": CheckItem(command="echo ok")}),
+        )
+        outcome = gate_check(
+            "mypy",
+            config,
+            tmp_path,
+            options=GateOptions(files=[]),
+        )
+        assert outcome.passed is True
+        assert outcome.results[0].name == "mypy"
+
+    def test_unknown_check_raises_key_error_with_available(
+        self, tmp_path: Path
+    ) -> None:
+        """KeyError message lists available check names for CLI rendering."""
+        config = CodeConfig(
+            pre_commit=StageBucket(checks={"echo": CheckItem(command="echo ok")}),
+            pre_push=StageBucket(checks={"mypy": CheckItem(command="echo ok")}),
+        )
+        with pytest.raises(KeyError) as exc_info:
+            gate_check(
+                "nonexistent",
+                config,
+                tmp_path,
+                options=GateOptions(files=[]),
+            )
+        message = exc_info.value.args[0]
+        assert "nonexistent" in message
+        assert "echo" in message
+        assert "mypy" in message
+
+    def test_outcome_stage_marker(self, tmp_path: Path) -> None:
+        """The synthetic outcome.stage is ``ad-hoc:<name>``."""
+        config = CodeConfig(
+            pre_commit=StageBucket(checks={"echo": CheckItem(command="echo ok")}),
+        )
+        outcome = gate_check("echo", config, tmp_path, options=GateOptions(files=[]))
+        assert outcome.stage == "ad-hoc:echo"
+
+
+class TestDelegateManagedStage:
+    """Pre-commit framework delegation for non-modeled stages.
+
+    Covers what the previous CLI ``_run_precommit_stage`` helper did
+    before it was relocated into ``code_gate.core``.
+    """
+
+    def test_returns_subprocess_returncode(self, tmp_path: Path) -> None:
+        """Exit code from the pre-commit subprocess propagates verbatim."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=42)
+            assert _delegate_managed_stage("pre-rebase", tmp_path) == 42
+
+    def test_invokes_pre_commit_with_hook_stage(self, tmp_path: Path) -> None:
+        """Command starts with `pre-commit run --hook-stage <stage>`."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _delegate_managed_stage("pre-merge-commit", tmp_path)
+            cmd = mock_run.call_args.args[0]
+            assert cmd[:4] == [
+                "pre-commit",
+                "run",
+                "--hook-stage",
+                "pre-merge-commit",
+            ]
+
+    def test_commit_msg_argv_forwarded(self, tmp_path: Path) -> None:
+        """commit-msg with argv forwards msg file via --commit-msg-filename."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _delegate_managed_stage("commit-msg", tmp_path, argv=["/tmp/msg-file"])
+            cmd = mock_run.call_args.args[0]
+            assert "--commit-msg-filename" in cmd
+            assert "/tmp/msg-file" in cmd
+            assert "--all-files" not in cmd
+
+    def test_commit_msg_no_argv_falls_back_to_all_files(self, tmp_path: Path) -> None:
+        """commit-msg without argv falls back to --all-files."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _delegate_managed_stage("commit-msg", tmp_path, argv=None)
+            cmd = mock_run.call_args.args[0]
+            assert "--all-files" in cmd
+            assert "--commit-msg-filename" not in cmd
+
+    def test_non_commit_msg_uses_all_files_even_with_argv(self, tmp_path: Path) -> None:
+        """Non-commit-msg stages always use --all-files; argv is ignored."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _delegate_managed_stage("pre-rebase", tmp_path, argv=["arg1"])
+            cmd = mock_run.call_args.args[0]
+            assert "--all-files" in cmd
+            assert "--commit-msg-filename" not in cmd
+
+    def test_passes_cwd_and_check_false(self, tmp_path: Path) -> None:
+        """project_root is forwarded as cwd; check=False so we own exit code."""
+        with patch("ac_guard.code_gate.core.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess([], returncode=0)
+            _delegate_managed_stage("pre-merge-commit", tmp_path)
+            assert mock_run.call_args.kwargs["cwd"] == tmp_path
+            assert mock_run.call_args.kwargs["check"] is False
+
+
+class TestStageStrategies:
+    """White-box tests for the per-stage strategy classes.
+
+    ``gate_stage`` / ``is_modeled_stage`` route to these strategies. The
+    public-facing tests in ``TestGateStage`` / ``TestIsModeledStage``
+    cover end-to-end behavior; here we exercise each strategy directly
+    to pin down their contracts.
+    """
+
+    def test_commit_strategy_metadata(self) -> None:
+        from ac_guard.code_gate.core import _CommitStrategy
+
+        strategy = _CommitStrategy()
+        assert strategy.stage == "pre-commit"
+        assert strategy.is_modeled is True
+
+    def test_commit_strategy_run_uses_pre_commit_bucket(self, tmp_path: Path) -> None:
+        from ac_guard.code_gate.core import _CommitStrategy
+
+        config = CodeConfig(
+            pre_commit=StageBucket(checks={"echo": CheckItem(command="echo ok")}),
+        )
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = _CommitStrategy().run(config, tmp_path, GateOptions())
+        assert outcome.stage == "pre-commit"
+        assert outcome.passed is True
+        assert any(r.name == "echo" for r in outcome.results)
+
+    def test_push_strategy_metadata(self) -> None:
+        from ac_guard.code_gate.core import _CommitStrategy, _PushStrategy
+
+        strategy = _PushStrategy(_CommitStrategy())
+        assert strategy.stage == "pre-push"
+        assert strategy.is_modeled is True
+
+    def test_push_strategy_runs_commit_first_for_fail_fast(
+        self, tmp_path: Path
+    ) -> None:
+        """Push strategy must call commit strategy first; fail short-circuits."""
+        from ac_guard.code_gate.core import _CommitStrategy, _PushStrategy
+
+        config = CodeConfig(
+            pre_commit=StageBucket(
+                checks={"fail": CheckItem(command="exit 1")},
+            ),
+        )
+        with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
+            outcome = _PushStrategy(_CommitStrategy()).run(
+                config, tmp_path, GateOptions()
+            )
+        assert outcome.stage == "pre-push"
+        assert outcome.passed is False
+        # Failed pre-commit results bubble up under the pre-push stage label
+        assert any(r.name == "fail" for r in outcome.results)
+
+    def test_push_strategy_runs_build_after_commit_passes(self, tmp_path: Path) -> None:
+        from ac_guard.code_gate.core import _CommitStrategy, _PushStrategy
+
+        config = CodeConfig(
+            pre_commit=StageBucket(format=False),
+            pre_push=StageBucket(lint=False),
+        )
+        with (
+            patch("ac_guard.code_gate.core._get_changed_files", return_value=[]),
+            patch(
+                "ac_guard.code_gate.core._run_build",
+                return_value=CheckResult(name="build", passed=True),
+            ) as mock_build,
+        ):
+            outcome = _PushStrategy(_CommitStrategy()).run(
+                config, tmp_path, GateOptions(build_command="echo build")
+            )
+        assert outcome.passed is True
+        mock_build.assert_called_once()
+
+    def test_delegated_strategy_metadata(self) -> None:
+        from ac_guard.code_gate.core import _DelegatedStrategy
+
+        strategy = _DelegatedStrategy("commit-msg")
+        assert strategy.stage == "commit-msg"
+        assert strategy.is_modeled is False
+
+    def test_delegated_strategy_wraps_exit_code(self, tmp_path: Path) -> None:
+        from ac_guard.code_gate.core import _DelegatedStrategy
+
+        with patch("ac_guard.code_gate.core._delegate_managed_stage", return_value=0):
+            outcome = _DelegatedStrategy("commit-msg").run(
+                CodeConfig(), tmp_path, GateOptions()
+            )
+        assert outcome.passed is True
+        assert outcome.results == []
+        assert outcome.stage == "commit-msg"
+
+    def test_delegated_strategy_failure_maps_to_passed_false(
+        self, tmp_path: Path
+    ) -> None:
+        from ac_guard.code_gate.core import _DelegatedStrategy
+
+        with patch("ac_guard.code_gate.core._delegate_managed_stage", return_value=42):
+            outcome = _DelegatedStrategy("pre-rebase").run(
+                CodeConfig(), tmp_path, GateOptions()
+            )
+        assert outcome.passed is False
+
+    def test_delegated_strategy_forwards_argv(self, tmp_path: Path) -> None:
+        from ac_guard.code_gate.core import _DelegatedStrategy
+
+        with patch(
+            "ac_guard.code_gate.core._delegate_managed_stage", return_value=0
+        ) as mock_delegate:
+            _DelegatedStrategy("commit-msg").run(
+                CodeConfig(), tmp_path, GateOptions(argv=["/tmp/msg-file"])
+            )
+        assert mock_delegate.call_args.kwargs["argv"] == ["/tmp/msg-file"]
+
+
+class TestStrategyRegistry:
+    """The ``_STRATEGIES`` table backs ``gate_stage`` / ``is_modeled_stage``."""
+
+    def test_all_five_gating_stages_registered(self) -> None:
+        from ac_guard.code_gate.core import _STRATEGIES
+
+        assert set(_STRATEGIES) == {
+            "pre-commit",
+            "pre-push",
+            "commit-msg",
+            "pre-merge-commit",
+            "pre-rebase",
+        }
+
+    def test_get_strategy_returns_correct_type(self) -> None:
+        from ac_guard.code_gate.core import (
+            _CommitStrategy,
+            _DelegatedStrategy,
+            _get_strategy,
+            _PushStrategy,
+        )
+
+        assert isinstance(_get_strategy("pre-commit"), _CommitStrategy)
+        assert isinstance(_get_strategy("pre-push"), _PushStrategy)
+        for delegated in ("commit-msg", "pre-merge-commit", "pre-rebase"):
+            assert isinstance(_get_strategy(delegated), _DelegatedStrategy)
+
+    def test_get_strategy_unknown_raises_value_error(self) -> None:
+        from ac_guard.code_gate.core import _get_strategy
+
+        with pytest.raises(ValueError, match="Unknown stage"):
+            _get_strategy("post-commit")
+
+    def test_push_strategy_shares_commit_strategy_instance(self) -> None:
+        """Push strategy holds the same commit strategy instance the registry uses."""
+        from ac_guard.code_gate.core import _STRATEGIES
+
+        commit = _STRATEGIES["pre-commit"]
+        push = _STRATEGIES["pre-push"]
+        assert push._commit is commit

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -535,7 +535,7 @@ class TestGenerateGitHooks:
         (tmp_path / ".git" / "hooks").mkdir()
         result = generate_git_hooks(tmp_path)
         for hook in result:
-            assert "ac-guard gate run" in hook.content
+            assert "ac-guard run --stage" in hook.content
 
     def test_pre_commit_has_correct_stage(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()


### PR DESCRIPTION
## Summary

Three-layer refactor of the `code_gate` subsystem and its CLI, addressing the API/surface concerns tracked in #109.

### 1. code_gate Python API 收敛

Public surface drops from 6 mechanism-named symbols (`run_precommit`, `run_check`, `run_build`, `run_stage`, `get_changed_files`, `StageOptions`) to 2 intent-named entries:

- `gate_stage(stage, config, root, *, options) -> StageOutcome`
- `gate_check(name, config, root, *, options) -> StageOutcome`

Plus `GateOptions`, `StageOutcome`, `CheckResult`, `is_modeled_stage`. Execution backends (`_run_managed_hook` / `_run_command` / `_delegate_managed_stage`) and adapters (`_run_check_item` / `_run_build`) are now private. CLI dispatch logic (built-in vs custom check, bucket-aware vs delegated stage) moves into `code_gate`.

### 2. CLI 统一为 `ac-guard run`

Removes `ac-guard check` / `verify` / `gate run`; folds them into a single `ac-guard run` command discriminated by name presence:

- `run <name>` → `gate_check` (single check, no PR comment)
- `run --stage X` → `gate_stage` (full stage, posts PR comment)
- `run --stage commit-msg --message-file X` (git hook usage)

PR comment behavior follows operation scope (full stage vs single check), not command name. Five hook templates regenerated; the `gate` subcommand group is removed entirely.

### 3. Strategy pattern in code_gate

`gate_stage`'s 70-line if/elif dispatch retires to a one-line `_get_strategy(stage).run(...)` call. Three private strategies (`_CommitStrategy` / `_PushStrategy` / `_DelegatedStrategy`) encapsulate per-stage runtime orchestration. `_PushStrategy` explicitly holds the `_CommitStrategy` reference to express the "push fail-fast on commit" dependency in the dispatch table. `is_modeled_stage` queries `strategy.is_modeled` instead of a separate `_BUCKET_AWARE_STAGES` constant.

## Breaking Changes

- `ac-guard check` / `ac-guard verify` / `ac-guard gate run` command names removed. **Migration**: replace with `ac-guard run --stage <stage>`.
- `code_gate` public API renamed (`gate_stage` replaces `run_stage` etc.). External consumers must update imports.
- `StageOptions` renamed to `GateOptions`.

## Test plan

- [x] `uv run pytest` — 1107 passed (13 new strategy tests)
- [x] `uv run pre-commit run --all-files` — green
- [x] `uv run ruff check src tests` — green
- [x] `ac-guard install` regenerates hooks correctly; `cat .git/hooks/commit-msg` shows new `--message-file` form
- [x] `ac-guard run --stage pre-commit/pre-push/commit-msg/pre-rebase` — behavior unchanged
- [x] `ac-guard run mypy` — single-check path
- [x] `ac-guard run nonexistent` — exits 1 with available list
- [x] `ac-guard run --stage bogus` — exits 2 with `Unknown stage`
- [x] `ac-guard doctor` — `stage-semantic-fit` output unchanged

## Out of scope

Tracked for follow-up PRs under M6 (#109):

- per-class `diagnose()` validation framework in `config/`
- per-check parallel invocation (performance)
- modeling `commit-msg` / `pre-merge-commit` / `pre-rebase` as bucket-aware

## Linked issue

Closes part of #109 (code_gate slice; remaining slices for `enforcer` / `generator` / `reporter` etc. tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)