### PR TITLE
refactor(cli)!: remove redundant `version` subcommand (keep --version flag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — `ac-guard version` subcommand removed.** The
+  `@app.callback` already exposes a `--version` / `-V` flag; the
+  `version` subcommand printed the same string and was a redundant
+  second exit. Use `ac-guard --version` (matches `python --version`,
+  `git --version`, `gh --version`, `pip --version` convention). Note
+  `uv version` has *bump-the-version* semantics, not the same thing.
+
+  **Migration:** `ac-guard version` → `ac-guard --version`.
+
 - **BREAKING — Module rename: `checker` → `code_gate`, `enforcer` → `action_guard`.**
   The two core modules now name their roles directly: `code_gate` is the
   git hook-time code quality gate (pass/fail), `action_guard` is the

--- a/src/ac_guard/cli/main.py
+++ b/src/ac_guard/cli/main.py
@@ -64,12 +64,6 @@ def main(
 
 
 @app.command()
-def version() -> None:
-    """Print AI Code Guard version."""
-    typer.echo(f"ac-guard {__version__} — AI Code Guard")
-
-
-@app.command()
 def init(
     language: Annotated[
         str,

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -8,12 +8,6 @@ from ac_guard.cli.main import app
 runner = CliRunner()
 
 
-def test_version_command() -> None:
-    result = runner.invoke(app, ["version"])
-    assert result.exit_code == 0
-    assert __version__ in result.output
-
-
 def test_version_flag() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Follow-up tightening to PR #154 — completes the same first-principles
pass on the CLI's S4 inspection slice. The Typer `@app.callback` already
exposes a `--version` / `-V` flag that prints exactly the same string
as the `version` subcommand. Two exits for one observation intent
violates S4 MECE — drop the subcommand, keep the flag.

## Convention precedent

All single-purpose CLIs use the flag, none have a subcommand:

| Tool | Flag | Subcommand |
|------|------|------------|
| `python`, `git`, `gh`, `pip`, `node`, `cargo`, `kubectl` | `--version` | (none) |
| `uv` | `--version` | `version` (but it *bumps* the version in pyproject.toml — different semantics) |

The `uv version` precedent is the **only** mainstream tool with a `version`
subcommand, and it deliberately means something different. Keeping our
own subcommand purely for "show me the version" duplicates the flag with
zero added value.

## Changes

- `src/ac_guard/cli/main.py`: delete `@app.command def version` (4 lines).
- `tests/unit/test_cli/test_main.py`: delete `test_version_command`;
  `test_version_flag` already covers the kept exit.
- `CHANGELOG.md`: add BREAKING note in `[Unreleased] / ### Changed`
  with the one-line migration.

## Test plan

- [x] `uv run pytest tests/unit/test_cli/ -q` — 136/136 green
- [x] `uv run pre-commit run` — format / lint / forbid-noqa /
      require-explicit-encoding / interrogate / bandit / import-linter all pass
- [x] Smoke:
  - `ac-guard --version` → `ac-guard 0.1.0 — AI Code Guard`
  - `ac-guard --help` no longer lists `version` row
  - `ac-guard version` → Typer `Error: No such command 'version'.`

## Breaking change

Removed CLI surface: `ac-guard version`. Migration is one character —
add `--`. No deprecation alias (0.1.0 is unreleased; no public users yet,
matching the no-alias policy used in #154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)