### PR TITLE
refactor(action-guard)!: tighten public API surface and align module name

### DIFF
--- a/src/ac_guard/action_guard/__init__.py
+++ b/src/ac_guard/action_guard/__init__.py
@@ -1,37 +1,23 @@
 """Action guard module — runtime behavior policy enforcement.
 
-Provides pattern matching, tool classification, policy loading,
-and the top-level evaluate() entry point for AI agent behavior
-enforcement.
+Public API: ``evaluate()`` is the sole entry point; ``PolicyDecision``
+is its return type; ``Decision`` is the decision enum;
+``ActionGuardError`` / ``PolicyCorruptError`` are the user-facing
+exceptions.
+
+Internal primitives (``classify``, ``load_policy``, matcher functions)
+remain in their submodules but are not re-exported. Tests import them
+via deep submodule paths.
 """
 
-from ac_guard.action_guard.classifier import classify
-from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.core import evaluate
 from ac_guard.action_guard.exceptions import ActionGuardError, PolicyCorruptError
-from ac_guard.action_guard.matcher import (
-    VALID_SCHEMES,
-    Decision,
-    MatchResult,
-    PolicyDecision,
-    evaluate_rules,
-    find_matching_rule,
-    matches,
-    parse_pattern,
-)
-from ac_guard.action_guard.policy import load_policy
+from ac_guard.action_guard.matcher import Decision, PolicyDecision
 
 __all__ = [
-    "Decision",
     "ActionGuardError",
-    "MatchResult",
+    "Decision",
     "PolicyCorruptError",
     "PolicyDecision",
-    "VALID_SCHEMES",
-    "classify",
     "evaluate",
-    "evaluate_rules",
-    "find_matching_rule",
-    "load_policy",
-    "matches",
-    "parse_pattern",
 ]

--- a/src/ac_guard/action_guard/cli.py
+++ b/src/ac_guard/action_guard/cli.py
@@ -23,7 +23,7 @@ import json
 import sys
 from pathlib import Path
 
-from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.core import evaluate
 
 __all__: list[str] = []
 

--- a/src/ac_guard/action_guard/core.py
+++ b/src/ac_guard/action_guard/core.py
@@ -1,4 +1,4 @@
-"""Action guard engine — top-level evaluate function.
+"""Action guard core — top-level evaluate function.
 
 Combines E1 (load_policy), E2 (classify), and E3/E4 (match + decide)
 into a single entry point for runtime behavior enforcement.
@@ -15,7 +15,7 @@ from ac_guard.action_guard.matcher import (
     Decision,
     MatchResult,
     PolicyDecision,
-    evaluate_rules,
+    decide,
 )
 from ac_guard.action_guard.policy import load_policy
 from ac_guard.audit import append_record
@@ -125,7 +125,7 @@ def evaluate(
         )
 
     # E3/E4: Match and decide
-    match_result = evaluate_rules(target, scheme, operation_rules)
+    match_result = decide(target, scheme, operation_rules)
 
     # E5: Post-rule guard rail — if the policy would otherwise allow a
     # `git commit` on a repository whose pre-commit hooks aren't

--- a/src/ac_guard/action_guard/matcher.py
+++ b/src/ac_guard/action_guard/matcher.py
@@ -24,7 +24,7 @@ __all__ = [
     "MatchResult",
     "PolicyDecision",
     "VALID_SCHEMES",
-    "evaluate_rules",
+    "decide",
     "find_matching_rule",
     "matches",
     "parse_pattern",
@@ -54,7 +54,7 @@ class Decision(enum.Enum):
 
 @dataclass
 class MatchResult:
-    """Outcome of evaluate_rules().
+    """Outcome of decide().
 
     Attributes:
         decision: The policy decision (allow/deny/ask).
@@ -232,12 +232,12 @@ def find_matching_rule(
 # ---------------------------------------------------------------------------
 
 
-def evaluate_rules(
+def decide(
     target: str,
     scheme: str,
     operation_rules: OperationRules,
 ) -> MatchResult:
-    """Evaluate three-tier rules and return a policy decision.
+    """Arbitrate three-tier rules and return a policy decision.
 
     Checks tiers in precedence order:
 

--- a/src/ac_guard/adapters/_templates/hooks/claude_code.j2
+++ b/src/ac_guard/adapters/_templates/hooks/claude_code.j2
@@ -40,7 +40,7 @@ if sys.executable != _INSTALL_PY and os.path.exists(_INSTALL_PY):
 # removed, venv rebuilt, package uninstalled), never let the tool call
 # silently pass — emit an `ask` decision so the user sees the problem.
 try:
-    from ac_guard.action_guard.engine import evaluate
+    from ac_guard.action_guard.core import evaluate
 except ImportError as _exc:
     json.dump(
         {

--- a/tests/integration/test_action_guard_e2e.py
+++ b/tests/integration/test_action_guard_e2e.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import yaml
 from typer.testing import CliRunner
 
-from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.core import evaluate
 from ac_guard.action_guard.matcher import Decision
 from ac_guard.audit import append_record, prune_by_age
 from ac_guard.cli.main import app
@@ -91,12 +91,12 @@ class TestHookActionGuardIntegration:
     """Hook templates correctly reference Action guard."""
 
     def test_claude_code_hook_has_action_guard(self, tmp_path: Path) -> None:
-        """Claude Code hook script imports action_guard.engine."""
+        """Claude Code hook script imports action_guard.core."""
         _init_and_install(tmp_path)
         hook_path = tmp_path / ".claude" / "hooks" / "interceptor.py"
         assert hook_path.is_file()
         content = hook_path.read_text(encoding="utf-8")
-        assert "from ac_guard.action_guard.engine import evaluate" in content
+        assert "from ac_guard.action_guard.core import evaluate" in content
 
     def test_cursor_hook_calls_action_guard(self, tmp_path: Path) -> None:
         """Cursor hook script calls python3 -m ac_guard.action_guard."""

--- a/tests/integration/test_ruleset_lifecycle.py
+++ b/tests/integration/test_ruleset_lifecycle.py
@@ -16,7 +16,7 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
-from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.core import evaluate
 from ac_guard.action_guard.matcher import Decision
 from ac_guard.cli.main import app
 from ac_guard.generator import installation_path

--- a/tests/unit/test_action_guard/test_core.py
+++ b/tests/unit/test_action_guard/test_core.py
@@ -1,4 +1,4 @@
-"""Tests for Action guard engine — top-level evaluate() (E1+E2+E3/E4)."""
+"""Tests for Action guard core — top-level evaluate() (E1+E2+E3/E4)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from ac_guard.action_guard.engine import evaluate
+from ac_guard.action_guard.core import evaluate
 from ac_guard.action_guard.matcher import Decision, PolicyDecision
 
 

--- a/tests/unit/test_action_guard/test_matcher.py
+++ b/tests/unit/test_action_guard/test_matcher.py
@@ -9,7 +9,7 @@ import pytest
 from ac_guard.action_guard.matcher import (
     VALID_SCHEMES,
     Decision,
-    evaluate_rules,
+    decide,
     find_matching_rule,
     matches,
     parse_pattern,
@@ -192,12 +192,12 @@ class TestFindMatchingRule:
 
 
 # ---------------------------------------------------------------------------
-# TestEvaluateRules
+# TestDecide
 # ---------------------------------------------------------------------------
 
 
-class TestEvaluateRules:
-    """Tests for evaluate_rules function."""
+class TestDecide:
+    """Tests for decide function."""
 
     def _rules(
         self,
@@ -214,7 +214,7 @@ class TestEvaluateRules:
     def test_forbidden_returns_deny(self) -> None:
         """Matching forbidden rule returns DENY."""
         rules = self._rules(forbidden=[Rule(pattern="file:.git/**")])
-        result = evaluate_rules(".git/config", "file", rules)
+        result = decide(".git/config", "file", rules)
         assert result.decision == Decision.DENY
         assert result.tier == "forbidden"
         assert result.matched_rule is not None
@@ -222,21 +222,21 @@ class TestEvaluateRules:
     def test_require_approval_returns_ask(self) -> None:
         """Matching require_approval rule returns ASK."""
         rules = self._rules(require_approval=[Rule(pattern="file:guard.yaml")])
-        result = evaluate_rules("guard.yaml", "file", rules)
+        result = decide("guard.yaml", "file", rules)
         assert result.decision == Decision.ASK
         assert result.tier == "require_approval"
 
     def test_allow_returns_allow(self) -> None:
         """Matching allow rule returns ALLOW."""
         rules = self._rules(allow=[Rule(pattern="file:src/**")])
-        result = evaluate_rules("src/main.py", "file", rules)
+        result = decide("src/main.py", "file", rules)
         assert result.decision == Decision.ALLOW
         assert result.tier == "allow"
 
     def test_no_match_returns_default_allow(self) -> None:
         """No matching rule returns default ALLOW."""
         rules = self._rules(forbidden=[Rule(pattern="file:.git/**")])
-        result = evaluate_rules("src/main.py", "file", rules)
+        result = decide("src/main.py", "file", rules)
         assert result.decision == Decision.ALLOW
         assert result.tier == "default"
         assert result.matched_rule is None
@@ -247,7 +247,7 @@ class TestEvaluateRules:
             forbidden=[Rule(pattern="file:.git/**")],
             require_approval=[Rule(pattern="file:.git/**")],
         )
-        result = evaluate_rules(".git/config", "file", rules)
+        result = decide(".git/config", "file", rules)
         assert result.decision == Decision.DENY
         assert result.tier == "forbidden"
 
@@ -257,28 +257,28 @@ class TestEvaluateRules:
             require_approval=[Rule(pattern="file:*.yaml")],
             allow=[Rule(pattern="file:*.yaml")],
         )
-        result = evaluate_rules("config.yaml", "file", rules)
+        result = decide("config.yaml", "file", rules)
         assert result.decision == Decision.ASK
         assert result.tier == "require_approval"
 
     def test_regex_error_fail_closed(self) -> None:
         """Regex error results in DENY (fail-closed)."""
         rules = self._rules(forbidden=[Rule(pattern="file:[invalid", regex=True)])
-        result = evaluate_rules("test.py", "file", rules)
+        result = decide("test.py", "file", rules)
         assert result.decision == Decision.DENY
         assert result.tier == "error"
 
     def test_malformed_pattern_fail_closed(self) -> None:
         """Malformed pattern results in DENY (fail-closed)."""
         rules = self._rules(forbidden=[Rule(pattern="no_colon")])
-        result = evaluate_rules("test", "file", rules)
+        result = decide("test", "file", rules)
         assert result.decision == Decision.DENY
         assert result.tier == "error"
 
     def test_empty_rules_default_allow(self) -> None:
         """Empty OperationRules returns default ALLOW."""
         rules = OperationRules.empty()
-        result = evaluate_rules("anything", "file", rules)
+        result = decide("anything", "file", rules)
         assert result.decision == Decision.ALLOW
         assert result.tier == "default"
 
@@ -310,23 +310,23 @@ class TestRealisticScenarios:
 
     def test_write_to_src_allowed(self) -> None:
         """Writing to src/ is allowed."""
-        result = evaluate_rules("src/main.py", "file", self._build_rules())
+        result = decide("src/main.py", "file", self._build_rules())
         assert result.decision == Decision.ALLOW
         assert result.tier == "allow"
 
     def test_write_to_git_denied(self) -> None:
         """Writing to .git/ is denied."""
-        result = evaluate_rules(".git/config", "file", self._build_rules())
+        result = decide(".git/config", "file", self._build_rules())
         assert result.decision == Decision.DENY
 
     def test_write_to_config_asks(self) -> None:
         """Writing to guard.yaml asks for approval."""
-        result = evaluate_rules("guard.yaml", "file", self._build_rules())
+        result = decide("guard.yaml", "file", self._build_rules())
         assert result.decision == Decision.ASK
 
     def test_write_to_unknown_default_allow(self) -> None:
         """Writing to unmatched path gets default allow."""
-        result = evaluate_rules("README.md", "file", self._build_rules())
+        result = decide("README.md", "file", self._build_rules())
         assert result.decision == Decision.ALLOW
         assert result.tier == "default"
 
@@ -344,12 +344,11 @@ class TestRealisticScenarios:
             ],
         )
         assert (
-            evaluate_rules("git push --force origin", "shell", rules).decision
-            == Decision.DENY
+            decide("git push --force origin", "shell", rules).decision == Decision.DENY
         )
-        assert evaluate_rules("git status", "shell", rules).decision == Decision.ALLOW
+        assert decide("git status", "shell", rules).decision == Decision.ALLOW
         assert (
-            evaluate_rules("npm install", "shell", rules).decision == Decision.ALLOW
+            decide("npm install", "shell", rules).decision == Decision.ALLOW
         )  # default
 
     def test_mcp_tool_matching(self) -> None:
@@ -359,13 +358,8 @@ class TestRealisticScenarios:
             require_approval=[],
             allow=[Rule(pattern="mcp:memory:search_*")],
         )
-        assert (
-            evaluate_rules("memory:delete_all", "mcp", rules).decision == Decision.DENY
-        )
-        assert (
-            evaluate_rules("memory:search_query", "mcp", rules).decision
-            == Decision.ALLOW
-        )
+        assert decide("memory:delete_all", "mcp", rules).decision == Decision.DENY
+        assert decide("memory:search_query", "mcp", rules).decision == Decision.ALLOW
 
     def test_scheme_isolation(self) -> None:
         """File rules don't match shell targets."""
@@ -375,6 +369,6 @@ class TestRealisticScenarios:
             allow=[],
         )
         # ".git/config" as a shell target should not match file rules
-        result = evaluate_rules(".git/config", "shell", rules)
+        result = decide(".git/config", "shell", rules)
         assert result.decision == Decision.ALLOW
         assert result.tier == "default"

--- a/tests/unit/test_action_guard/test_public_api.py
+++ b/tests/unit/test_action_guard/test_public_api.py
@@ -1,0 +1,57 @@
+"""Contract tests locking the public surface of ``ac_guard.action_guard``.
+
+These tests fail loudly when symbols are added to or removed from the
+top-level ``__all__`` without a corresponding update here. They prevent
+quiet drift between the module's promised API and its imports.
+"""
+
+from __future__ import annotations
+
+import ac_guard.action_guard as ag
+
+_EXPECTED_PUBLIC_API: frozenset[str] = frozenset(
+    {
+        "ActionGuardError",
+        "Decision",
+        "PolicyCorruptError",
+        "PolicyDecision",
+        "evaluate",
+    }
+)
+
+
+def test_public_api_exact() -> None:
+    """``__all__`` must be exactly the agreed public surface."""
+    assert set(ag.__all__) == _EXPECTED_PUBLIC_API
+
+
+def test_each_public_symbol_is_importable() -> None:
+    """Every name in ``__all__`` must resolve on the package."""
+    for name in _EXPECTED_PUBLIC_API:
+        assert hasattr(ag, name), f"{name} listed in __all__ but not importable"
+
+
+def test_demoted_primitives_not_in_public_api() -> None:
+    """Internal pipeline primitives must not appear at top level.
+
+    These remain accessible via deep submodule imports for tests, but
+    are not part of the package's public contract — only ``evaluate``
+    is.
+    """
+    for name in (
+        "classify",
+        "load_policy",
+        "decide",
+        "find_matching_rule",
+        "matches",
+        "parse_pattern",
+        "MatchResult",
+        "VALID_SCHEMES",
+    ):
+        assert name not in ag.__all__, f"{name} should be demoted to internal"
+
+
+def test_legacy_evaluate_rules_removed() -> None:
+    """``evaluate_rules`` was renamed to ``decide``; neither name is public."""
+    assert "evaluate_rules" not in ag.__all__
+    assert not hasattr(ag, "evaluate_rules")

--- a/tests/unit/test_adapters/_snapshots/claude-code__hook__.claude__hooks__interceptor.py
+++ b/tests/unit/test_adapters/_snapshots/claude-code__hook__.claude__hooks__interceptor.py
@@ -30,7 +30,7 @@ if sys.executable != _INSTALL_PY and os.path.exists(_INSTALL_PY):
 # removed, venv rebuilt, package uninstalled), never let the tool call
 # silently pass — emit an `ask` decision so the user sees the problem.
 try:
-    from ac_guard.action_guard.engine import evaluate
+    from ac_guard.action_guard.core import evaluate
 except ImportError as _exc:
     json.dump(
         {

--- a/tests/unit/test_adapters/test_hooks.py
+++ b/tests/unit/test_adapters/test_hooks.py
@@ -24,7 +24,7 @@ class TestClaudeCodeHook:
     def test_renders_python_script(self) -> None:
         """Claude Code hook renders a Python script."""
         content = render_hook(_CLAUDE_CODE, BehaviorConfig.empty())
-        assert "from ac_guard.action_guard.engine import evaluate" in content
+        assert "from ac_guard.action_guard.core import evaluate" in content
 
     def test_contains_main_entry(self) -> None:
         """Claude Code hook has main() entry point."""


### PR DESCRIPTION
## Summary

Continuation of the ruleset (#152), generator (#153), and cli (#154/#155)
tightening series. Derives `action_guard`'s external surface from first
principles: the package is a behavior decision function, so the only
contract callers need is `evaluate()` + its return type + decision enum
+ exceptions. Also aligns `engine.py` → `core.py` with the four sibling
pipeline packages (`audit`, `code_gate`, `generator`, `reporter`) that
already use that name.

## Public surface

- `__init__.py` shrinks from **11 names to 5**: `evaluate`,
  `PolicyDecision`, `Decision`, `ActionGuardError`, `PolicyCorruptError`.
- Demoted to internal (deep-import only): `classify`, `load_policy`,
  `decide` (renamed from `evaluate_rules` — see below),
  `find_matching_rule`, `matches`, `parse_pattern`, `MatchResult`,
  `VALID_SCHEMES`. Submodule files and per-module `__all__` unchanged
  — only the top-level re-export is removed (matches
  ruleset/generator/cli pattern).
- New `tests/unit/test_action_guard/test_public_api.py` locks
  `__all__`.

## Internal rename

`matcher.evaluate_rules` → `matcher.decide`. Removes the naming
collision with `engine.evaluate` (the pipeline orchestrator); aligns
with the `Decision` enum and `PolicyDecision.decision` field. Only 2
callers (`core.py` + `test_matcher.py`).

## Module rename (BREAKING for already-deployed hooks)

- `engine.py` → `core.py` via `git mv` (preserves history).
- All in-repo callers updated: `__init__.py`, `cli.py`,
  `hooks/*.j2` template, `test_engine.py` → `test_core.py`,
  integration tests, snapshot fixtures.
- **Users with already-installed hooks must run `ac-guard install`
  (or `ac-guard update`) to regenerate
  `.claude/hooks/interceptor.py` et al.**, otherwise the embedded
  `from ac_guard.action_guard.engine import evaluate` will fail.

## Verified callers

- `.claude/hooks/interceptor.py` and
  `adapters/_templates/hooks/*.j2` only use `evaluate`; no
  production code touches the removed re-exports.
- Single subprocess surface (`python3 -m ac_guard.action_guard`) is
  unaffected.

## Test plan

- [x] `uv run pytest tests/` — 1205/1205 green
- [x] `uv run lint-imports` — both contracts kept
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] Manual smoke: `echo '{"tool_name":"Write","tool_input":{"file_path":"guard.yaml"}}' | uv run python3 -m ac_guard.action_guard` returns `{"decision":"ask",...}` as expected
- [x] Acceptance grep:
  - `from ac_guard.action_guard.engine` absent from `src/`, `tests/`,
    `.claude/`, `scripts/`
  - `evaluate_rules` absent from runtime code
  - `ac_guard.action_guard.__all__` contains exactly 5 names

## Plan

[`.claude/plans/action-guard-melodic-backus.md`](https://github.com/ikroal/ai-code-guard/blob/refactor/action-guard-api-tighten/.claude/plans/action-guard-melodic-backus.md)
in the local working tree (not committed; the file lives outside the
repo under `~/.claude/plans/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)