### PR TITLE
refactor(config): tighten public API surface

### DIFF
--- a/src/ac_guard/cli/install.py
+++ b/src/ac_guard/cli/install.py
@@ -7,7 +7,7 @@ and state management to manage AI Code Guard artifact lifecycle.
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -15,8 +15,6 @@ from ac_guard.adapters.registry import AdapterNotFoundError, get_adapter, list_a
 from ac_guard.audit import prune_by_age
 from ac_guard.config import (
     ConfigError,
-    RawConfig,
-    load_config,
     resolve_config,
 )
 from ac_guard.generator.core import (
@@ -190,7 +188,7 @@ def _merge_agents(existing: list[str], new: list[str]) -> list[str]:
 def _load_ruleset_configs(
     project_root: Path,
     rulesets: list[str],
-) -> list[tuple[str, RawConfig]]:
+) -> list[tuple[str, dict[str, Any]]]:
     """Load guard.yaml from each cached ruleset.
 
     For each ruleset name listed in the project config, looks for
@@ -213,7 +211,7 @@ def _load_ruleset_configs(
         return []
 
     cache_dir = get_cache_dir(project_root)
-    pairs: list[tuple[str, RawConfig]] = []
+    pairs: list[tuple[str, dict[str, Any]]] = []
 
     for name in rulesets:
         rs_config_path = cache_dir / name / "guard.yaml"
@@ -294,12 +292,13 @@ def install_command(
         )
         raise SystemExit(1)
 
-    # Load and resolve config (with ruleset configs from cache)
+    # Resolve config; ruleset cache is fed to the resolver via callback
+    # so we never have to peek the raw yaml ourselves.
     try:
-        raw_config = load_config(config_path)
-        rulesets: list[str] = raw_config.get("rulesets", [])
-        ruleset_pairs = _load_ruleset_configs(project_root, rulesets)
-        resolved = resolve_config(config_path, rulesets=ruleset_pairs)
+        resolved = resolve_config(
+            config_path,
+            fetch_rulesets=lambda names: _load_ruleset_configs(project_root, names),
+        )
     except ConfigError as e:
         print(f"Error: {e}")
         raise SystemExit(1) from None
@@ -315,7 +314,7 @@ def install_command(
     # Run generator pipeline
     try:
         written_paths = _run_generator_pipeline(
-            resolved, adapters, project_root, rulesets, force=force
+            resolved, adapters, project_root, resolved.rulesets, force=force
         )
     except ArtifactWriteError as e:
         print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")
@@ -350,12 +349,13 @@ def update_command(
         print("Error: AI Code Guard is not installed. Run 'ac-guard install' first.")
         raise SystemExit(1)
 
-    # Load and resolve config (with ruleset configs from cache)
+    # Resolve config; ruleset cache is fed to the resolver via callback
+    # so we never have to peek the raw yaml ourselves.
     try:
-        raw_config = load_config(config_path)
-        rulesets: list[str] = raw_config.get("rulesets", [])
-        ruleset_pairs = _load_ruleset_configs(project_root, rulesets)
-        resolved = resolve_config(config_path, rulesets=ruleset_pairs)
+        resolved = resolve_config(
+            config_path,
+            fetch_rulesets=lambda names: _load_ruleset_configs(project_root, names),
+        )
     except ConfigError as e:
         print(f"Error: {e}")
         raise SystemExit(1) from None
@@ -371,7 +371,7 @@ def update_command(
     # Run generator pipeline
     try:
         written_paths = _run_generator_pipeline(
-            resolved, adapters, project_root, rulesets, force=force
+            resolved, adapters, project_root, resolved.rulesets, force=force
         )
     except ArtifactWriteError as e:
         print(f"Error: Failed to write artifacts: {', '.join(e.failed_paths)}")

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 
 from ac_guard import __version__
 from ac_guard.adapters.registry import get_adapter, list_adapters
-from ac_guard.config import ConfigError, load_config, resolve_config, runtime_check
+from ac_guard.config import (
+    ConfigError,
+    diagnose_config,
+    load_config,
+    resolve_config,
+)
 from ac_guard.generator.core import read_state
 
 if TYPE_CHECKING:
@@ -234,15 +239,15 @@ def doctor_command(
     print("\n4. Drift Detection")
     _check_drift(project_root, config_path, tally)
 
-    # 5. Config semantic-runtime checks (skip when config failed to load).
-    # Stage-semantic fit (format/lint placement) is now enforced at L2
-    # of config validation, not here — broken configs fail step 2 above.
-    # The remaining IO-bearing semantic checks (hook PATH resolvability,
-    # language coverage, ruleset paths) live in ``config.runtime_check``;
-    # doctor just renders the diagnostics and aggregates the tally.
+    # 5. Config-environment consistency diagnosis (skip if load failed).
+    # Stage-semantic fit (format/lint placement) is enforced at semantic
+    # validation, not here — broken configs fail step 2 above. The
+    # remaining IO-bearing checks (hook PATH resolvability, language
+    # coverage, ruleset paths) live in ``config.diagnose``; doctor
+    # renders the Diagnostic list and aggregates the tally.
     if resolved is not None:
-        print("\n5. Config Semantic Runtime")
-        _render_runtime_check(resolved, project_root, tally)
+        print("\n5. Configuration Diagnosis")
+        _render_diagnosis(resolved, project_root, tally)
 
     # Exit policy: FAIL always exits 1. WARN exits 1 only under --strict.
     if tally.fail > 0 or (strict and tally.warn > 0):
@@ -374,22 +379,22 @@ def _check_drift(project_root: Path, config_path: Path, tally: _Tally) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Config semantic-runtime renderer (delegates to config.runtime_check)
+# Configuration diagnosis renderer (delegates to config.diagnose_config)
 # ---------------------------------------------------------------------------
 
 
-def _render_runtime_check(
+def _render_diagnosis(
     resolved: ResolvedConfig, project_root: Path, tally: _Tally
 ) -> None:
-    """Run config-layer L4 semantic-runtime checks and print diagnostics.
+    """Run configuration-environment diagnosis and print findings.
 
     All the actual logic — hook PATH resolution, language coverage,
-    ruleset path existence — lives in ``config.runtime_check``. Doctor's
+    ruleset path existence — lives in ``config.diagnose``. Doctor's
     only job here is to render each ``Diagnostic`` in the existing
     ``[ok] / [WARN] / [FAIL]`` style and feed the tally so the exit
     policy stays uniform across check sections.
     """
-    diags = runtime_check(resolved, project_root)
+    diags = diagnose_config(resolved, project_root)
     for d in diags:
         if d.level == "fail":
             print(f"  [FAIL] {d.message}")

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -17,7 +17,6 @@ from ac_guard.adapters.registry import get_adapter, list_adapters
 from ac_guard.config import (
     ConfigError,
     diagnose_config,
-    load_config,
     resolve_config,
 )
 from ac_guard.generator.core import read_state
@@ -316,16 +315,9 @@ def _check_config(config_path: Path, tally: _Tally) -> ResolvedConfig | None:
         return None
 
     try:
-        load_config(config_path)
-    except ConfigError as e:
-        print(f"  [FAIL] guard.yaml invalid: {e}")
-        tally.fail_inc()
-        return None
-
-    try:
         resolved = resolve_config(config_path)
     except ConfigError as e:
-        print(f"  [FAIL] guard.yaml cannot be resolved: {e}")
+        print(f"  [FAIL] guard.yaml: {e}")
         tally.fail_inc()
         return None
 

--- a/src/ac_guard/config/__init__.py
+++ b/src/ac_guard/config/__init__.py
@@ -7,17 +7,17 @@ that downstream modules consume.
 
 Entry points
 ------------
-``resolve_config(path, rulesets=None) -> ResolvedConfig``
-    Main entry. Loads, merges, validates, and hashes.
-``load_config(path) -> RawConfig``
-    Raw pass-through: parse + validate a single file, no merge.
+``resolve_config(path, *, fetch_rulesets=None) -> ResolvedConfig``
+    Single entry for the load → merge → validate pipeline. Pass a
+    ``fetch_rulesets`` callback if the project uses rulesets and you
+    want the resolver to invoke your fetcher instead of expecting
+    pre-fetched data.
 ``diagnose_config(resolved, project_root) -> list[Diagnostic]``
     Diagnose configuration consistency against the current environment
     (IO-bearing; consumed by doctor and other sanity-check callers).
 
 Schemas
 -------
-- ``RawConfig`` (input): the ``guard.yaml`` structure.
 - ``ResolvedConfig`` (output): the merged value tree. The 13 nested
   dataclasses (``BehaviorConfig``, ``OperationRules``, ``Rule``,
   ``CodeConfig``, ``StageBucket``, ``CheckItem``, ``PreCommitHook``,
@@ -54,7 +54,6 @@ from ac_guard.config.exceptions import (
     ConfigWarning,
     ValidationIssue,
 )
-from ac_guard.config.loader import RawConfig, load_config
 from ac_guard.config.merger import resolve_config
 from ac_guard.config.models import (
     AuditConfig,
@@ -76,10 +75,7 @@ from ac_guard.config.models import (
 __all__ = [
     # Entry-point functions
     "resolve_config",
-    "load_config",
     "diagnose_config",
-    # Input schema
-    "RawConfig",
     # Output schema tree (14 dataclasses reachable from ResolvedConfig)
     "ResolvedConfig",
     "BehaviorConfig",

--- a/src/ac_guard/config/__init__.py
+++ b/src/ac_guard/config/__init__.py
@@ -11,8 +11,9 @@ Entry points
     Main entry. Loads, merges, validates, and hashes.
 ``load_config(path) -> RawConfig``
     Raw pass-through: parse + validate a single file, no merge.
-``runtime_check(resolved, project_root) -> list[Diagnostic]``
-    Semantic-runtime checks (IO-bearing, doctor-side).
+``diagnose_config(resolved, project_root) -> list[Diagnostic]``
+    Diagnose configuration consistency against the current environment
+    (IO-bearing; consumed by doctor and other sanity-check callers).
 
 Schemas
 -------
@@ -44,6 +45,7 @@ Everything intended for cross-module use lives in this package's
 from :mod:`ac_guard.config` directly.
 """
 
+from ac_guard.config.diagnose import Diagnostic, diagnose_config
 from ac_guard.config.exceptions import (
     ConfigError,
     ConfigFileNotFoundError,
@@ -70,13 +72,12 @@ from ac_guard.config.models import (
     Rule,
     StageBucket,
 )
-from ac_guard.config.runtime_check import Diagnostic, runtime_check
 
 __all__ = [
     # Entry-point functions
     "resolve_config",
     "load_config",
-    "runtime_check",
+    "diagnose_config",
     # Input schema
     "RawConfig",
     # Output schema tree (14 dataclasses reachable from ResolvedConfig)

--- a/src/ac_guard/config/diagnose.py
+++ b/src/ac_guard/config/diagnose.py
@@ -1,21 +1,26 @@
-"""Semantic-runtime config checks (L4) — the only IO-bearing layer
-of config validation.
+"""Configuration-environment consistency diagnosis — the IO-bearing
+half of config validation.
 
-Where ``semantic.py`` is strictly zero-IO, this module is allowed to
-touch the filesystem, the user's PATH, and the project's git working
-tree to cross-check the merged ``ResolvedConfig`` against runtime
+Where ``semantic.py`` is strictly zero-IO, this module touches the
+filesystem, the user's PATH, and the project's git working tree to
+cross-check the merged ``ResolvedConfig`` against the current runtime
 reality. Examples: a hook ``entry`` references a tool that isn't on
 PATH, a ruleset path doesn't exist, a language is declared but the
 repo has no files matching it.
 
-doctor consumes ``runtime_check(resolved, project_root)`` and renders
-the returned ``Diagnostic`` list — diagnostics carry their own
-severity so doctor's only job is grouping/printing/exit-code logic.
+doctor (and any other caller doing a sanity check) calls
+``diagnose_config(resolved, project_root)`` and renders the returned
+``Diagnostic`` list — diagnostics carry their own severity so the
+caller's only job is grouping / printing / exit-code logic. The
+function never raises: configuration validity vs. environment fitness
+are different failure modes, and reporting the latter as a list of
+findings (rather than a thrown exception) keeps doctor in control of
+exit-code policy.
 
-The file boundary between ``semantic.py`` (zero-IO) and
-``runtime_check.py`` (IO-bearing) makes the contract physically
-visible: a future contributor who wants to add a new rule has to
-choose a side, and the choice is unambiguous.
+The file boundary between ``semantic.py`` (zero-IO) and ``diagnose.py``
+(IO-bearing) makes the contract physically visible: a future
+contributor adding a new check has to pick a side, and the choice is
+unambiguous.
 
 Internal submodule — import the public surface via
 :mod:`ac_guard.config` rather than reaching in here directly.
@@ -36,7 +41,7 @@ from ac_guard.domain.languages import detect_language
 if TYPE_CHECKING:
     from ac_guard.config.models import ResolvedConfig
 
-__all__ = ["Diagnostic", "runtime_check"]
+__all__ = ["Diagnostic", "diagnose_config"]
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +51,7 @@ __all__ = ["Diagnostic", "runtime_check"]
 
 @dataclass(frozen=True)
 class Diagnostic:
-    """A single semantic-runtime finding to display to the user.
+    """A single config-environment consistency finding to display.
 
     Attributes:
         level: Severity. ``"ok"`` is shown for transparency (so the
@@ -69,12 +74,14 @@ class Diagnostic:
 # ---------------------------------------------------------------------------
 
 
-def runtime_check(resolved: ResolvedConfig, project_root: Path) -> list[Diagnostic]:
-    """Run all L4 semantic-runtime checks against ``resolved``.
+def diagnose_config(resolved: ResolvedConfig, project_root: Path) -> list[Diagnostic]:
+    """Diagnose configuration consistency against the current environment.
 
-    Every helper returns its own diagnostic list; this entry point
-    simply concatenates them. The order of helpers in the result is
-    stable so callers (doctor) can present sections consistently.
+    Cross-checks the merged configuration against runtime reality:
+    PATH for declared hook commands, ``git ls-files`` for declared
+    languages, filesystem for local ruleset paths. Emits a
+    ``Diagnostic`` per finding (ok / warn / fail); never raises.
+    Callers (doctor and friends) render the list and decide exit code.
 
     Args:
         resolved: A fully-merged ``ResolvedConfig``.
@@ -83,7 +90,7 @@ def runtime_check(resolved: ResolvedConfig, project_root: Path) -> list[Diagnost
             and as the cwd for ``git ls-files``.
 
     Returns:
-        Concatenated diagnostics from all helpers.
+        Concatenated diagnostics from each helper, in stable order.
     """
     diags: list[Diagnostic] = []
     diags.extend(_verify_command_paths(resolved, project_root))

--- a/src/ac_guard/config/loader.py
+++ b/src/ac_guard/config/loader.py
@@ -22,7 +22,11 @@ from ac_guard.config.exceptions import (
     ConfigValidationError,
     ValidationIssue,
 )
-from ac_guard.config.semantic import validate_semantic_static
+from ac_guard.config.semantic import (
+    _COMMAND_SYNTAX,
+    _FORMAT_LINT_SCOPE,
+    validate_semantic,
+)
 from ac_guard.config.validator import validate_raw_config
 
 __all__ = ["RawConfig", "load_config"]
@@ -213,8 +217,9 @@ def load_config(path: str | Path) -> RawConfig:
     data = _read_yaml(resolved)
     _check_is_dict(data, resolved)
     validate_raw_config(data, source=str(resolved))
-    # L2 semantic checks run after L1 schema passes — typing is safe.
-    validate_semantic_static(data, source=str(resolved))
+    # Semantic rules judging yaml content — run after L1 passes so
+    # field types are guaranteed by the time the rules read them.
+    validate_semantic(data, [_FORMAT_LINT_SCOPE, _COMMAND_SYNTAX])
     return data  # type: ignore[return-value]
 
 

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -20,15 +20,15 @@ import hashlib
 import warnings
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from ac_guard.config.exceptions import ConfigWarning
-from ac_guard.config.loader import (
-    RawConfig,
-    load_config,
-)
+from ac_guard.config.loader import RawConfig, load_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 from ac_guard.config.models import (
     AuditConfig,
     BehaviorConfig,
@@ -599,7 +599,9 @@ def _compute_config_hash(path: Path) -> str:
 def resolve_config(
     path: str | Path,
     *,
-    rulesets: list[tuple[str, RawConfig]] | None = None,
+    rulesets: list[tuple[str, dict[str, Any]]] | None = None,
+    fetch_rulesets: Callable[[list[str]], list[tuple[str, dict[str, Any]]]]
+    | None = None,
 ) -> ResolvedConfig:
     """Load and merge all config sources into a :class:`ResolvedConfig`.
 
@@ -608,8 +610,17 @@ def resolve_config(
 
     Args:
         path: Path to the project's ``guard.yaml``.
-        rulesets: Pre-loaded rulesets as ``(name, raw_config)`` pairs,
-            in merge order.  Defaults to an empty list.
+        rulesets: Pre-fetched ``(name, raw_dict)`` pairs in merge
+            order. White-box convenience for tests and callers that
+            already have ruleset data on hand.
+        fetch_rulesets: Optional callback. When the user's
+            ``guard.yaml`` declares a non-empty ``rulesets`` list, the
+            callback is invoked with those names and must return
+            ``(name, raw_dict)`` pairs in merge order. Lets callers
+            control **where** rulesets come from (cache, remote git,
+            custom store, …) without peeking at the raw yaml first.
+
+        Pass at most one of the two; passing both raises ``TypeError``.
 
     Returns:
         A fully populated :class:`ResolvedConfig`.
@@ -618,7 +629,12 @@ def resolve_config(
         ConfigFileNotFoundError: ``guard.yaml`` does not exist.
         ConfigSyntaxError: YAML parsing failed.
         ConfigValidationError: Schema validation failed.
+        TypeError: Both ``rulesets`` and ``fetch_rulesets`` were given.
     """
+    if rulesets is not None and fetch_rulesets is not None:
+        raise TypeError(
+            "resolve_config(): pass at most one of 'rulesets' or 'fetch_rulesets'"
+        )
     resolved_path = Path(path)
 
     # 1. Load and validate the user's guard.yaml (may raise)
@@ -631,8 +647,13 @@ def resolve_config(
     merged = copy.deepcopy(_BUILTIN_DEFAULTS)
     _tag_rules(merged, "default")
 
-    # 4. Merge rulesets in order
-    for name, raw in rulesets or []:
+    # 4. Resolve ruleset pairs (callback-driven or pre-fetched) and merge
+    ruleset_pairs: list[tuple[str, dict[str, Any]]] = list(rulesets or [])
+    if fetch_rulesets is not None:
+        declared = list(user_config.get("rulesets") or [])
+        if declared:
+            ruleset_pairs = list(fetch_rulesets(declared))
+    for name, raw in ruleset_pairs:
         ruleset_copy: dict[str, Any] = copy.deepcopy(dict(raw))
         _tag_rules(ruleset_copy, f"ruleset:{name}")
         merged = _merge_raw_configs(merged, ruleset_copy)

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -45,7 +45,11 @@ from ac_guard.config.models import (
     Rule,
     StageBucket,
 )
-from ac_guard.config.semantic import validate_semantic_resolved
+from ac_guard.config.semantic import (
+    _PATTERN_UNIQUENESS,
+    _TIER_CONSISTENCY,
+    validate_semantic,
+)
 
 __all__ = ["resolve_config"]
 
@@ -655,7 +659,7 @@ def resolve_config(
         default_project_name=default_project_name,
     )
 
-    # 10. L3 semantic checks over the merged result (zero IO).
-    validate_semantic_resolved(resolved)
+    # 10. Semantic rules judging the merged tree (zero IO).
+    validate_semantic(resolved, [_TIER_CONSISTENCY, _PATTERN_UNIQUENESS])
 
     return resolved

--- a/src/ac_guard/config/semantic.py
+++ b/src/ac_guard/config/semantic.py
@@ -1,34 +1,44 @@
-"""Semantic config validation — L2 (raw) and L3 (resolved), zero-IO.
+"""Semantic config validation — zero-IO rules over yaml or merged config.
 
 L1 ``validator.py`` checks structural shape (types, required fields,
 enum values). This module checks **semantic** correctness that schema
-shape can't express:
+shape can't express. All rules are zero-IO; the IO-bearing
+configuration-vs-environment diagnostics live in ``diagnose.py``.
 
-L2 (raw dict, after ``validate_raw_config``):
-    * ``format-lint-stage-scope`` — ``format``/``lint`` toggles only
-      apply on file-scoped stages (``pre-commit``/``pre-push``).
-    * ``command-syntax`` — user-supplied command strings must be
-      ``shlex.split``-parseable (balanced quotes, etc.).
+The four rules currently implemented:
 
-L3 (ResolvedConfig, after merge / system-rule injection):
-    * ``tier-consistency`` — same pattern must not appear in both
-      ``forbidden`` and ``allow`` under one operation.
-    * ``pattern-uniqueness`` — within a tier list, no pattern should
-      appear twice (system-injected rules excluded — they may
-      legitimately overlap user patterns).
+* ``format-lint-stage-scope`` — ``format``/``lint`` toggles only apply
+  on file-scoped stages (``pre-commit`` / ``pre-push``); judged from a
+  parsed yaml.
+* ``command-syntax`` — user-supplied command strings must be
+  ``shlex.split``-parseable (balanced quotes, etc.); judged from a
+  parsed yaml.
+* ``tier-consistency`` — same pattern must not appear in both
+  ``forbidden`` and ``allow`` under one operation; judged from the
+  merged tree.
+* ``pattern-uniqueness`` — within a tier list, no pattern should
+  appear twice (system-injected rules excluded — they may legitimately
+  overlap user patterns); judged from the merged tree.
 
-Each rule is a small function ``(data, issues) -> None``; the
-``_SemanticRule`` struct binds it to a stable ``code``. The driver
-runs all rules, post-injects ``rule_code`` on every issue produced,
-and raises ``ConfigValidationError`` once at the end so the user sees
-every problem in a single pass.
+Public surface (within the ``ac_guard.config`` package only — this
+module's ``__all__`` is empty):
 
-Adding a new rule is mechanical: write ``_verify_xxx``, append a
-``_SemanticRule(code=..., apply=_verify_xxx)`` to the relevant tuple,
-and add a ``rule_code``-asserting test in ``test_semantic.py``.
+* ``validate_semantic(payload, rules)`` — single driver. Runs the
+  given rules against ``payload``, aggregates ``ValidationIssue``
+  entries (each tagged with ``rule.code``), and raises
+  ``ConfigValidationError`` once if any rule fired. Caller decides
+  which rules apply to its payload.
+* ``_FORMAT_LINT_SCOPE`` / ``_COMMAND_SYNTAX`` / ``_TIER_CONSISTENCY``
+  / ``_PATTERN_UNIQUENESS`` — named rule constants. ``loader.py`` and
+  ``merger.py`` each import the rules that match the data they have
+  on hand (parsed yaml for loader, merged tree for merger).
 
-Internal submodule — import the public surface via
-:mod:`ac_guard.config` rather than reaching in here directly.
+Adding a new rule is mechanical: write ``_verify_xxx``, define a
+module-level ``_SemanticRule(code=..., apply=_verify_xxx)`` constant, and
+have the relevant caller import it into its rule list. Add a
+``rule_code``-asserting test in ``test_semantic.py``.
+
+Internal submodule — never imported across packages.
 """
 
 from __future__ import annotations
@@ -41,11 +51,11 @@ from typing import TYPE_CHECKING, Any
 from ac_guard.config.exceptions import ConfigValidationError, ValidationIssue
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterable, Iterator
 
     from ac_guard.config.models import OperationRules, ResolvedConfig
 
-__all__ = ["validate_semantic_resolved", "validate_semantic_static"]
+__all__: list[str] = []  # package-internal — accessed via submodule path
 
 
 # Stages whose pre-commit ``types:`` filter matches source files. Only
@@ -80,7 +90,7 @@ class _SemanticRule:
     apply: Callable[[Any, list[ValidationIssue]], None]
 
 
-def _run_rules(rules: tuple[_SemanticRule, ...], data: Any) -> list[ValidationIssue]:
+def _run_rules(rules: Iterable[_SemanticRule], data: Any) -> list[ValidationIssue]:
     """Run every rule against ``data``, post-inject ``rule_code``."""
     issues: list[ValidationIssue] = []
     for rule in rules:
@@ -256,54 +266,51 @@ def _verify_pattern_uniqueness(
 
 
 # ---------------------------------------------------------------------------
-# Rule registries — adding a new rule means appending a line here.
+# Named rule constants — caller imports the ones it cares about.
 # ---------------------------------------------------------------------------
 
 
-_STATIC_RULES: tuple[_SemanticRule, ...] = (
-    _SemanticRule(code="format-lint-stage-scope", apply=_verify_format_lint_scope),
-    _SemanticRule(code="command-syntax", apply=_verify_command_syntax),
+_FORMAT_LINT_SCOPE = _SemanticRule(
+    code="format-lint-stage-scope",
+    apply=_verify_format_lint_scope,
+)
+_COMMAND_SYNTAX = _SemanticRule(
+    code="command-syntax",
+    apply=_verify_command_syntax,
+)
+_TIER_CONSISTENCY = _SemanticRule(
+    code="tier-consistency",
+    apply=_verify_tier_consistency,
+)
+_PATTERN_UNIQUENESS = _SemanticRule(
+    code="pattern-uniqueness",
+    apply=_verify_pattern_uniqueness,
 )
 
 
-_RESOLVED_RULES: tuple[_SemanticRule, ...] = (
-    _SemanticRule(code="tier-consistency", apply=_verify_tier_consistency),
-    _SemanticRule(code="pattern-uniqueness", apply=_verify_pattern_uniqueness),
-)
-
-
 # ---------------------------------------------------------------------------
-# Public entry points
+# Driver
 # ---------------------------------------------------------------------------
 
 
-def validate_semantic_static(raw: dict[str, Any], *, source: str) -> None:
-    """Run L2 semantic rules over a raw config dict.
+def validate_semantic(payload: Any, rules: Iterable[_SemanticRule]) -> None:
+    """Run the given semantic rules over *payload*; raise on any issue.
+
+    Callers (loader.py / merger.py) decide which rules apply to their
+    payload by passing the rule constants they want to enforce. The
+    driver itself stays oblivious to "phase" / "stage" / "raw vs
+    resolved" concepts — those are caller-side strategy.
 
     Args:
-        raw: Parsed YAML dict, post-L1 schema validation.
-        source: Label kept for parity with ``validate_raw_config``;
-            currently unused by the rules but reserved for future
-            error context (e.g. yaml line numbers).
+        payload: The data each rule will inspect. For rules judging
+            yaml content, pass the parsed dict (post-L1). For rules
+            judging the merged tree, pass the ``ResolvedConfig``.
+        rules: Iterable of rule constants to run. Issues from each
+            rule are tagged with that rule's ``code`` automatically.
 
     Raises:
-        ConfigValidationError: If any L2 rule fires.
+        ConfigValidationError: If any rule produces issues.
     """
-    del source  # reserved
-    issues = _run_rules(_STATIC_RULES, raw)
-    if issues:
-        raise ConfigValidationError(issues)
-
-
-def validate_semantic_resolved(resolved: ResolvedConfig) -> None:
-    """Run L3 semantic rules over a fully merged ``ResolvedConfig``.
-
-    Args:
-        resolved: ResolvedConfig returned by the merger.
-
-    Raises:
-        ConfigValidationError: If any L3 rule fires.
-    """
-    issues = _run_rules(_RESOLVED_RULES, resolved)
+    issues = _run_rules(rules, payload)
     if issues:
         raise ConfigValidationError(issues)

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -380,7 +380,7 @@ class TestDoctorLanguageCoverage:
         config = _yaml_with_languages(tmp_path, {"python": {}})
         # No .git dir in tmp_path → git ls-files returns non-zero
         result = runner.invoke(app, ["doctor", "--config", str(config)])
-        assert "5. Config Semantic Runtime" in result.output
+        assert "5. Configuration Diagnosis" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config/test_diagnose.py
+++ b/tests/unit/test_config/test_diagnose.py
@@ -1,12 +1,12 @@
-"""Tests for ac_guard.config.runtime_check — L4 semantic-runtime checks.
+"""Tests for ac_guard.config.diagnose — IO-bearing config-environment checks.
 
-L4 holds the semantic checks that need a runtime context (filesystem,
-PATH, git working tree). They live in ``config.runtime_check`` rather
-than ``config.semantic`` so the file boundary makes the IO contract
-visible: ``semantic.py`` is zero-IO, ``runtime_check.py`` is the only
-config-layer module allowed to touch the outside world.
+These checks need a runtime context (filesystem, PATH, git working
+tree). They live in ``config.diagnose`` rather than ``config.semantic``
+so the file boundary makes the IO contract visible: ``semantic.py``
+is zero-IO, ``diagnose.py`` is the only config-layer module allowed
+to touch the outside world.
 
-doctor consumes ``runtime_check(resolved, project_root)`` and renders
+doctor consumes ``diagnose_config(resolved, project_root)`` and renders
 the returned ``Diagnostic`` list; these tests exercise the helpers in
 isolation under a controlled tmp_path.
 """
@@ -14,17 +14,11 @@ isolation under a controlled tmp_path.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-# Importing the submodule populates ``sys.modules`` even though the
-# ``__init__.py`` rebinds the ``runtime_check`` *attribute* of the
-# config package to the function. Reaching into ``sys.modules`` is the
-# only way to get a handle on the actual submodule for ``__all__``
-# introspection.
-import ac_guard.config.runtime_check  # noqa: F401  (registers in sys.modules)
+from ac_guard.config import diagnose as rc
 from ac_guard.config.models import (
     BehaviorConfig,
     CodeConfig,
@@ -35,8 +29,6 @@ from ac_guard.config.models import (
     ResolvedConfig,
     StageBucket,
 )
-
-rc = sys.modules["ac_guard.config.runtime_check"]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -273,16 +265,16 @@ class TestVerifyRulesetPaths:
 
 
 # ---------------------------------------------------------------------------
-# runtime_check public entry
+# diagnose_config public entry
 # ---------------------------------------------------------------------------
 
 
-class TestRuntimeCheck:
+class TestDiagnoseConfig:
     """The public entry runs all helpers and concatenates diagnostics."""
 
     def test_returns_list_of_diagnostics(self, tmp_path: Path) -> None:
         cfg = _resolved()
-        diags = rc.runtime_check(cfg, tmp_path)
+        diags = rc.diagnose_config(cfg, tmp_path)
         assert isinstance(diags, list)
         assert all(isinstance(d, rc.Diagnostic) for d in diags)
 
@@ -295,11 +287,11 @@ class TestRuntimeCheck:
             ),
             rulesets=[str(tmp_path / "missing.yaml")],
         )
-        diags = rc.runtime_check(cfg, tmp_path)
+        diags = rc.diagnose_config(cfg, tmp_path)
         fails = [d for d in diags if d.level == "fail"]
         # One from command-paths, one from ruleset-paths.
         assert len(fails) >= 2
 
     def test_public_module_surface(self) -> None:
-        assert "runtime_check" in rc.__all__
+        assert "diagnose_config" in rc.__all__
         assert "Diagnostic" in rc.__all__

--- a/tests/unit/test_config/test_public_api.py
+++ b/tests/unit/test_config/test_public_api.py
@@ -15,13 +15,10 @@ import ac_guard.config as config_pkg
 
 EXPECTED_PUBLIC_API: frozenset[str] = frozenset(
     {
-        # Entry-point functions (B1 / B2)
+        # Entry-point functions
         "resolve_config",
-        "load_config",
         # Configuration-environment diagnosis entry (IO-bearing, doctor-side).
         "diagnose_config",
-        # Input schema (S1)
-        "RawConfig",
         # Output schema tree (S2): 14 dataclasses reachable from ResolvedConfig
         "ResolvedConfig",
         "BehaviorConfig",

--- a/tests/unit/test_config/test_public_api.py
+++ b/tests/unit/test_config/test_public_api.py
@@ -18,8 +18,8 @@ EXPECTED_PUBLIC_API: frozenset[str] = frozenset(
         # Entry-point functions (B1 / B2)
         "resolve_config",
         "load_config",
-        # Semantic-runtime entry — IO-bearing config check used by doctor.
-        "runtime_check",
+        # Configuration-environment diagnosis entry (IO-bearing, doctor-side).
+        "diagnose_config",
         # Input schema (S1)
         "RawConfig",
         # Output schema tree (S2): 14 dataclasses reachable from ResolvedConfig

--- a/tests/unit/test_config/test_semantic.py
+++ b/tests/unit/test_config/test_semantic.py
@@ -1,13 +1,16 @@
-"""Tests for ac_guard.config.semantic — L2/L3 semantic validation rules.
+"""Tests for ac_guard.config.semantic — zero-IO semantic rules.
 
-L2 takes raw config dicts (post-L1 schema validation) and checks
-cross-field semantic consistency that schema can't express. L3 takes a
-fully resolved config and checks invariants that depend on the merge
-result. Both layers are zero-IO.
+Four named rules cover the cross-field semantics that L1 schema can't
+express. Tests group them by rule (one ``Test*Rule`` class per code)
+and dispatch through the single ``validate_semantic(payload, rules)``
+driver. Each issue carries a ``rule_code`` so tests can assert which
+rule fired without coupling to error wording.
 
-Each rule is identified by a stable ``rule_code`` that the driver
-injects into every ``ValidationIssue`` it produces, so tests can
-assert which rule fired without coupling to error messages.
+Two of the rules judge yaml content (``_FORMAT_LINT_SCOPE`` /
+``_COMMAND_SYNTAX``) and run from ``loader.py``; the other two judge
+the merged tree (``_TIER_CONSISTENCY`` / ``_PATTERN_UNIQUENESS``) and
+run from ``merger.py``. The split is caller-side strategy, not a
+property of the rules themselves.
 """
 
 from __future__ import annotations
@@ -24,9 +27,17 @@ from ac_guard.config.models import (
     Rule,
 )
 from ac_guard.config.semantic import (
-    validate_semantic_resolved,
-    validate_semantic_static,
+    _COMMAND_SYNTAX,
+    _FORMAT_LINT_SCOPE,
+    _PATTERN_UNIQUENESS,
+    _TIER_CONSISTENCY,
+    validate_semantic,
 )
+
+# Rule groupings used by the package-internal callers (loader / merger).
+# Tests reuse them so behavior matches what loader / merger actually run.
+_YAML_RULES = (_FORMAT_LINT_SCOPE, _COMMAND_SYNTAX)
+_TREE_RULES = (_TIER_CONSISTENCY, _PATTERN_UNIQUENESS)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -47,7 +58,7 @@ def _resolved(behavior: BehaviorConfig | None = None) -> ResolvedConfig:
 
 
 # ---------------------------------------------------------------------------
-# L2: validate_semantic_static (raw dict input)
+# Yaml-content rules: dispatched via validate_semantic(_YAML_RULES)
 # ---------------------------------------------------------------------------
 
 
@@ -64,7 +75,7 @@ class TestFormatLintStageScopeRule:
     def test_format_on_commit_msg_rejected(self) -> None:
         raw = {"code": {"commit-msg": {"format": True}}}
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         issues = [
             e for e in exc_info.value.errors if e.rule_code == "format-lint-stage-scope"
         ]
@@ -74,7 +85,7 @@ class TestFormatLintStageScopeRule:
     def test_lint_on_pre_rebase_rejected(self) -> None:
         raw = {"code": {"pre-rebase": {"lint": True}}}
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         issues = [
             e for e in exc_info.value.errors if e.rule_code == "format-lint-stage-scope"
         ]
@@ -83,22 +94,22 @@ class TestFormatLintStageScopeRule:
 
     def test_format_on_pre_commit_passes(self) -> None:
         raw = {"code": {"pre-commit": {"format": True}}}
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
     def test_format_on_pre_push_passes(self) -> None:
         raw = {"code": {"pre-push": {"format": True}}}
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
     def test_format_false_on_commit_msg_passes(self) -> None:
         """Rule fires only on True; explicit False is benign."""
         raw = {"code": {"commit-msg": {"format": False, "lint": False}}}
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
     def test_both_format_and_lint_misplaced_each_reported(self) -> None:
         """Both toggles produce separate issues so the user sees both."""
         raw = {"code": {"commit-msg": {"format": True, "lint": True}}}
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         paths = sorted(e.path for e in exc_info.value.errors)
         assert paths == ["code.commit-msg.format", "code.commit-msg.lint"]
 
@@ -106,7 +117,7 @@ class TestFormatLintStageScopeRule:
         """Schema (L1) catches non-dict buckets; L2 defends against
         being run independently with a malformed input."""
         raw = {"code": {"pre-commit": "not-a-dict"}}
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
 
 class TestCommandSyntaxRule:
@@ -119,7 +130,7 @@ class TestCommandSyntaxRule:
             }
         }
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         issues = [e for e in exc_info.value.errors if e.rule_code == "command-syntax"]
         assert len(issues) == 1
         assert issues[0].path == "languages.python.tools.format"
@@ -129,7 +140,7 @@ class TestCommandSyntaxRule:
             "languages": {"python": {"tools": {"format": "black", "lint": 'ruff "x'}}}
         }
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         issues = [e for e in exc_info.value.errors if e.rule_code == "command-syntax"]
         assert len(issues) == 1
         assert issues[0].path == "languages.python.tools.lint"
@@ -141,7 +152,7 @@ class TestCommandSyntaxRule:
             }
         }
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         issues = [e for e in exc_info.value.errors if e.rule_code == "command-syntax"]
         assert len(issues) == 1
         assert issues[0].path == "code.pre-commit.checks.my-check.command"
@@ -159,16 +170,16 @@ class TestCommandSyntaxRule:
                 },
             },
         }
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
     def test_empty_command_skipped(self) -> None:
         """Empty strings are an L1 concern (non_empty); L2 must not double-report."""
         raw = {"languages": {"python": {"tools": {"format": "", "lint": ""}}}}
-        validate_semantic_static(raw, source="guard.yaml")  # no raise
+        validate_semantic(raw, _YAML_RULES)  # no raise
 
 
 # ---------------------------------------------------------------------------
-# L3: validate_semantic_resolved (ResolvedConfig input)
+# Merged-tree rules: dispatched via validate_semantic(_TREE_RULES)
 # ---------------------------------------------------------------------------
 
 
@@ -187,7 +198,7 @@ class TestTierConsistencyRule:
             )
         )
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_resolved(cfg)
+            validate_semantic(cfg, _TREE_RULES)
         issues = [e for e in exc_info.value.errors if e.rule_code == "tier-consistency"]
         assert len(issues) == 1
         assert "behavior.read" in issues[0].path
@@ -203,7 +214,7 @@ class TestTierConsistencyRule:
                 read=rules, write=OperationRules.empty(), execute=OperationRules.empty()
             )
         )
-        validate_semantic_resolved(cfg)  # no raise
+        validate_semantic(cfg, _TREE_RULES)  # no raise
 
     def test_same_pattern_in_different_ops_does_not_conflict(self) -> None:
         """forbidden:X under read does not conflict with allow:X under write."""
@@ -222,7 +233,7 @@ class TestTierConsistencyRule:
                 execute=OperationRules.empty(),
             )
         )
-        validate_semantic_resolved(cfg)  # no raise
+        validate_semantic(cfg, _TREE_RULES)  # no raise
 
     def test_each_op_checked_independently(self) -> None:
         """All three operations (read/write/execute) get their own check."""
@@ -233,7 +244,7 @@ class TestTierConsistencyRule:
         )
         cfg = _resolved(BehaviorConfig(read=conflict, write=conflict, execute=conflict))
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_resolved(cfg)
+            validate_semantic(cfg, _TREE_RULES)
         paths = {
             e.path for e in exc_info.value.errors if e.rule_code == "tier-consistency"
         }
@@ -259,7 +270,7 @@ class TestPatternUniquenessRule:
             )
         )
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_resolved(cfg)
+            validate_semantic(cfg, _TREE_RULES)
         issues = [
             e for e in exc_info.value.errors if e.rule_code == "pattern-uniqueness"
         ]
@@ -282,7 +293,7 @@ class TestPatternUniquenessRule:
                 execute=OperationRules.empty(),
             )
         )
-        validate_semantic_resolved(cfg)  # no raise
+        validate_semantic(cfg, _TREE_RULES)  # no raise
 
     def test_two_user_duplicates_rejected_even_with_system_third(self) -> None:
         """System rule does not save user duplicates from being reported."""
@@ -302,7 +313,7 @@ class TestPatternUniquenessRule:
             )
         )
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_resolved(cfg)
+            validate_semantic(cfg, _TREE_RULES)
         issues = [
             e for e in exc_info.value.errors if e.rule_code == "pattern-uniqueness"
         ]
@@ -323,7 +334,7 @@ class TestPatternUniquenessRule:
                 execute=OperationRules.empty(),
             )
         )
-        validate_semantic_resolved(cfg)  # no raise
+        validate_semantic(cfg, _TREE_RULES)  # no raise
 
     def test_duplicates_in_each_tier_reported(self) -> None:
         cfg = _resolved(
@@ -338,7 +349,7 @@ class TestPatternUniquenessRule:
             )
         )
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_resolved(cfg)
+            validate_semantic(cfg, _TREE_RULES)
         paths = {
             e.path for e in exc_info.value.errors if e.rule_code == "pattern-uniqueness"
         }
@@ -360,7 +371,7 @@ class TestDriverInjection:
     def test_rule_code_set_on_all_issues_from_rule(self) -> None:
         raw = {"code": {"commit-msg": {"format": True, "lint": True}}}
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         # Both issues from format-lint-stage-scope must carry the same rule_code.
         for issue in exc_info.value.errors:
             assert issue.rule_code == "format-lint-stage-scope"
@@ -378,7 +389,7 @@ class TestDriverInjection:
             },
         }
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         codes = {e.rule_code for e in exc_info.value.errors}
         assert codes == {"format-lint-stage-scope", "command-syntax"}
 
@@ -387,16 +398,16 @@ class TestEmptyConfigsPass:
     """Empty / minimal configs should not trigger any rule."""
 
     def test_static_passes_on_empty(self) -> None:
-        validate_semantic_static({}, source="guard.yaml")
+        validate_semantic({}, _YAML_RULES)
 
     def test_static_passes_on_minimal(self) -> None:
-        validate_semantic_static(
+        validate_semantic(
             {"version": 1, "project": {"language": "python"}},
-            source="guard.yaml",
+            _YAML_RULES,
         )
 
     def test_resolved_passes_on_empty_behavior(self) -> None:
-        validate_semantic_resolved(_resolved())
+        validate_semantic(_resolved(), _TREE_RULES)
 
 
 class TestIssueIsValidationIssueInstance:
@@ -405,6 +416,6 @@ class TestIssueIsValidationIssueInstance:
     def test_issue_class(self) -> None:
         raw = {"code": {"commit-msg": {"format": True}}}
         with pytest.raises(ConfigValidationError) as exc_info:
-            validate_semantic_static(raw, source="guard.yaml")
+            validate_semantic(raw, _YAML_RULES)
         for issue in exc_info.value.errors:
             assert isinstance(issue, ValidationIssue)


### PR DESCRIPTION
## Summary
Three steps that together collapse `ac_guard.config`'s public surface to the minimum it actually owes its callers:

1. **Unify the semantic driver** — `validate_semantic_static` / `validate_semantic_resolved` collapse into a single `validate_semantic(payload, rules)` driver. Four named rule constants (`_FORMAT_LINT_SCOPE` / `_COMMAND_SYNTAX` / `_TIER_CONSISTENCY` / `_PATTERN_UNIQUENESS`) are exposed within the package; callers (`loader.py`, `merger.py`) pick rules explicitly. `semantic.py` becomes package-internal (`__all__` is empty).

2. **Rename `runtime_check` → `diagnose_config`** — the function diagnoses configuration consistency against the current environment, so the new name says *what* (diagnose) and *to what* (config). Pairs naturally with the `Diagnostic` return type. Module renamed to `diagnose.py`. Doctor's "5. Config Semantic Runtime" section becomes "5. Configuration Diagnosis".

3. **Drop `load_config` and `RawConfig` from the public API** (closes #109 P1-1). `resolve_config` gains a `fetch_rulesets` callback so callers don't need to peek raw yaml just to drive ruleset fetch. `cli/install.py` uses the callback; `cli/status.py` collapses its two-stage error reporting (yaml-invalid vs cannot-be-resolved) into one. Both `load_config` and `RawConfig` stay reachable via the submodule path for merger-internal use and white-box tests, but leave the package facade.

## Why
Naming review after #147 surfaced misleading names (`validate_semantic_static` vs `validate_semantic_resolved` — both zero-IO, "static" implies the wrong axis; `runtime_check` — vague verb without a subject). And a recurring pattern in `cli/install.py` (`load_config()` → take `rulesets:` field → fetch → `resolve_config()`) leaked yaml internals into the caller — exactly the dimension #109 P1-1 listed for tightening.

The fixes are conceptually one job ("audit and tighten the public face of `config`"), so they ship together.

## Test plan
- [x] `pytest` — full suite (1165) passes
- [x] `import-linter` — both contracts kept
- [x] `pre-commit run --all-files` — passes
- [x] Old public names removed: `from ac_guard.config import runtime_check / validate_semantic_static / validate_semantic_resolved / load_config / RawConfig` all raise `ImportError`
- [x] New public names work: `from ac_guard.config import diagnose_config, Diagnostic`
- [x] Submodule paths still work for internal callers: `from ac_guard.config.semantic import validate_semantic, _FORMAT_LINT_SCOPE`; `from ac_guard.config.loader import load_config, RawConfig`
- [x] End-to-end: `ac-guard doctor` shows "5. Configuration Diagnosis" with the same Diagnostic content
- [x] End-to-end: broken yaml fails at config load with rule code, single `[FAIL] guard.yaml: ...` line (no longer split into "invalid" / "cannot be resolved")
- [x] End-to-end: `ac-guard install` with `rulesets:` declared still fetches and merges rulesets (now via the new callback path)

## Public API delta
**Removed from `ac_guard.config.__all__`:**
- `runtime_check` (replaced by `diagnose_config`)
- `load_config`
- `RawConfig`

**Added to `ac_guard.config.__all__`:**
- `diagnose_config`

**Net surface size:** 24 → 23 (reduced by 1; one rename, two collapses).

`Diagnostic` and the 14 dataclass output schema are unchanged. Errors layer is unchanged. `validate_semantic_static` / `validate_semantic_resolved` were never in the package facade — they only lived in the `semantic` submodule's `__all__`, which is now empty (`semantic.py` is fully package-internal).

## Behavior changes for end users
- Configs that previously surfaced as `[FAIL] guard.yaml invalid: ...` or `[FAIL] guard.yaml cannot be resolved: ...` now both surface as `[FAIL] guard.yaml: ...`. The underlying `ConfigError` content is unchanged.

Refs #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)