### PR TITLE
chore(dogfood): tighten guard.yaml with pre-push tests and secret forbid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # Edit guard.yaml (code.<stage>.*) instead.
 # ac-guard version: 0.1.0
 minimum_pre_commit_version: "3.0.0"
-default_install_hook_types: ["pre-commit", "commit-msg"]
+default_install_hook_types: ["pre-commit", "commit-msg", "pre-push"]
 default_language_version:
   python: python3
 
@@ -103,3 +103,10 @@ repos:
         types: ["python"]
         pass_filenames: true
         stages: ["pre-push"]
+      - id: custom-pytest
+        name: "pytest"
+        entry: "uv run --no-sync pytest --cov --cov-fail-under=80"
+        language: "system"
+        pass_filenames: false
+        stages: ["pre-push"]
+        types: ["python"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ The following rules define what operations are permitted, blocked, or require ap
 
 ### Write Operations
 
+**Forbidden** (blocked):
+- `file:.env*` — Environment files contain secrets- `file:**/credentials*` — Credential files are protected- `file:**/*.pem` — Private keys must not be checked in
 
 **Require Approval** (ask user):
 - `file:.importlinter` — Editing the import-linter contract changes module layering- `file:scripts/**` — scripts/ contains guard infrastructure (lint checkers etc.); edits weaken enforcement- `file:guard.yaml`- `file:.ac-guard/**`- `file:.pre-commit-config.yaml`- `file:.git/hooks/**`

--- a/guard.yaml
+++ b/guard.yaml
@@ -16,6 +16,13 @@ behavior:
     # guard.yaml, .ac-guard/**, .pre-commit-config.yaml, .git/hooks/** are
     # already protected by default. The extra entries below cover repo-specific
     # policy surface that, if edited unexpectedly, would silently weaken the gate.
+    forbidden:
+      - pattern: "file:.env*"
+        reason: "Environment files contain secrets"
+      - pattern: "file:**/credentials*"
+        reason: "Credential files are protected"
+      - pattern: "file:**/*.pem"
+        reason: "Private keys must not be checked in"
     require_approval:
       - pattern: "file:.importlinter"
         message: "Editing the import-linter contract changes module layering"
@@ -24,7 +31,7 @@ behavior:
 
 _pre_commit:
   minimum_version: "3.0.0"
-  default_install_hook_types: [pre-commit, commit-msg]
+  default_install_hook_types: [pre-commit, commit-msg, pre-push]
   default_language_version:
     python: python3
 
@@ -91,8 +98,18 @@ code:
           - id: conventional-pre-commit
             args: [--force-scope]
 
+  pre-push:
+    checks:
+      pytest:
+        command: "uv run --no-sync pytest --cov --cov-fail-under=80"
+        pass_filenames: false
+        types: [python]
+
 output:
+  locale: "zh-CN"
   audit:
+    enabled: true
+  pr_report:
     enabled: true
 
 languages:


### PR DESCRIPTION
## Summary

- Add `code.pre-push.checks.pytest` running `pytest --cov --cov-fail-under=80` so the project's own tests gate before push (currently 98% coverage; threshold leaves 18 points headroom). Also append `pre-push` to `_pre_commit.default_install_hook_types` so the stage actually installs.
- Hard-forbid `.env*` / `**/credentials*` / `**/*.pem` writes via `behavior.write.forbidden`, catching AI-Agent writes earlier than the existing `detect-private-key` post-hoc hook.
- Enable `output.pr_report` (uses CI-injected `GITHUB_TOKEN`) and switch `output.locale` to `zh-CN` for local audit/PR-report copy.

## Why this matters

ac-guard is a quality-gate tool dogfooded on its own repo. The existing `guard.yaml` left four schema knobs unused that the strict preset already validates:

- testing was deferred entirely to GitHub Actions, contradicting the project's thesis that gating belongs at the developer's machine
- secret-class files relied on `require_approval` instead of hard `forbidden`
- check results never landed in PR comments
- audit copy stayed English-only despite a Chinese-speaking maintainer

## Generated artefacts regenerated

`.pre-commit-config.yaml` and `CLAUDE.md` are auto-derived from `guard.yaml` via `ac-guard install`; both are committed alongside the source change.

## Test plan

- [x] `uv run --no-sync pytest --cov` — 1214 passed, 98% coverage (calibration step before adopting 80 threshold)
- [x] `uv run ac-guard install --agent claude-code` — 7 artefacts regenerated cleanly on top of main (post-#157)
- [x] `uv run pre-commit run --all-files` — 15 hooks Passed/Skipped, none Failed
- [x] `uv run pre-commit run --hook-stage pre-push --all-files` — `lint-python` + new `pytest` hook both Passed
- [x] Local commit run produced Chinese output (`阶段: pre-commit — 通过`) confirming `locale: zh-CN` end-to-end
- [x] Local commit also produced `Warning: report delivery failed: GitHub token not found` — confirms `pr_report` correctly degrades to a warning when `GITHUB_TOKEN` is absent (does not fail the hook)
- [ ] CI on this PR posts an ac-guard summary comment back to the PR (only verifiable once Actions runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)