### PR TITLE
refactor(generator)!: tighten public API surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,8 @@ known-first-party = ["ac_guard"]
 # exceed max-args. The dataclass-bundle pattern (RunRequest in cli.check)
 # applies to the business layer; the Typer surface itself cannot use it.
 "src/ac_guard/cli/main.py" = ["PLR0913"]
+# Path is used at runtime in installation_path() — cannot be TYPE_CHECKING only.
+"src/ac_guard/generator/models.py" = ["TC003"]
 
 [tool.ruff.lint.pep8-naming]
 # Private conventions inherited from the retired scripts/checks/_config.py:

--- a/src/ac_guard/cli/install.py
+++ b/src/ac_guard/cli/install.py
@@ -15,22 +15,17 @@ from ac_guard.config import (
     ConfigError,
     resolve_config,
 )
-from ac_guard.generator.core import (
-    create_state,
+from ac_guard.generator import (
+    ArtifactWriteError,
+    create_installation,
     delete_artifacts,
-    generate_check_scripts,
-    generate_git_hooks,
-    generate_hook_files,
-    generate_policy_cache,
-    generate_precommit_config,
-    generate_rule_docs,
-    generate_tool_configs,
-    read_state,
+    delete_installation,
+    generate_all,
+    installation_path,
+    read_installation,
     write_artifacts,
-    write_state,
+    write_installation,
 )
-from ac_guard.generator.exceptions import ArtifactWriteError
-from ac_guard.generator.models import STATE_FILE
 from ac_guard.ruleset import load_ruleset_config
 
 _LEGACY_RUNTIME_CACHE = ".ac-guard/policy.json"
@@ -40,7 +35,6 @@ if TYPE_CHECKING:
 
     from ac_guard.adapters.base import AgentAdapter
     from ac_guard.config import ResolvedConfig
-    from ac_guard.domain import FileSpec
 
 __all__ = ["install_command", "update_command", "uninstall_command"]
 
@@ -88,46 +82,7 @@ def _run_generator_pipeline(
     Raises:
         ArtifactWriteError: If file writes fail.
     """
-
-    artifacts: list[FileSpec] = []
-
-    # G1: Rule documents
-    artifacts.extend(generate_rule_docs(adapters, resolved_config.behavior))
-
-    # G2: Hook files
-    artifacts.extend(generate_hook_files(adapters, resolved_config.behavior))
-
-    # G3: Tool configs from rulesets (skip existing unless --force)
-    artifacts.extend(generate_tool_configs(project_root, rulesets, force=force))
-
-    # G3b: Check scripts from rulesets (always overwrite)
-    artifacts.extend(generate_check_scripts(project_root, rulesets))
-
-    # G4: Pre-commit config
-    artifacts.append(
-        generate_precommit_config(
-            resolved_config.code,
-            resolved_config.languages,
-            resolved_config.pre_commit_meta,
-        )
-    )
-
-    # G5: Policy cache (runtime.json — behavior + audit config)
-    artifacts.append(
-        generate_policy_cache(
-            resolved_config.behavior,
-            resolved_config.config_hash,
-            audit=resolved_config.output.audit,
-        )
-    )
-
-    # G6: Git hooks
-    git_hooks = generate_git_hooks(project_root, resolved_config.code)
-    if not git_hooks:
-        print("Warning: .git directory not found. Git hooks were not installed.")
-    artifacts.extend(git_hooks)
-
-    # G7: Write all artifacts to disk
+    artifacts = generate_all(project_root, resolved_config, adapters, force=force)
     return write_artifacts(project_root, artifacts)
 
 
@@ -295,7 +250,7 @@ def install_command(
         raise SystemExit(1) from None
 
     # Read existing state for incremental install
-    existing_state = read_state(project_root)
+    existing_state = read_installation(project_root)
     existing_agents = existing_state.installed_agents if existing_state else []
     all_agents = _merge_agents(existing_agents, agents)
 
@@ -312,8 +267,8 @@ def install_command(
         raise SystemExit(1) from None
 
     # Update state
-    state = create_state(all_agents, resolved.config_hash, written_paths)
-    write_state(project_root, state)
+    state = create_installation(all_agents, resolved.config_hash, written_paths)
+    write_installation(project_root, state)
 
     _run_post_install_audit_maintenance(project_root, resolved)
 
@@ -335,7 +290,7 @@ def update_command(
         config_path: Path to guard.yaml.
         force: If True, overwrite existing tool config files.
     """
-    existing_state = read_state(project_root)
+    existing_state = read_installation(project_root)
     if existing_state is None:
         print("Error: AI Code Guard is not installed. Run 'ac-guard install' first.")
         raise SystemExit(1)
@@ -369,10 +324,10 @@ def update_command(
         raise SystemExit(1) from None
 
     # Update state
-    state = create_state(
+    state = create_installation(
         existing_state.installed_agents, resolved.config_hash, written_paths
     )
-    write_state(project_root, state)
+    write_installation(project_root, state)
 
     _run_post_install_audit_maintenance(project_root, resolved)
 
@@ -392,7 +347,7 @@ def uninstall_command(
         project_root: Path to project root directory.
         keep_config: If True, preserves guard.yaml.
     """
-    existing_state = read_state(project_root)
+    existing_state = read_installation(project_root)
     if existing_state is None:
         print("Nothing to uninstall.")
         return
@@ -401,10 +356,8 @@ def uninstall_command(
     deleted = delete_artifacts(project_root, existing_state.artifacts)
 
     # Delete state.json
-    state_path = project_root / STATE_FILE
-    if state_path.is_file():
-        state_path.unlink()
-        deleted.append(STATE_FILE)
+    if delete_installation(project_root):
+        deleted.append(str(installation_path(project_root).relative_to(project_root)))
 
     # Clean up .ac-guard directory if empty
     ac_guard_dir = project_root / ".ac-guard"

--- a/src/ac_guard/cli/status.py
+++ b/src/ac_guard/cli/status.py
@@ -19,7 +19,7 @@ from ac_guard.config import (
     diagnose_config,
     resolve_config,
 )
-from ac_guard.generator.core import read_state
+from ac_guard.generator import read_installation
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,7 +61,7 @@ def status_command(
         show_rules: Whether to display the active rule list.
         output_format: Output format (``"text"`` or ``"json"``).
     """
-    state = read_state(project_root)
+    state = read_installation(project_root)
 
     if output_format == "json":
         _status_json(state, project_root, config_path)
@@ -79,7 +79,7 @@ def _status_text(
     """Output status as text.
 
     Args:
-        state: GeneratedState or None.
+        state: Installation or None.
         project_root: Path to project root.
         config_path: Path to guard.yaml.
         show_rules: Whether to display active rules.
@@ -136,7 +136,7 @@ def _status_json(state: object, project_root: Path, config_path: Path) -> None:
     """Output status as JSON.
 
     Args:
-        state: GeneratedState or None.
+        state: Installation or None.
         project_root: Path to project root.
         config_path: Path to guard.yaml.
     """
@@ -327,7 +327,7 @@ def _check_config(config_path: Path, tally: _Tally) -> ResolvedConfig | None:
 
 def _check_file_integrity(project_root: Path, tally: _Tally) -> None:
     """Check artifact file integrity."""
-    state = read_state(project_root)
+    state = read_installation(project_root)
     if state is None:
         print("  [WARN] Not installed (no state.json)")
         tally.warn_inc()
@@ -351,7 +351,7 @@ def _check_file_integrity(project_root: Path, tally: _Tally) -> None:
 
 def _check_drift(project_root: Path, config_path: Path, tally: _Tally) -> None:
     """Check configuration drift."""
-    state = read_state(project_root)
+    state = read_installation(project_root)
     if state is None:
         print("  [SKIP] Not installed")
         return
@@ -411,7 +411,7 @@ def agents_command(project_root: Path) -> None:
     Args:
         project_root: Path to project root directory.
     """
-    state = read_state(project_root)
+    state = read_installation(project_root)
     installed = set(state.installed_agents) if state else set()
 
     print("Agent Capability Matrix")

--- a/src/ac_guard/generator/__init__.py
+++ b/src/ac_guard/generator/__init__.py
@@ -1,59 +1,45 @@
 """Generator module for AI Code Guard.
 
-Consumes ResolvedConfig and generates all static artifacts (rule docs,
+Consumes ResolvedConfig and produces all static artifacts (rule docs,
 hook scripts, tool configs, pre-commit config, policy cache, git hooks).
 
-G primitives:
-- G1: generate_rule_docs - Agent-specific rule documents
-- G2: generate_hook_files - Agent-specific Hook scripts
-- G3-G6: Agent-agnostic artifacts (WP1.3c)
-- G7: write_artifacts - Write all artifacts to disk
+``generate_all`` is the single orchestration entry-point for
+``install`` / ``update``.  The seven per-G primitives are
+module-private (test via deep import from ``core``).
 """
 
-from ac_guard.domain import FileSpec  # Shared type
+from ac_guard.domain import FileSpec  # Shared DTO, re-exported for callers
 from ac_guard.generator.core import (
-    create_state,
+    create_installation,
     delete_artifacts,
-    generate_git_hooks,
-    generate_hook_files,
-    generate_policy_cache,
-    generate_precommit_config,
-    generate_rule_docs,
-    generate_tool_configs,
-    read_state,
+    delete_installation,
+    generate_all,
+    read_installation,
     write_artifacts,
-    write_state,
+    write_installation,
 )
 from ac_guard.generator.exceptions import (
-    AdapterNotRegisteredError,
     ArtifactWriteError,
     GeneratorError,
-    GitDirectoryNotFoundError,
 )
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+from ac_guard.generator.models import Installation, installation_path
 
 __all__ = [
+    # Schema
+    "FileSpec",
+    "Installation",
     # Exceptions
     "GeneratorError",
     "ArtifactWriteError",
-    "GitDirectoryNotFoundError",
-    "AdapterNotRegisteredError",
-    # Models
-    "FileSpec",
-    "GeneratedState",
-    "STATE_FILE",
-    # G1/G2 primitives
-    "generate_rule_docs",
-    "generate_hook_files",
-    # G3-G6 primitives
-    "generate_policy_cache",
-    "generate_git_hooks",
-    "generate_tool_configs",
-    "generate_precommit_config",
-    # Core functions
-    "create_state",
-    "delete_artifacts",
-    "read_state",
-    "write_state",
+    # Orchestration
+    "generate_all",
     "write_artifacts",
+    # Installation lifecycle
+    "read_installation",
+    "write_installation",
+    "create_installation",
+    "delete_installation",
+    "installation_path",
+    # Cleanup
+    "delete_artifacts",
 ]

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -1,8 +1,8 @@
 """Generator core functions for AI Code Guard.
 
 Implements G1-G7 primitives for artifact generation:
-- G1: generate_rule_docs - Agent-specific rule documents
-- G2: generate_hook_files - Agent-specific Hook scripts
+- G1: _generate_rule_docs - Agent-specific rule documents
+- G2: _generate_hook_files - Agent-specific Hook scripts
 - G3-G6: Agent-agnostic artifacts (WP1.3c)
 - G7: write_artifacts - Write all artifacts to disk
 
@@ -22,9 +22,10 @@ from typing import TYPE_CHECKING, Any
 from jinja2 import Environment, FileSystemLoader
 
 from ac_guard import __version__
+from ac_guard.config import PreCommitMeta
 from ac_guard.domain import FileSpec, managed_block
 from ac_guard.generator.exceptions import ArtifactWriteError
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+from ac_guard.generator.models import Installation, installation_path
 from ac_guard.ruleset import get_ruleset_dir
 
 if TYPE_CHECKING:
@@ -35,27 +36,22 @@ if TYPE_CHECKING:
         CodeConfig,
         LanguageTools,
         OperationRules,
-        PreCommitMeta,
         PreCommitRepo,
+        ResolvedConfig,
         Rule,
         StageBucket,
     )
 
 __all__ = [
-    # G1/G2 primitives
-    "generate_rule_docs",
-    "generate_hook_files",
-    # G3-G6 primitives
-    "generate_policy_cache",
-    "generate_git_hooks",
-    "generate_tool_configs",
-    "generate_precommit_config",
-    # State management
-    "read_state",
-    "write_state",
-    "create_state",
-    # Artifact writing (G7)
+    # Orchestration
+    "generate_all",
     "write_artifacts",
+    # Installation lifecycle
+    "read_installation",
+    "write_installation",
+    "create_installation",
+    "delete_installation",
+    # Cleanup
     "delete_artifacts",
 ]
 
@@ -89,7 +85,7 @@ def _get_generator_env() -> Environment:
 # ---------------------------------------------------------------------------
 
 
-def generate_rule_docs(
+def _generate_rule_docs(
     adapters: list[AgentAdapter],
     behavior: BehaviorConfig,
 ) -> list[FileSpec]:
@@ -118,7 +114,7 @@ def generate_rule_docs(
     return artifacts
 
 
-def generate_hook_files(
+def _generate_hook_files(
     adapters: list[AgentAdapter],
     behavior: BehaviorConfig,
 ) -> list[FileSpec]:
@@ -148,42 +144,42 @@ def generate_hook_files(
 # ---------------------------------------------------------------------------
 
 
-def read_state(project_root: Path) -> GeneratedState | None:
+def read_installation(project_root: Path) -> Installation | None:
     """Read installation state from .ac-guard/state.json.
 
     Args:
         project_root: Path to the project root directory.
 
     Returns:
-        GeneratedState if state.json exists, None otherwise.
+        Installation if state.json exists, None otherwise.
     """
-    state_path = project_root / STATE_FILE
+    state_path = installation_path(project_root)
     if not state_path.is_file():
         return None
     content = state_path.read_text(encoding="utf-8")
-    return GeneratedState.from_json(content)
+    return Installation.from_json(content)
 
 
-def write_state(project_root: Path, state: GeneratedState) -> None:
+def write_installation(project_root: Path, state: Installation) -> None:
     """Write installation state to .ac-guard/state.json.
 
     Creates the .ac-guard/ directory if it doesn't exist.
 
     Args:
         project_root: Path to the project root directory.
-        state: The GeneratedState to write.
+        state: The Installation to write.
     """
-    state_path = project_root / STATE_FILE
+    state_path = installation_path(project_root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(state.to_json(), encoding="utf-8")
 
 
-def create_state(
+def create_installation(
     installed_agents: list[str],
     config_hash: str,
     artifacts: list[str],
-) -> GeneratedState:
-    """Create a new GeneratedState with current tool version.
+) -> Installation:
+    """Create a new Installation with current tool version.
 
     Args:
         installed_agents: List of agent identifiers being installed.
@@ -191,9 +187,9 @@ def create_state(
         artifacts: List of generated artifact paths.
 
     Returns:
-        A new GeneratedState instance.
+        A new Installation instance.
     """
-    return GeneratedState(
+    return Installation(
         ac_guard_version=__version__,
         installed_agents=installed_agents,
         config_hash=config_hash,
@@ -361,7 +357,7 @@ def delete_artifacts(
 # ---------------------------------------------------------------------------
 
 
-def generate_policy_cache(
+def _generate_policy_cache(
     behavior: BehaviorConfig,
     config_hash: str,
     audit: AuditConfig | None = None,
@@ -440,7 +436,7 @@ def _serialize_rule(rule: Rule) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def generate_git_hooks(
+def _generate_git_hooks(
     project_root: Path,
     code: CodeConfig | None = None,
 ) -> list[FileSpec]:
@@ -497,7 +493,7 @@ def generate_git_hooks(
 # ---------------------------------------------------------------------------
 
 
-def generate_tool_configs(
+def _generate_tool_configs(
     project_root: Path,
     rulesets: list[str],
     *,
@@ -556,7 +552,7 @@ def generate_tool_configs(
     return artifacts
 
 
-def generate_check_scripts(
+def _generate_check_scripts(
     project_root: Path,
     rulesets: list[str],
 ) -> list[FileSpec]:
@@ -619,7 +615,7 @@ _LANGUAGE_TYPES = {
 }
 
 
-def generate_precommit_config(
+def _generate_precommit_config(
     code: CodeConfig,
     languages: dict[str, LanguageTools],
     pre_commit_meta: PreCommitMeta | None = None,
@@ -641,8 +637,6 @@ def generate_precommit_config(
     ``code.extra_repos`` are rendered at the end with no injected
     ``stages`` (passthrough only).
     """
-    from ac_guard.config import PreCommitMeta
-
     env = _get_generator_env()
     template = env.get_template("precommit_config.yaml.j2")
 
@@ -754,3 +748,95 @@ def _build_external_repos(
         repo_dict["hooks"] = hooks
         result.append(repo_dict)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def generate_all(
+    project_root: Path,
+    config: ResolvedConfig,
+    adapters: list[AgentAdapter],
+    *,
+    force: bool = False,
+) -> list[FileSpec]:
+    """Generate the full set of artifacts for a single installation.
+
+    Orchestrates G1→G6 in a fixed order.  The caller is responsible for
+    passing the resulting list to :func:`write_artifacts` (G7) and for
+    managing the installation lifecycle (read/write/create/delete).
+
+    Args:
+        project_root: Path to the project root directory.
+        config: Fully resolved configuration from guard.yaml merge.
+        adapters: List of agent adapters to generate for.
+        force: If ``True``, overwrite existing tool config files (G3).
+
+    Returns:
+        List of :class:`FileSpec` artifacts (not yet written to disk).
+
+    Raises:
+        ArtifactWriteError: If an internal write step fails.
+    """
+    artifacts: list[FileSpec] = []
+
+    # G1: Rule documents (agent-specific)
+    artifacts.extend(_generate_rule_docs(adapters, config.behavior))
+
+    # G2: Hook files (agent-specific, only for can_block adapters)
+    artifacts.extend(_generate_hook_files(adapters, config.behavior))
+
+    # G3: Tool configs from rulesets (skip existing unless --force)
+    artifacts.extend(_generate_tool_configs(project_root, config.rulesets, force=force))
+
+    # G3b: Check scripts from rulesets (always overwrite)
+    artifacts.extend(_generate_check_scripts(project_root, config.rulesets))
+
+    # G4: Pre-commit config
+    artifacts.append(
+        _generate_precommit_config(
+            config.code,
+            config.languages,
+            config.pre_commit_meta,
+        )
+    )
+
+    # G5: Policy cache (runtime.json — behavior + audit config)
+    artifacts.append(
+        _generate_policy_cache(
+            config.behavior,
+            config.config_hash,
+            audit=config.output.audit if config.output else None,
+        )
+    )
+
+    # G6: Git hooks
+    git_hooks = _generate_git_hooks(project_root, config.code)
+    if not git_hooks:
+        print("Warning: .git directory not found. Git hooks were not installed.")
+    artifacts.extend(git_hooks)
+
+    return artifacts
+
+
+# ---------------------------------------------------------------------------
+# Installation lifecycle
+# ---------------------------------------------------------------------------
+
+
+def delete_installation(project_root: Path) -> bool:
+    """Remove the installation state file if it exists.
+
+    Args:
+        project_root: Path to the project root directory.
+
+    Returns:
+        ``True`` if the file was removed, ``False`` if it did not exist.
+    """
+    state_path = installation_path(project_root)
+    if state_path.is_file():
+        state_path.unlink()
+        return True
+    return False

--- a/src/ac_guard/generator/exceptions.py
+++ b/src/ac_guard/generator/exceptions.py
@@ -8,16 +8,10 @@ callers to catch broadly or handle specific failure modes.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 __all__ = [
-    "AdapterNotRegisteredError",
     "ArtifactWriteError",
     "GeneratorError",
-    "GitDirectoryNotFoundError",
 ]
 
 
@@ -38,46 +32,3 @@ class ArtifactWriteError(GeneratorError):
     def __str__(self) -> str:
         paths_str = ", ".join(self.failed_paths)
         return f"Failed to write artifacts (permission denied): {paths_str}"
-
-
-class GitDirectoryNotFoundError(GeneratorError):
-    """Raised when .git directory does not exist.
-
-    This is a warning-level error — Git Hooks installation is skipped
-    but other artifact generation continues.
-
-    Attributes:
-        project_root: The project root where .git was expected.
-    """
-
-    def __init__(self, project_root: Path) -> None:
-        """Initialize with the project root path.
-
-        Args:
-            project_root: The project root directory.
-        """
-        self.project_root = project_root
-        super().__init__(
-            f".git directory not found in {project_root}. "
-            "Git Hooks installation skipped."
-        )
-
-
-@dataclass
-class AdapterNotRegisteredError(GeneratorError):
-    """Raised when requested agent adapter is not in registry.
-
-    Attributes:
-        agent_name: The agent name that was requested.
-        available_agents: List of registered agent names.
-    """
-
-    agent_name: str
-    available_agents: list[str]
-
-    def __str__(self) -> str:
-        available_str = ", ".join(self.available_agents)
-        return (
-            f"Agent adapter '{self.agent_name}' not registered. "
-            f"Available agents: {available_str}"
-        )

--- a/src/ac_guard/generator/models.py
+++ b/src/ac_guard/generator/models.py
@@ -1,6 +1,9 @@
 """Generator data models for AI Code Guard.
 
-Defines dataclasses for artifact generation state tracking.
+Defines the ``Installation`` record that tracks what was installed
+during ``ac-guard install`` / ``ac-guard update``, enabling subsequent
+``update`` / ``uninstall`` / ``status`` operations.
+
 FileSpec lives in ac_guard.domain (shared across modules).
 """
 
@@ -9,21 +12,37 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 
 __all__ = [
-    "GeneratedState",
-    "STATE_FILE",
+    "Installation",
+    "installation_path",
 ]
 
-# Path to state.json relative to project root
-STATE_FILE: str = ".ac-guard/state.json"
+# Internal constant — callers use ``installation_path()`` instead.
+_STATE_FILE: str = ".ac-guard/state.json"
+
+
+def installation_path(project_root: Path) -> Path:
+    """Return the path to the installation state file.
+
+    The result is a plain ``Path`` computation with **no** side-effects
+    (the parent directory is *not* created).
+
+    Args:
+        project_root: Path to the project root.
+
+    Returns:
+        Absolute path to ``.ac-guard/state.json``.
+    """
+    return project_root / _STATE_FILE
 
 
 @dataclass
-class GeneratedState:
-    """Installation state tracking for AI Code Guard artifacts.
+class Installation:
+    """Installation state record for AI Code Guard.
 
-    Stored in .ac-guard/state.json to track what was installed,
+    Stored in ``.ac-guard/state.json`` to track what was installed,
     enabling update and uninstall operations.
 
     Attributes:
@@ -55,7 +74,7 @@ class GeneratedState:
         return json.dumps(self.to_dict(), indent=2)
 
     @classmethod
-    def from_dict(cls, data: dict) -> GeneratedState:
+    def from_dict(cls, data: dict) -> Installation:
         """Create from dictionary (parsed from JSON)."""
         installed_at = data.get("installed_at")
         if isinstance(installed_at, str):
@@ -71,7 +90,7 @@ class GeneratedState:
         )
 
     @classmethod
-    def from_json(cls, json_str: str) -> GeneratedState:
+    def from_json(cls, json_str: str) -> Installation:
         """Create from JSON string."""
         data = json.loads(json_str)
         return cls.from_dict(data)

--- a/tests/integration/test_cli_lifecycle.py
+++ b/tests/integration/test_cli_lifecycle.py
@@ -15,7 +15,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ac_guard.cli.main import app
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+from ac_guard.generator import Installation, installation_path
 
 runner = CliRunner()
 
@@ -42,9 +42,9 @@ class TestFullLifecycle:
             ["install", "--agent", "claude-code", "--config", str(config)],
         )
         assert result.exit_code == 0, f"install failed: {result.output}"
-        state_path = tmp_path / STATE_FILE
+        state_path = installation_path(tmp_path)
         assert state_path.is_file()
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert "claude-code" in state.installed_agents
         assert (tmp_path / "CLAUDE.md").is_file()
 
@@ -103,13 +103,13 @@ class TestFullLifecycle:
         runner.invoke(
             app, ["install", "--agent", "claude-code", "--config", str(config)]
         )
-        assert (tmp_path / STATE_FILE).is_file()
+        assert (installation_path(tmp_path)).is_file()
 
         # uninstall --keep-config
         mp.chdir(tmp_path)
         result = runner.invoke(app, ["uninstall", "--keep-config"])
         assert result.exit_code == 0, f"uninstall failed: {result.output}"
-        assert not (tmp_path / STATE_FILE).exists()
+        assert not (installation_path(tmp_path)).exists()
         assert config.is_file()  # guard.yaml preserved
         mp.undo()
 
@@ -131,8 +131,8 @@ class TestMultiAgentLifecycle:
             ["install", "--agent", "claude-code", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state = GeneratedState.from_json(
-            (tmp_path / STATE_FILE).read_text(encoding="utf-8")
+        state = Installation.from_json(
+            (installation_path(tmp_path)).read_text(encoding="utf-8")
         )
         assert state.installed_agents == ["claude-code"]
 
@@ -142,8 +142,8 @@ class TestMultiAgentLifecycle:
             ["install", "--agent", "cursor", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state = GeneratedState.from_json(
-            (tmp_path / STATE_FILE).read_text(encoding="utf-8")
+        state = Installation.from_json(
+            (installation_path(tmp_path)).read_text(encoding="utf-8")
         )
         assert "claude-code" in state.installed_agents
         assert "cursor" in state.installed_agents
@@ -177,8 +177,8 @@ class TestMultiAgentLifecycle:
             ],
         )
         assert result.exit_code == 0
-        state = GeneratedState.from_json(
-            (tmp_path / STATE_FILE).read_text(encoding="utf-8")
+        state = Installation.from_json(
+            (installation_path(tmp_path)).read_text(encoding="utf-8")
         )
         assert len(state.installed_agents) == 3
         assert "claude-code" in state.installed_agents
@@ -309,7 +309,7 @@ class TestErrorRecovery:
         )
         assert result.exit_code == 0
         assert "warning" in result.output.lower()
-        assert (tmp_path / STATE_FILE).is_file()
+        assert (installation_path(tmp_path)).is_file()
 
 
 class TestRuleDocMarkers:

--- a/tests/integration/test_ruleset_cli.py
+++ b/tests/integration/test_ruleset_cli.py
@@ -16,7 +16,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ac_guard.cli.main import app
-from ac_guard.generator.models import STATE_FILE
+from ac_guard.generator import installation_path
 
 runner = CliRunner()
 
@@ -215,7 +215,7 @@ class TestInstallWithRuleset:
         assert result.exit_code == 0, f"install failed: {result.output}"
 
         # Verify state was written
-        state_path = tmp_path / STATE_FILE
+        state_path = installation_path(tmp_path)
         assert state_path.is_file()
 
         # Verify the ruleset's .editorconfig was copied via G3

--- a/tests/integration/test_ruleset_lifecycle.py
+++ b/tests/integration/test_ruleset_lifecycle.py
@@ -19,7 +19,7 @@ from typer.testing import CliRunner
 from ac_guard.action_guard.engine import evaluate
 from ac_guard.action_guard.matcher import Decision
 from ac_guard.cli.main import app
-from ac_guard.generator.models import STATE_FILE
+from ac_guard.generator import installation_path
 
 runner = CliRunner()
 
@@ -158,7 +158,7 @@ class TestLifecycleStages:
             app, ["install", "--agent", "claude-code", "--config", str(config)]
         )
         assert result.exit_code == 0, f"install failed: {result.output}"
-        assert (tmp_path / STATE_FILE).is_file()
+        assert (installation_path(tmp_path)).is_file()
         assert (tmp_path / ".editorconfig").is_file()
         assert (tmp_path / ".ac-guard" / "checks" / "check_header.py").is_file()
 
@@ -169,7 +169,7 @@ class TestLifecycleStages:
         # uninstall (uses cwd, hence monkeypatch.chdir)
         result = runner.invoke(app, ["uninstall"])
         assert result.exit_code == 0, f"uninstall failed: {result.output}"
-        assert not (tmp_path / STATE_FILE).is_file()
+        assert not (installation_path(tmp_path)).is_file()
 
     def test_fetch_clear_refetch(self, tmp_path: Path) -> None:
         """D1-2: Cache recovery — fetch → clear → re-fetch → install."""
@@ -335,7 +335,7 @@ class TestFileCopyCompleteness:
         # Uninstall
         result = runner.invoke(app, ["uninstall"])
         assert result.exit_code == 0
-        assert not (tmp_path / STATE_FILE).is_file()
+        assert not (installation_path(tmp_path)).is_file()
         # CLAUDE.md (rule doc) should be cleaned
         assert not (tmp_path / "CLAUDE.md").is_file()
 

--- a/tests/unit/test_cli/test_install.py
+++ b/tests/unit/test_cli/test_install.py
@@ -9,7 +9,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ac_guard.cli.main import app
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+from ac_guard.generator import Installation, installation_path
 
 runner = CliRunner()
 
@@ -37,13 +37,13 @@ def project_with_config(tmp_path: Path) -> Path:
 @pytest.fixture
 def installed_project(project_with_config: Path) -> Path:
     """Create a project with an existing installation state."""
-    state = GeneratedState(
+    state = Installation(
         ac_guard_version="0.1.0",
         installed_agents=["claude-code"],
         config_hash="abcd1234",
         artifacts=["CLAUDE.md", ".ac-guard/runtime.json"],
     )
-    state_path = project_with_config / STATE_FILE
+    state_path = installation_path(project_with_config)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(state.to_json(), encoding="utf-8")
     # Create the artifact files so uninstall can delete them
@@ -90,9 +90,9 @@ class TestInstallCommand:
         )
         assert result.exit_code == 0
         # State file should exist
-        state_path = project_with_config / STATE_FILE
+        state_path = installation_path(project_with_config)
         assert state_path.is_file()
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert "claude-code" in state.installed_agents
         # Rule doc should exist
         assert (project_with_config / "CLAUDE.md").is_file()
@@ -105,8 +105,8 @@ class TestInstallCommand:
             ["install", "--agent", "claude-code,cursor", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state_path = project_with_config / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(project_with_config)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert "claude-code" in state.installed_agents
         assert "cursor" in state.installed_agents
 
@@ -118,8 +118,8 @@ class TestInstallCommand:
             ["install", "--agent", "cursor", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state_path = installed_project / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(installed_project)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert "claude-code" in state.installed_agents
         assert "cursor" in state.installed_agents
 
@@ -133,8 +133,8 @@ class TestInstallCommand:
             ["install", "--agent", "claude-code", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state_path = installed_project / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(installed_project)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert state.installed_agents.count("claude-code") == 1
 
     def test_install_unknown_agent_fails(self, project_with_config: Path) -> None:
@@ -174,7 +174,7 @@ class TestInstallCommand:
         assert result.exit_code == 0
         assert "Warning" in result.output or "warning" in result.output
         # State should still be created
-        state_path = tmp_path / STATE_FILE
+        state_path = installation_path(tmp_path)
         assert state_path.is_file()
 
     def test_install_creates_state_json(self, project_with_config: Path) -> None:
@@ -185,8 +185,8 @@ class TestInstallCommand:
             ["install", "--agent", "claude-code", "--config", str(config)],
         )
         assert result.exit_code == 0
-        state_path = project_with_config / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(project_with_config)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert state.ac_guard_version
         assert state.config_hash
         assert len(state.artifacts) > 0
@@ -210,8 +210,8 @@ class TestUpdateCommand:
         )
         assert result.exit_code == 0
         # State should still have claude-code
-        state_path = installed_project / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(installed_project)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         assert "claude-code" in state.installed_agents
 
     def test_update_no_state_fails(self, project_with_config: Path) -> None:
@@ -227,8 +227,8 @@ class TestUpdateCommand:
     def test_update_reflects_config_changes(self, installed_project: Path) -> None:
         """update picks up config changes (new hash)."""
         config = installed_project / "guard.yaml"
-        old_state = GeneratedState.from_json(
-            (installed_project / STATE_FILE).read_text(encoding="utf-8")
+        old_state = Installation.from_json(
+            (installation_path(installed_project)).read_text(encoding="utf-8")
         )
         # Modify config
         config.write_text(
@@ -246,8 +246,8 @@ class TestUpdateCommand:
             ["update", "--config", str(config)],
         )
         assert result.exit_code == 0
-        new_state = GeneratedState.from_json(
-            (installed_project / STATE_FILE).read_text(encoding="utf-8")
+        new_state = Installation.from_json(
+            (installation_path(installed_project)).read_text(encoding="utf-8")
         )
         assert new_state.config_hash != old_state.config_hash
 
@@ -268,7 +268,7 @@ class TestUninstallCommand:
         result = runner.invoke(app, ["uninstall"])
         assert result.exit_code == 0
         assert not (installed_project / "CLAUDE.md").exists()
-        assert not (installed_project / STATE_FILE).exists()
+        assert not (installation_path(installed_project)).exists()
 
     def test_uninstall_no_state_exits_clean(
         self, project_with_config: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_cli/test_status.py
+++ b/tests/unit/test_cli/test_status.py
@@ -11,7 +11,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ac_guard.cli.main import app
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+from ac_guard.generator import Installation, installation_path
 
 runner = CliRunner()
 
@@ -40,15 +40,15 @@ def _write_state(
     agents: list[str] | None = None,
     config_hash: str = "abcd1234",
     artifacts: list[str] | None = None,
-) -> GeneratedState:
-    """Write a state.json and return the GeneratedState."""
-    state = GeneratedState(
+) -> Installation:
+    """Write a state.json and return the Installation."""
+    state = Installation(
         ac_guard_version="0.1.0",
         installed_agents=agents or ["claude-code"],
         config_hash=config_hash,
         artifacts=artifacts or ["CLAUDE.md", ".ac-guard/runtime.json"],
     )
-    state_path = project_root / STATE_FILE
+    state_path = installation_path(project_root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(state.to_json(), encoding="utf-8")
     return state
@@ -143,8 +143,8 @@ class TestStatusCommand:
         """status detects tool version mismatch."""
         config = installed_project / "guard.yaml"
         # Set state version to something different
-        state_path = installed_project / STATE_FILE
-        state = GeneratedState.from_json(state_path.read_text(encoding="utf-8"))
+        state_path = installation_path(installed_project)
+        state = Installation.from_json(state_path.read_text(encoding="utf-8"))
         state.ac_guard_version = "99.99.99"
         state_path.write_text(state.to_json(), encoding="utf-8")
         result = runner.invoke(app, ["status", "--config", str(config)])

--- a/tests/unit/test_generator/test_core.py
+++ b/tests/unit/test_generator/test_core.py
@@ -15,23 +15,35 @@ from ac_guard.config.models import (
     CodeConfig,
     LanguageTools,
     OperationRules,
+    OutputConfig,
+    ResolvedConfig,
     Rule,
     StageBucket,
 )
-from ac_guard.domain import FileSpec
-from ac_guard.generator.core import (
-    create_state,
+from ac_guard.generator import (
+    ArtifactWriteError,
+    FileSpec,
+    Installation,
+    create_installation,
     delete_artifacts,
-    generate_git_hooks,
-    generate_policy_cache,
-    generate_precommit_config,
-    generate_tool_configs,
-    read_state,
+    delete_installation,
+    generate_all,
+    installation_path,
+    read_installation,
     write_artifacts,
-    write_state,
+    write_installation,
 )
-from ac_guard.generator.exceptions import ArtifactWriteError
-from ac_guard.generator.models import STATE_FILE, GeneratedState
+
+# Seven G primitives are now module-private (gap 4 in the plan).
+# Tests reach them via deep import — same pattern as ruleset PR #151
+# uses for ``_is_commit_sha`` and ``_validate_ruleset_dir``.
+from ac_guard.generator.core import (
+    _generate_check_scripts,
+    _generate_git_hooks,
+    _generate_policy_cache,
+    _generate_precommit_config,
+    _generate_tool_configs,
+)
 
 # Literal markers for fixture construction in this test module only.
 # Production code operates on managed blocks exclusively through
@@ -47,11 +59,11 @@ MARKER_BEGIN_HASH, MARKER_END_HASH = _MB_HASH
 # ---------------------------------------------------------------------------
 
 
-class TestReadState:
-    """read_state function tests."""
+class TestReadInstallation:
+    """read_installation function tests."""
 
     def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
-        result = read_state(tmp_path)
+        result = read_installation(tmp_path)
         assert result is None
 
     def test_returns_state_when_file_exists(self, tmp_path: Path) -> None:
@@ -62,82 +74,82 @@ class TestReadState:
             "installed_at": "2026-04-16T12:00:00",
             "artifacts": ["CLAUDE.md"],
         }
-        state_file = tmp_path / STATE_FILE
+        state_file = installation_path(tmp_path)
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text(json.dumps(state_data), encoding="utf-8")
 
-        result = read_state(tmp_path)
+        result = read_installation(tmp_path)
         assert result is not None
         assert result.ac_guard_version == "0.1.0"
         assert result.installed_agents == ["claude-code"]
 
     def test_handles_empty_state_file(self, tmp_path: Path) -> None:
-        state_file = tmp_path / STATE_FILE
+        state_file = installation_path(tmp_path)
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text("{}", encoding="utf-8")
 
-        result = read_state(tmp_path)
+        result = read_installation(tmp_path)
         assert result is not None
         assert result.installed_agents == []
 
 
-class TestWriteState:
-    """write_state function tests."""
+class TestWriteInstallation:
+    """write_installation function tests."""
 
     def test_creates_ac_guard_directory(self, tmp_path: Path) -> None:
-        state = GeneratedState(
+        state = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code"],
             config_hash="abc",
             installed_at=datetime.now(),
             artifacts=["x"],
         )
-        write_state(tmp_path, state)
+        write_installation(tmp_path, state)
         assert (tmp_path / ".ac-guard").is_dir()
-        assert (tmp_path / STATE_FILE).is_file()
+        assert (installation_path(tmp_path)).is_file()
 
     def test_writes_valid_json(self, tmp_path: Path) -> None:
-        state = GeneratedState(
+        state = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code", "cursor"],
             config_hash="abc123",
             installed_at=datetime(2026, 4, 16, 14, 0, 0),
             artifacts=["CLAUDE.md", ".cursor/rules"],
         )
-        write_state(tmp_path, state)
+        write_installation(tmp_path, state)
 
-        content = (tmp_path / STATE_FILE).read_text(encoding="utf-8")
+        content = (installation_path(tmp_path)).read_text(encoding="utf-8")
         data = json.loads(content)
         assert data["ac_guard_version"] == "0.1.0"
         assert data["installed_agents"] == ["claude-code", "cursor"]
 
     def test_overwrites_existing_state(self, tmp_path: Path) -> None:
         # Write initial state
-        state1 = GeneratedState(
+        state1 = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code"],
             installed_at=datetime.now(),
         )
-        write_state(tmp_path, state1)
+        write_installation(tmp_path, state1)
 
         # Write updated state
-        state2 = GeneratedState(
+        state2 = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code", "cursor"],
             installed_at=datetime.now(),
         )
-        write_state(tmp_path, state2)
+        write_installation(tmp_path, state2)
 
-        result = read_state(tmp_path)
+        result = read_installation(tmp_path)
         assert result is not None
         assert result.installed_agents == ["claude-code", "cursor"]
 
 
-class TestCreateState:
-    """create_state function tests."""
+class TestCreateInstallation:
+    """create_installation function tests."""
 
     def test_creates_state_with_current_version(self) -> None:
-        state = create_state(
+        state = create_installation(
             installed_agents=["claude-code"],
             config_hash="abc123",
             artifacts=["CLAUDE.md"],
@@ -408,19 +420,19 @@ class TestGeneratePolicyCache:
 
     def test_returns_file_spec(self) -> None:
         behavior = BehaviorConfig.empty()
-        result = generate_policy_cache(behavior, "abc123")
+        result = _generate_policy_cache(behavior, "abc123")
         assert isinstance(result, FileSpec)
         assert result.path == ".ac-guard/runtime.json"
 
     def test_includes_config_hash(self) -> None:
         behavior = BehaviorConfig.empty()
-        result = generate_policy_cache(behavior, "test_hash")
+        result = _generate_policy_cache(behavior, "test_hash")
         data = json.loads(result.content)
         assert data["config_hash"] == "test_hash"
 
     def test_serializes_empty_behavior(self) -> None:
         behavior = BehaviorConfig.empty()
-        result = generate_policy_cache(behavior, "hash")
+        result = _generate_policy_cache(behavior, "hash")
         data = json.loads(result.content)
         assert "behavior" in data
         assert data["behavior"]["read"]["forbidden"] == []
@@ -439,7 +451,7 @@ class TestGeneratePolicyCache:
             write=OperationRules.empty(),
             execute=OperationRules.empty(),
         )
-        result = generate_policy_cache(behavior, "hash")
+        result = _generate_policy_cache(behavior, "hash")
         data = json.loads(result.content)
         assert data["behavior"]["read"]["forbidden"][0]["pattern"] == "file:.env"
         assert data["behavior"]["read"]["forbidden"][0]["reason"] == "secrets"
@@ -455,7 +467,7 @@ class TestGeneratePolicyCache:
             write=OperationRules.empty(),
             execute=OperationRules.empty(),
         )
-        result = generate_policy_cache(behavior, "hash")
+        result = _generate_policy_cache(behavior, "hash")
         data = json.loads(result.content)
         rule = data["behavior"]["read"]["forbidden"][0]
         assert "reason" not in rule
@@ -467,7 +479,7 @@ class TestGeneratePolicyCache:
 
         behavior = BehaviorConfig.empty()
         audit = AuditConfig(enabled=True, path=".ac-guard/audit.jsonl", retention=60)
-        result = generate_policy_cache(behavior, "hash", audit=audit)
+        result = _generate_policy_cache(behavior, "hash", audit=audit)
         data = json.loads(result.content)
         assert data["audit"] == {
             "enabled": True,
@@ -477,7 +489,7 @@ class TestGeneratePolicyCache:
 
     def test_runtime_cache_omits_audit_when_none(self) -> None:
         behavior = BehaviorConfig.empty()
-        result = generate_policy_cache(behavior, "hash")
+        result = _generate_policy_cache(behavior, "hash")
         data = json.loads(result.content)
         assert "audit" not in data
 
@@ -491,7 +503,7 @@ class TestGeneratePolicyCache:
             write=OperationRules.empty(),
             execute=OperationRules.empty(),
         )
-        result = generate_policy_cache(behavior, "hash")
+        result = _generate_policy_cache(behavior, "hash")
         data = json.loads(result.content)
         rule = data["behavior"]["read"]["forbidden"][0]
         assert rule["regex"] is True
@@ -506,19 +518,19 @@ class TestGenerateGitHooks:
     """generate_git_hooks function tests."""
 
     def test_returns_empty_list_when_git_missing(self, tmp_path: Path) -> None:
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         assert result == []
 
     def test_returns_hooks_when_git_exists(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         assert len(result) == 2
 
     def test_hooks_have_correct_paths(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         paths = [a.path for a in result]
         assert ".git/hooks/pre-commit" in paths
         assert ".git/hooks/pre-push" in paths
@@ -526,28 +538,28 @@ class TestGenerateGitHooks:
     def test_hooks_are_executable(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         for hook in result:
             assert hook.executable is True
 
     def test_hooks_contain_guard_command(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         for hook in result:
             assert "ac-guard run --stage" in hook.content
 
     def test_pre_commit_has_correct_stage(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         pre_commit = next(a for a in result if "pre-commit" in a.path)
         assert "--stage pre-commit" in pre_commit.content
 
     def test_pre_push_has_correct_stage(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "hooks").mkdir()
-        result = generate_git_hooks(tmp_path)
+        result = _generate_git_hooks(tmp_path)
         pre_push = next(a for a in result if "pre-push" in a.path)
         assert "--stage pre-push" in pre_push.content
 
@@ -561,11 +573,11 @@ class TestGenerateToolConfigs:
     """generate_tool_configs function tests."""
 
     def test_returns_empty_list_when_no_rulesets(self, tmp_path: Path) -> None:
-        result = generate_tool_configs(tmp_path, [])
+        result = _generate_tool_configs(tmp_path, [])
         assert result == []
 
     def test_returns_empty_list_when_cache_missing(self, tmp_path: Path) -> None:
-        result = generate_tool_configs(tmp_path, ["company-rules"])
+        result = _generate_tool_configs(tmp_path, ["company-rules"])
         assert result == []
 
     def test_copies_files_from_ruleset(self, tmp_path: Path) -> None:
@@ -574,7 +586,7 @@ class TestGenerateToolConfigs:
         cache_dir.mkdir(parents=True)
         (cache_dir / ".clang-format").write_text("Format config", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["company-rules"])
+        result = _generate_tool_configs(tmp_path, ["company-rules"])
         assert len(result) == 1
         assert result[0].path == ".clang-format"
         assert result[0].content == "Format config"
@@ -589,7 +601,7 @@ class TestGenerateToolConfigs:
         cache2.mkdir(parents=True)
         (cache2 / "config-b.yaml").write_text("b", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["ruleset-a", "ruleset-b"])
+        result = _generate_tool_configs(tmp_path, ["ruleset-a", "ruleset-b"])
         assert len(result) == 2
         paths = [a.path for a in result]
         assert "config-a.yaml" in paths
@@ -601,7 +613,7 @@ class TestGenerateToolConfigs:
         cache.mkdir(parents=True)
         (cache / "file.txt").write_text("content", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["existing", "missing"])
+        result = _generate_tool_configs(tmp_path, ["existing", "missing"])
         assert len(result) == 1
         assert result[0].path == "file.txt"
 
@@ -612,7 +624,7 @@ class TestGenerateToolConfigs:
         # Write binary file
         (cache / "binary.bin").write_bytes(b"\x00\xff\xfe")
 
-        result = generate_tool_configs(tmp_path, ["ruleset"])
+        result = _generate_tool_configs(tmp_path, ["ruleset"])
         # Should only have text file
         assert len(result) == 1
         assert result[0].path == "text.txt"
@@ -632,7 +644,7 @@ class TestGenerateToolConfigsForce:
         # User already has this file
         (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        result = _generate_tool_configs(tmp_path, ["rules"], force=False)
         assert len(result) == 0
 
         captured = capsys.readouterr()
@@ -647,7 +659,7 @@ class TestGenerateToolConfigsForce:
 
         (tmp_path / ".editorconfig").write_text("user content", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["rules"], force=True)
+        result = _generate_tool_configs(tmp_path, ["rules"], force=True)
         assert len(result) == 1
         assert result[0].content == "ruleset content"
 
@@ -657,7 +669,7 @@ class TestGenerateToolConfigsForce:
         cache.mkdir(parents=True)
         (cache / "new-config.yml").write_text("new", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        result = _generate_tool_configs(tmp_path, ["rules"], force=False)
         assert len(result) == 1
         assert result[0].path == "new-config.yml"
 
@@ -672,7 +684,7 @@ class TestGenerateToolConfigsForce:
 
         (tmp_path / "existing.cfg").write_text("user version", encoding="utf-8")
 
-        result = generate_tool_configs(tmp_path, ["rules"], force=False)
+        result = _generate_tool_configs(tmp_path, ["rules"], force=False)
         assert len(result) == 1
         assert result[0].path == "new.cfg"
 
@@ -681,32 +693,24 @@ class TestGenerateCheckScripts:
     """generate_check_scripts function tests."""
 
     def test_returns_empty_list_when_no_rulesets(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
-        result = generate_check_scripts(tmp_path, [])
+        result = _generate_check_scripts(tmp_path, [])
         assert result == []
 
     def test_returns_empty_list_when_cache_missing(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
-        result = generate_check_scripts(tmp_path, ["company-rules"])
+        result = _generate_check_scripts(tmp_path, ["company-rules"])
         assert result == []
 
     def test_copies_scripts_to_ac_guard_checks(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
         cache = tmp_path / ".ac-guard" / "cache" / "rules" / "checks"
         cache.mkdir(parents=True)
         (cache / "encoding_check.py").write_text("# check", encoding="utf-8")
 
-        result = generate_check_scripts(tmp_path, ["rules"])
+        result = _generate_check_scripts(tmp_path, ["rules"])
         assert len(result) == 1
         assert result[0].path == ".ac-guard/checks/encoding_check.py"
         assert result[0].content == "# check"
 
     def test_copies_from_multiple_rulesets(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
         cache1 = tmp_path / ".ac-guard" / "cache" / "a" / "checks"
         cache1.mkdir(parents=True)
         (cache1 / "check_a.py").write_text("a", encoding="utf-8")
@@ -715,33 +719,29 @@ class TestGenerateCheckScripts:
         cache2.mkdir(parents=True)
         (cache2 / "check_b.py").write_text("b", encoding="utf-8")
 
-        result = generate_check_scripts(tmp_path, ["a", "b"])
+        result = _generate_check_scripts(tmp_path, ["a", "b"])
         assert len(result) == 2
         paths = [r.path for r in result]
         assert ".ac-guard/checks/check_a.py" in paths
         assert ".ac-guard/checks/check_b.py" in paths
 
     def test_skips_binary_files(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
         cache = tmp_path / ".ac-guard" / "cache" / "rules" / "checks"
         cache.mkdir(parents=True)
         (cache / "check.py").write_text("# ok", encoding="utf-8")
         (cache / "binary.bin").write_bytes(b"\x00\xff\xfe")
 
-        result = generate_check_scripts(tmp_path, ["rules"])
+        result = _generate_check_scripts(tmp_path, ["rules"])
         assert len(result) == 1
         assert result[0].path == ".ac-guard/checks/check.py"
 
     def test_skips_missing_checks_dir(self, tmp_path: Path) -> None:
-        from ac_guard.generator.core import generate_check_scripts
-
         # Ruleset exists in cache but has no checks/ dir
         cache = tmp_path / ".ac-guard" / "cache" / "rules"
         cache.mkdir(parents=True)
         (cache / "guard.yaml").write_text("version: 1", encoding="utf-8")
 
-        result = generate_check_scripts(tmp_path, ["rules"])
+        result = _generate_check_scripts(tmp_path, ["rules"])
         assert result == []
 
 
@@ -756,34 +756,34 @@ class TestGeneratePrecommitConfig:
     def test_returns_file_spec(self) -> None:
         code = CodeConfig()
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert isinstance(result, FileSpec)
         assert result.path == ".pre-commit-config.yaml"
 
     def test_includes_repo_local(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "repo: local" in result.content
 
     def test_includes_format_hooks_when_enabled(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "format-python" in result.content
         assert "black" in result.content
 
     def test_includes_lint_hooks_when_enabled(self) -> None:
         code = CodeConfig(pre_push=StageBucket(lint=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "lint-python" in result.content
         assert "ruff" in result.content
 
     def test_omits_format_when_disabled(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=False))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "format-python" not in result.content
 
     def test_includes_custom_checks(self) -> None:
@@ -795,14 +795,14 @@ class TestGeneratePrecommitConfig:
             ),
         )
         languages = {}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "custom-test" in result.content
         assert "pytest" in result.content
 
     def test_includes_language_types(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         # Schema v2 emits JSON-serialized types (via ``tojson`` filter)
         assert '"python"' in result.content
 
@@ -814,7 +814,7 @@ class TestGeneratePrecommitConfig:
             "python": LanguageTools(format="black", lint="ruff"),
             "typescript": LanguageTools(format="prettier", lint="eslint"),
         }
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         assert "format-python" in result.content
         assert "format-typescript" in result.content
         assert "lint-python" in result.content
@@ -839,14 +839,14 @@ class TestPrecommitArtifactLifecycle:
             pre_push=StageBucket(lint=lint_on),
         )
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        spec = generate_precommit_config(code, languages)
+        spec = _generate_precommit_config(code, languages)
         write_artifacts(tmp_path, [spec])
         return (tmp_path / ".pre-commit-config.yaml").read_text(encoding="utf-8")
 
     def test_no_managed_block_markers_emitted(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=True))
         languages = {"python": LanguageTools(format="black", lint="ruff")}
-        result = generate_precommit_config(code, languages)
+        result = _generate_precommit_config(code, languages)
         # D4: template no longer embeds AI-GUARD markers.
         assert MARKER_BEGIN_HASH not in result.content
         assert MARKER_END_HASH not in result.content
@@ -855,7 +855,7 @@ class TestPrecommitArtifactLifecycle:
 
     def test_header_warns_against_hand_edit(self) -> None:
         code = CodeConfig(pre_commit=StageBucket(format=True))
-        result = generate_precommit_config(
+        result = _generate_precommit_config(
             code, {"python": LanguageTools(format="black", lint="ruff")}
         )
         assert "Generated by ac-guard install" in result.content
@@ -881,3 +881,172 @@ class TestPrecommitArtifactLifecycle:
         first = self._write_precommit(tmp_path)
         second = self._write_precommit(tmp_path)
         assert first == second
+
+
+# ---------------------------------------------------------------------------
+# generate_all integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAll:
+    """generate_all orchestrates all G primitives into one artifact list."""
+
+    @staticmethod
+    def _minimal_resolved_config() -> ResolvedConfig:
+        return ResolvedConfig(
+            version=1,
+            project_name="test",
+            project_language="python",
+            behavior=BehaviorConfig(
+                read=OperationRules.empty(),
+                write=OperationRules.empty(),
+                execute=OperationRules.empty(),
+            ),
+            code=CodeConfig(),
+            languages={},
+            output=OutputConfig(),
+            config_hash="test_hash",
+        )
+
+    @staticmethod
+    def _mock_adapter(name: str = "test-agent", can_block: bool = False):
+        """Create a minimal mock adapter for generate_all tests."""
+        from unittest.mock import MagicMock
+
+        from ac_guard.domain import FileSpec
+
+        adapter = MagicMock()
+        adapter.name = name
+        adapter.capabilities.can_block = can_block
+        adapter.rule_doc_path.return_value = f"{name.upper()}.md"
+        adapter.render_rule_doc.return_value = f"# {name} rules\n"
+        adapter.hook_files.return_value = [
+            FileSpec(path=f".{name}/hook.py", content="# hook", executable=True)
+        ]
+        return adapter
+
+    def test_produces_artifacts_for_adapter(self, tmp_path: Path) -> None:
+        """generate_all returns FileSpec objects with valid paths."""
+        config = self._minimal_resolved_config()
+        adapter = self._mock_adapter()
+
+        artifacts = generate_all(tmp_path, config, [adapter])
+
+        assert len(artifacts) > 0
+        paths = [a.path for a in artifacts]
+        # G4 and G5 are always produced regardless of adapters
+        assert ".pre-commit-config.yaml" in paths
+        assert ".ac-guard/runtime.json" in paths
+
+    def test_produces_git_hooks_when_git_dir_exists(self, tmp_path: Path) -> None:
+        """G6 artifacts are produced when .git exists and stages are active."""
+
+        (tmp_path / ".git").mkdir()
+        config = ResolvedConfig(
+            version=1,
+            project_name="test",
+            project_language="python",
+            behavior=BehaviorConfig(
+                read=OperationRules.empty(),
+                write=OperationRules.empty(),
+                execute=OperationRules.empty(),
+            ),
+            code=CodeConfig(pre_commit=StageBucket(format=True)),
+            languages={
+                "python": LanguageTools(format="ruff format", lint="ruff check")
+            },
+            output=OutputConfig(),
+            config_hash="test_hash",
+        )
+        adapter = self._mock_adapter()
+
+        artifacts = generate_all(tmp_path, config, [adapter])
+
+        paths = [a.path for a in artifacts]
+        assert any(p.startswith(".git/hooks/") for p in paths)
+
+    def test_g2_hook_included_for_block_adapter(self, tmp_path: Path) -> None:
+        config = self._minimal_resolved_config()
+        adapter = self._mock_adapter(can_block=True)
+
+        artifacts = generate_all(tmp_path, config, [adapter])
+
+        paths = [a.path for a in artifacts]
+        assert any("hook.py" in p for p in paths)
+
+    def test_g2_hook_excluded_for_non_block_adapter(self, tmp_path: Path) -> None:
+        config = self._minimal_resolved_config()
+        adapter = self._mock_adapter(can_block=False)
+
+        artifacts = generate_all(tmp_path, config, [adapter])
+
+        paths = [a.path for a in artifacts]
+        assert not any("hook.py" in p for p in paths)
+
+    def test_force_forwarded_to_g3(self, tmp_path: Path) -> None:
+        """generate_all passes force through to _generate_tool_configs."""
+
+        # Create a ruleset cache with a tool config
+        cache = tmp_path / ".ac-guard" / "cache" / "rules" / "files"
+        cache.mkdir(parents=True)
+        (cache / ".clang-format").write_text("style: LLVM\n", encoding="utf-8")
+
+        config = ResolvedConfig(
+            version=1,
+            project_name="test",
+            project_language="python",
+            behavior=BehaviorConfig(
+                read=OperationRules.empty(),
+                write=OperationRules.empty(),
+                execute=OperationRules.empty(),
+            ),
+            code=CodeConfig(),
+            languages={},
+            output=OutputConfig(),
+            config_hash="test_hash",
+            rulesets=["rules"],
+        )
+        adapter = self._mock_adapter()
+
+        artifacts = generate_all(tmp_path, config, [adapter], force=True)
+        paths = [a.path for a in artifacts]
+        assert ".clang-format" in paths
+
+    def test_returns_empty_list_when_no_adapters(self, tmp_path: Path) -> None:
+        config = self._minimal_resolved_config()
+
+        artifacts = generate_all(tmp_path, config, [])
+
+        # Even with no adapters, G4/G5 still produce artifacts
+        paths = [a.path for a in artifacts]
+        assert ".pre-commit-config.yaml" in paths
+
+
+# ---------------------------------------------------------------------------
+# delete_installation tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteInstallation:
+    """delete_installation removes the installation state file."""
+
+    def test_returns_false_when_no_state(self, tmp_path: Path) -> None:
+        assert delete_installation(tmp_path) is False
+
+    def test_removes_state_file_and_returns_true(self, tmp_path: Path) -> None:
+        inst = Installation(ac_guard_version="0.1.0", installed_agents=["claude-code"])
+        write_installation(tmp_path, inst)
+        state_file = installation_path(tmp_path)
+        assert state_file.is_file()
+
+        result = delete_installation(tmp_path)
+        assert result is True
+        assert not state_file.is_file()
+
+    def test_state_file_already_gone(self, tmp_path: Path) -> None:
+        """Idempotent: deleting when already deleted returns False."""
+        inst = Installation(ac_guard_version="0.1.0")
+        write_installation(tmp_path, inst)
+        delete_installation(tmp_path)
+        # Second call
+        assert delete_installation(tmp_path) is False

--- a/tests/unit/test_generator/test_exceptions.py
+++ b/tests/unit/test_generator/test_exceptions.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from ac_guard.generator.exceptions import (
-    AdapterNotRegisteredError,
     ArtifactWriteError,
     GeneratorError,
-    GitDirectoryNotFoundError,
 )
 
 
@@ -44,45 +40,3 @@ class TestArtifactWriteError:
 
     def test_inherits_generator_error(self) -> None:
         assert issubclass(ArtifactWriteError, GeneratorError)
-
-
-class TestGitDirectoryNotFoundError:
-    """GitDirectoryNotFoundError tests."""
-
-    def test_project_root_attribute(self) -> None:
-        path = Path("/tmp/project")
-        err = GitDirectoryNotFoundError(path)
-        assert err.project_root == path
-
-    def test_message_contains_path(self) -> None:
-        path = Path("/tmp/myproject")
-        err = GitDirectoryNotFoundError(path)
-        assert "myproject" in str(err)
-        assert ".git" in str(err)
-
-    def test_inherits_generator_error(self) -> None:
-        assert issubclass(GitDirectoryNotFoundError, GeneratorError)
-
-
-class TestAdapterNotRegisteredError:
-    """AdapterNotRegisteredError tests."""
-
-    def test_attributes(self) -> None:
-        err = AdapterNotRegisteredError(
-            agent_name="unknown-agent",
-            available_agents=["claude-code", "cursor"],
-        )
-        assert err.agent_name == "unknown-agent"
-        assert err.available_agents == ["claude-code", "cursor"]
-
-    def test_str_contains_agent_name(self) -> None:
-        err = AdapterNotRegisteredError(
-            agent_name="myagent",
-            available_agents=["agent1", "agent2"],
-        )
-        assert "myagent" in str(err)
-        assert "agent1" in str(err)
-        assert "agent2" in str(err)
-
-    def test_inherits_generator_error(self) -> None:
-        assert issubclass(AdapterNotRegisteredError, GeneratorError)

--- a/tests/unit/test_generator/test_models.py
+++ b/tests/unit/test_generator/test_models.py
@@ -7,47 +7,45 @@ a domain-layer DTO, not a generator-specific type.
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 
-from ac_guard.generator.models import (
-    STATE_FILE,
-    GeneratedState,
-)
+from ac_guard.generator import Installation, installation_path
 
 
-class TestGeneratedState:
-    """GeneratedState dataclass and serialization tests."""
+class TestInstallation:
+    """Installation dataclass and serialization tests."""
 
     def test_basic_construction(self) -> None:
         now = datetime.now()
-        state = GeneratedState(
+        inst = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code"],
             config_hash="abc123",
             installed_at=now,
             artifacts=["CLAUDE.md"],
         )
-        assert state.ac_guard_version == "0.1.0"
-        assert state.installed_agents == ["claude-code"]
-        assert state.config_hash == "abc123"
-        assert state.installed_at == now
-        assert state.artifacts == ["CLAUDE.md"]
+        assert inst.ac_guard_version == "0.1.0"
+        assert inst.installed_agents == ["claude-code"]
+        assert inst.config_hash == "abc123"
+        assert inst.installed_at == now
+        assert inst.artifacts == ["CLAUDE.md"]
 
     def test_defaults(self) -> None:
-        state = GeneratedState(ac_guard_version="0.1.0")
-        assert state.installed_agents == []
-        assert state.config_hash == ""
-        assert state.artifacts == []
+        inst = Installation(ac_guard_version="0.1.0")
+        assert inst.installed_agents == []
+        assert inst.config_hash == ""
+        assert inst.artifacts == []
 
     def test_to_dict(self) -> None:
         now = datetime(2026, 4, 16, 12, 0, 0)
-        state = GeneratedState(
+        inst = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code", "cursor"],
             config_hash="abc123",
             installed_at=now,
             artifacts=["CLAUDE.md", ".claude/settings.json"],
         )
-        d = state.to_dict()
+        d = inst.to_dict()
         assert d["ac_guard_version"] == "0.1.0"
         assert d["installed_agents"] == ["claude-code", "cursor"]
         assert d["config_hash"] == "abc123"
@@ -55,14 +53,14 @@ class TestGeneratedState:
         assert d["artifacts"] == ["CLAUDE.md", ".claude/settings.json"]
 
     def test_to_json(self) -> None:
-        state = GeneratedState(
+        inst = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code"],
             config_hash="abc",
             installed_at=datetime(2026, 4, 16, 12, 0, 0),
             artifacts=["x"],
         )
-        json_str = state.to_json()
+        json_str = inst.to_json()
         assert '"ac_guard_version": "0.1.0"' in json_str
         assert '"installed_agents"' in json_str
 
@@ -74,22 +72,22 @@ class TestGeneratedState:
             "installed_at": "2026-04-15T10:30:00",
             "artifacts": ["file1", "file2"],
         }
-        state = GeneratedState.from_dict(d)
-        assert state.ac_guard_version == "0.2.0"
-        assert state.installed_agents == ["cursor"]
-        assert state.config_hash == "def456"
-        assert state.installed_at == datetime(2026, 4, 15, 10, 30, 0)
-        assert state.artifacts == ["file1", "file2"]
+        inst = Installation.from_dict(d)
+        assert inst.ac_guard_version == "0.2.0"
+        assert inst.installed_agents == ["cursor"]
+        assert inst.config_hash == "def456"
+        assert inst.installed_at == datetime(2026, 4, 15, 10, 30, 0)
+        assert inst.artifacts == ["file1", "file2"]
 
     def test_from_dict_missing_fields(self) -> None:
         d = {"ac_guard_version": "0.1.0"}
-        state = GeneratedState.from_dict(d)
-        assert state.installed_agents == []
-        assert state.config_hash == ""
-        assert state.artifacts == []
+        inst = Installation.from_dict(d)
+        assert inst.installed_agents == []
+        assert inst.config_hash == ""
+        assert inst.artifacts == []
 
     def test_json_roundtrip(self) -> None:
-        original = GeneratedState(
+        original = Installation(
             ac_guard_version="0.1.0",
             installed_agents=["claude-code", "cursor"],
             config_hash="abc123",
@@ -97,7 +95,7 @@ class TestGeneratedState:
             artifacts=["CLAUDE.md", ".cursor/rules/behavior.mdc"],
         )
         json_str = original.to_json()
-        restored = GeneratedState.from_json(json_str)
+        restored = Installation.from_json(json_str)
         assert restored.ac_guard_version == original.ac_guard_version
         assert restored.installed_agents == original.installed_agents
         assert restored.config_hash == original.config_hash
@@ -105,8 +103,17 @@ class TestGeneratedState:
         assert restored.artifacts == original.artifacts
 
 
-class TestConstants:
-    """Module constants tests."""
+class TestInstallationPath:
+    """``installation_path`` returns the project-relative state file path."""
 
-    def test_state_file_path(self) -> None:
-        assert STATE_FILE == ".ac-guard/state.json"
+    def test_returns_under_ac_guard_dir(self, tmp_path: Path) -> None:
+        result = installation_path(tmp_path)
+        assert result == tmp_path / ".ac-guard" / "state.json"
+
+    def test_does_not_create_directory(self, tmp_path: Path) -> None:
+        """Computing the path must be side-effect free."""
+        installation_path(tmp_path)
+        assert not (tmp_path / ".ac-guard").exists()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        assert installation_path(tmp_path) == installation_path(tmp_path)

--- a/tests/unit/test_generator/test_public_api.py
+++ b/tests/unit/test_generator/test_public_api.py
@@ -1,0 +1,70 @@
+"""Contract tests locking the public surface of ``ac_guard.generator``.
+
+These tests fail loudly when symbols are added to or removed from the
+top-level ``__all__`` without a corresponding update here. They prevent
+quiet drift between the module's promised API and its imports.
+"""
+
+from __future__ import annotations
+
+import ac_guard.generator as gen
+
+_EXPECTED_PUBLIC_API: frozenset[str] = frozenset(
+    {
+        "ArtifactWriteError",
+        "FileSpec",
+        "GeneratorError",
+        "Installation",
+        "create_installation",
+        "delete_artifacts",
+        "delete_installation",
+        "generate_all",
+        "installation_path",
+        "read_installation",
+        "write_artifacts",
+        "write_installation",
+    }
+)
+
+
+def test_public_api_exact() -> None:
+    """``__all__`` must be exactly the agreed public surface."""
+    assert set(gen.__all__) == _EXPECTED_PUBLIC_API
+
+
+def test_each_public_symbol_is_importable() -> None:
+    """Every name in ``__all__`` must resolve on the package."""
+    for name in _EXPECTED_PUBLIC_API:
+        assert hasattr(gen, name), f"{name} listed in __all__ but not importable"
+
+
+def test_demoted_state_symbols_not_in_public_api() -> None:
+    """Old ``state``-named symbols must not appear in the top-level ``__all__``."""
+    for name in (
+        "STATE_FILE",
+        "GeneratedState",
+        "read_state",
+        "write_state",
+        "create_state",
+    ):
+        assert name not in gen.__all__, f"{name} should be demoted"
+
+
+def test_demoted_g_primitives_not_in_public_api() -> None:
+    """Seven G primitives must be private (deep-import only for tests)."""
+    for name in (
+        "generate_rule_docs",
+        "generate_hook_files",
+        "generate_tool_configs",
+        "generate_check_scripts",
+        "generate_precommit_config",
+        "generate_policy_cache",
+        "generate_git_hooks",
+    ):
+        assert name not in gen.__all__, f"{name} should be private"
+
+
+def test_demoted_exceptions_not_in_public_api() -> None:
+    """Dead/misplaced exception classes must not appear at top level."""
+    assert "GitDirectoryNotFoundError" not in gen.__all__
+    assert "AdapterNotRegisteredError" not in gen.__all__


### PR DESCRIPTION
## Summary

- Realigns `ac_guard.generator` public surface from **17 → 12 symbols**, each mapping one-to-one onto a lifecycle phase (generate / write / track installation / cleanup).
- Adds `generate_all()` orchestrating G1→G6 in fixed order, eliminating `cli/install.py:_run_generator_pipeline` hand-wiring.
- Adds `delete_installation()` and `installation_path()` — callers no longer manually unlink `state.json` or construct `project_root / STATE_FILE`.
- Renames `GeneratedState` → `Installation` and `STATE_FILE` → private `_STATE_FILE`; renames `read/write/create_state` → `*_installation`.
- Seven G-primitives (`generate_rule_docs` through `generate_git_hooks`) become `_`-prefixed private, tested via deep import (same pattern as #151).
- Removes dead `GitDirectoryNotFoundError` and misplaced `AdapterNotRegisteredError`.
- Promotes `PreCommitMeta` from function-body lazy import to top-level runtime import (gap 10); adds `ResolvedConfig` to `TYPE_CHECKING` block.
- Adds `tests/unit/test_generator/test_public_api.py` contract test locking the 12-symbol surface.

Closes #152.

## Test plan

- [x] `pytest -q` — 1193 passed
- [x] `ruff check src/ tests/` — clean
- [x] `pre-commit run --all-files` — format / lint / forbid-noqa / require-explicit-encoding / interrogate / bandit / import-linter all pass
- [x] Acceptance grep:
  - `GeneratedState` / `STATE_FILE` absent from `src/`
  - `GitDirectoryNotFoundError` / `AdapterNotRegisteredError` absent from `src/`
  - No function-body lazy imports in `generator/core.py` (TYPE_CHECKING block only)
  - No deep `from ac_guard.generator.<sub> import` in `src/ac_guard/cli/`

## Breaking changes

Symbols removed from `ac_guard.generator.__all__`:
`STATE_FILE`, `GeneratedState`, `read_state`, `write_state`, `create_state`, `generate_rule_docs`, `generate_hook_files`, `generate_tool_configs`, `generate_check_scripts`, `generate_precommit_config`, `generate_policy_cache`, `generate_git_hooks`, `GitDirectoryNotFoundError`, `AdapterNotRegisteredError`.

All callers migrated in this PR; no downstream consumers affected.