### PR TITLE
feat(reporter): update-or-create PR comments + gh CLI fallback + hook fixes

### DIFF
--- a/guard.yaml
+++ b/guard.yaml
@@ -94,6 +94,8 @@ code:
 output:
   audit:
     enabled: true
+  pr_report:
+    enabled: true
 
 languages:
   python:

--- a/src/ac_guard/action_guard/core.py
+++ b/src/ac_guard/action_guard/core.py
@@ -36,6 +36,8 @@ _GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
 # Presence of both is the canonical "hooks installed" indicator used by
 # pre-commit itself (see their hook-impl template).
 _PRECOMMIT_HOOK_SIGNATURES = ("pre-commit", "hook-impl")
+# Signature in ac-guard's own generated hook template.
+_AC_GUARD_HOOK_SIGNATURE = "AI Code Guard"
 
 
 def evaluate(
@@ -159,19 +161,22 @@ def evaluate(
 
 
 def _precommit_hook_installed(project_root: Path) -> bool:
-    """Return True iff ``.git/hooks/pre-commit`` carries pre-commit's signature.
+    """Return True iff ``.git/hooks/pre-commit`` carries a known hook signature.
 
-    We look at the hook file contents rather than shelling out to
-    ``pre-commit`` so the check works on agents that don't have the
-    tool on PATH and so we don't pay subprocess startup on every
-    tool call.
+    Recognizes both the pre-commit framework's signature and ac-guard's
+    own generated hook. We look at the hook file contents rather than
+    shelling out to ``pre-commit`` so the check works on agents that
+    don't have the tool on PATH and so we don't pay subprocess startup
+    on every tool call.
     """
     hook_path = project_root / ".git" / "hooks" / "pre-commit"
     try:
         contents = hook_path.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
-    return all(sig in contents for sig in _PRECOMMIT_HOOK_SIGNATURES)
+    if all(sig in contents for sig in _PRECOMMIT_HOOK_SIGNATURES):
+        return True
+    return _AC_GUARD_HOOK_SIGNATURE in contents
 
 
 def _hooks_not_installed_result() -> MatchResult:

--- a/src/ac_guard/domain/__init__.py
+++ b/src/ac_guard/domain/__init__.py
@@ -42,9 +42,16 @@ Admission criteria for **Domain Services** (own sub-module, e.g.
 """
 
 from ac_guard.domain import languages, managed_block, stages
-from ac_guard.domain.models import CheckResult, FileSpec, StageOutcome, Violation
+from ac_guard.domain.models import (
+    CheckMetrics,
+    CheckResult,
+    FileSpec,
+    StageOutcome,
+    Violation,
+)
 
 __all__ = [
+    "CheckMetrics",
     "CheckResult",
     "FileSpec",
     "StageOutcome",

--- a/src/ac_guard/domain/models.py
+++ b/src/ac_guard/domain/models.py
@@ -9,8 +9,15 @@ a Domain Service in its own sub-module (e.g. ``managed_block.py``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
-__all__ = ["CheckResult", "FileSpec", "StageOutcome", "Violation"]
+__all__ = [
+    "CheckMetrics",
+    "CheckResult",
+    "FileSpec",
+    "StageOutcome",
+    "Violation",
+]
 
 
 @dataclass
@@ -37,6 +44,34 @@ class Violation:
 
 
 @dataclass
+class CheckMetrics:
+    """Structured metrics extracted from a check's raw output.
+
+    All fields are optional; only populated when the corresponding
+    tool output is detected and parsed.
+
+    Attributes:
+        coverage_pct: Code coverage percentage (from pytest-cov).
+        tests_total: Total number of tests.
+        tests_passed: Number of passed tests.
+        tests_failed: Number of failed tests.
+        tests_skipped: Number of skipped tests.
+        docstring_pct: Docstring coverage percentage (from interrogate).
+        static_analysis_issues: Number of static analysis issues found.
+        extra: Tool-specific metrics that don't have dedicated fields.
+    """
+
+    coverage_pct: float | None = None
+    tests_total: int | None = None
+    tests_passed: int | None = None
+    tests_failed: int | None = None
+    tests_skipped: int | None = None
+    docstring_pct: float | None = None
+    static_analysis_issues: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class CheckResult:
     """Result of running a single check or hook.
 
@@ -47,6 +82,7 @@ class CheckResult:
         duration_ms: Execution time in milliseconds.
         output: Captured stdout/stderr for diagnostics.
         skipped: Whether the check was skipped.
+        metrics: Structured metrics extracted from output.
     """
 
     name: str
@@ -55,6 +91,7 @@ class CheckResult:
     duration_ms: int = 0
     output: str = ""
     skipped: bool = False
+    metrics: CheckMetrics | None = None
 
 
 @dataclass
@@ -66,12 +103,16 @@ class StageOutcome:
         passed: Whether all checks in the stage passed.
         results: Per-check results.
         duration_ms: Total execution time in milliseconds.
+        guard_files_changed: Guard system files changed in this PR.
+        generated_at: Formatted timestamp of report generation.
     """
 
     stage: str
     passed: bool
     results: list[CheckResult] = field(default_factory=list)
     duration_ms: int = 0
+    guard_files_changed: list[str] = field(default_factory=list)
+    generated_at: str = ""
 
 
 @dataclass

--- a/src/ac_guard/generator/_templates/git_hooks/commit-msg.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/commit-msg.j2
@@ -6,4 +6,5 @@
 # Receives the commit message file path as $1; forward to the gate
 # runner so pre-commit hooks for the commit-msg stage can inspect it.
 
+export PATH="{{ venv_bin_dir }}:$PATH"
 exec "{{ ac_guard_executable }}" run --stage commit-msg --message-file "$1"

--- a/src/ac_guard/generator/_templates/git_hooks/pre-commit.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-commit.j2
@@ -3,4 +3,5 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
+export PATH="{{ venv_bin_dir }}:$PATH"
 exec "{{ ac_guard_executable }}" run --stage pre-commit

--- a/src/ac_guard/generator/_templates/git_hooks/pre-merge-commit.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-merge-commit.j2
@@ -3,4 +3,5 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
+export PATH="{{ venv_bin_dir }}:$PATH"
 exec "{{ ac_guard_executable }}" run --stage pre-merge-commit

--- a/src/ac_guard/generator/_templates/git_hooks/pre-push.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-push.j2
@@ -3,4 +3,5 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
+export PATH="{{ venv_bin_dir }}:$PATH"
 exec "{{ ac_guard_executable }}" run --stage pre-push

--- a/src/ac_guard/generator/_templates/git_hooks/pre-rebase.j2
+++ b/src/ac_guard/generator/_templates/git_hooks/pre-rebase.j2
@@ -3,4 +3,5 @@
 # Managed by ac-guard - do not edit manually
 # Run 'ac-guard install' to regenerate
 
+export PATH="{{ venv_bin_dir }}:$PATH"
 exec "{{ ac_guard_executable }}" run --stage pre-rebase

--- a/src/ac_guard/generator/core.py
+++ b/src/ac_guard/generator/core.py
@@ -518,14 +518,18 @@ def _generate_git_hooks(
 
     artifacts: list[FileSpec] = []
     env = _get_generator_env()
-    ac_guard_executable = str(_resolve_ac_guard_executable())
+    ac_guard_executable = _resolve_ac_guard_executable()
+    venv_bin_dir = str(ac_guard_executable.parent)
 
     for stage in stages:
         template = env.get_template(f"git_hooks/{stage}.j2")
         artifacts.append(
             FileSpec(
                 path=f".git/hooks/{stage}",
-                content=template.render(ac_guard_executable=ac_guard_executable),
+                content=template.render(
+                    ac_guard_executable=str(ac_guard_executable),
+                    venv_bin_dir=venv_bin_dir,
+                ),
                 executable=True,
             )
         )

--- a/src/ac_guard/reporter/_templates/report_en.md.j2
+++ b/src/ac_guard/reporter/_templates/report_en.md.j2
@@ -1,13 +1,13 @@
-## AI Code Guard Check Report
+## 🤖 AI Code Guard Check Report
 
-{% if generated_at %}**Generated**: {{ generated_at }}
+{% if generated_at %}📅 **Generated**: {{ generated_at }}
 
-{% endif %}**Stage**: {{ report.stage }} | **Result**: {{ "✅ PASSED" if report.passed else "❌ FAILED" }}
+{% endif %}🔍 **Stage**: {{ report.stage }} | **Result**: {{ "✅ PASSED" if report.passed else "❌ FAILED" }}
 
 {% if checklist %}
 ---
 
-### Checklist
+### 📋 Checklist
 
 | Item | Status |
 |------|--------|
@@ -17,7 +17,7 @@
 {% endif %}
 ---
 
-### Results
+### 📊 Results
 
 | Check | Status | Time | Metrics |
 |-------|--------|------|---------|
@@ -30,7 +30,7 @@
 
 {% if violations %}
 <details>
-<summary>Violations ({{ violations | length }})</summary>
+<summary>⚠️ Violations ({{ violations | length }})</summary>
 
 ```
 {% for v in violations %}
@@ -48,7 +48,7 @@
 {% endif %}
 
 {% if guard_files_changed %}
-> **Note**: Guard system files changed in this PR: {{ guard_files_changed | join(", ") }}
+> 🔧 **Note**: Guard system files changed in this PR: {{ guard_files_changed | join(", ") }}
 
 {% endif %}
 **{{ passed }}/{{ total }}** checks passed

--- a/src/ac_guard/reporter/_templates/report_en.md.j2
+++ b/src/ac_guard/reporter/_templates/report_en.md.j2
@@ -1,22 +1,36 @@
 ## AI Code Guard Check Report
 
-**Stage**: {{ report.stage }} | **Result**: {{ "✅ PASSED" if report.passed else "❌ FAILED" }}
+{% if generated_at %}**Generated**: {{ generated_at }}
 
-| Check | Status | Time |
-|-------|--------|------|
+{% endif %}**Stage**: {{ report.stage }} | **Result**: {{ "✅ PASSED" if report.passed else "❌ FAILED" }}
+
+{% if checklist %}
+---
+
+### Checklist
+
+| Item | Status |
+|------|--------|
+{% for item in checklist %}| {{ item.label }} | {{ status_emoji(item.status) }}{% if item.detail %} {{ item.detail }}{% endif %} |
+{% endfor %}
+
+{% endif %}
+---
+
+### Results
+
+| Check | Status | Time | Metrics |
+|-------|--------|------|---------|
 {% for r in report.results %}
-{% if r.skipped %}
-| {{ r.name }} | ⏭️ Skip | - |
-{% elif r.passed %}
-| {{ r.name }} | ✅ Pass | {{ r.duration_ms }}ms |
-{% else %}
-| {{ r.name }} | ❌ Fail | {{ r.duration_ms }}ms |
+{% if r.skipped %}| {{ r.name }} | ⏭️ Skip | - | |
+{% elif r.passed %}| {{ r.name }} | ✅ Pass | {{ r.duration_ms }}ms | {{ metrics_summary(r) }} |
+{% else %}| {{ r.name }} | ❌ Fail | {{ r.duration_ms }}ms | {{ metrics_summary(r) }} |
 {% endif %}
 {% endfor %}
 
 {% if violations %}
 <details>
-<summary>Violations</summary>
+<summary>Violations ({{ violations | length }})</summary>
 
 ```
 {% for v in violations %}
@@ -33,4 +47,8 @@
 </details>
 {% endif %}
 
+{% if guard_files_changed %}
+> **Note**: Guard system files changed in this PR: {{ guard_files_changed | join(", ") }}
+
+{% endif %}
 **{{ passed }}/{{ total }}** checks passed

--- a/src/ac_guard/reporter/_templates/report_zh_cn.md.j2
+++ b/src/ac_guard/reporter/_templates/report_zh_cn.md.j2
@@ -1,22 +1,36 @@
 ## AI Code Guard 检查报告
 
-**阶段**: {{ report.stage }} | **结果**: {{ "✅ 通过" if report.passed else "❌ 失败" }}
+{% if generated_at %}**生成时间**: {{ generated_at }}
 
-| 检查项 | 状态 | 耗时 |
-|--------|------|------|
+{% endif %}**阶段**: {{ report.stage }} | **结果**: {{ "✅ 通过" if report.passed else "❌ 失败" }}
+
+{% if checklist %}
+---
+
+### 检查清单
+
+| 项目 | 状态 |
+|------|------|
+{% for item in checklist %}| {{ item.label }} | {{ status_emoji(item.status) }}{% if item.detail %} {{ item.detail }}{% endif %} |
+{% endfor %}
+
+{% endif %}
+---
+
+### 检查详情
+
+| 检查项 | 状态 | 耗时 | 指标 |
+|--------|------|------|------|
 {% for r in report.results %}
-{% if r.skipped %}
-| {{ r.name }} | ⏭️ 跳过 | - |
-{% elif r.passed %}
-| {{ r.name }} | ✅ 通过 | {{ r.duration_ms }}ms |
-{% else %}
-| {{ r.name }} | ❌ 失败 | {{ r.duration_ms }}ms |
+{% if r.skipped %}| {{ r.name }} | ⏭️ 跳过 | - | |
+{% elif r.passed %}| {{ r.name }} | ✅ 通过 | {{ r.duration_ms }}ms | {{ metrics_summary(r) }} |
+{% else %}| {{ r.name }} | ❌ 失败 | {{ r.duration_ms }}ms | {{ metrics_summary(r) }} |
 {% endif %}
 {% endfor %}
 
 {% if violations %}
 <details>
-<summary>违规详情</summary>
+<summary>违规详情 ({{ violations | length }})</summary>
 
 ```
 {% for v in violations %}
@@ -33,4 +47,8 @@
 </details>
 {% endif %}
 
+{% if guard_files_changed %}
+> **注意**: 本 PR 修改了检查系统文件: {{ guard_files_changed | join(", ") }}
+
+{% endif %}
 **{{ passed }}/{{ total }}** 项检查通过

--- a/src/ac_guard/reporter/_templates/report_zh_cn.md.j2
+++ b/src/ac_guard/reporter/_templates/report_zh_cn.md.j2
@@ -1,13 +1,13 @@
-## AI Code Guard 检查报告
+## 🤖 AI Code Guard 检查报告
 
-{% if generated_at %}**生成时间**: {{ generated_at }}
+{% if generated_at %}📅 **生成时间**: {{ generated_at }}
 
-{% endif %}**阶段**: {{ report.stage }} | **结果**: {{ "✅ 通过" if report.passed else "❌ 失败" }}
+{% endif %}🔍 **阶段**: {{ report.stage }} | **结果**: {{ "✅ 通过" if report.passed else "❌ 失败" }}
 
 {% if checklist %}
 ---
 
-### 检查清单
+### 📋 检查清单
 
 | 项目 | 状态 |
 |------|------|
@@ -17,7 +17,7 @@
 {% endif %}
 ---
 
-### 检查详情
+### 📊 检查详情
 
 | 检查项 | 状态 | 耗时 | 指标 |
 |--------|------|------|------|
@@ -30,7 +30,7 @@
 
 {% if violations %}
 <details>
-<summary>违规详情 ({{ violations | length }})</summary>
+<summary>⚠️ 违规详情 ({{ violations | length }})</summary>
 
 ```
 {% for v in violations %}
@@ -48,7 +48,7 @@
 {% endif %}
 
 {% if guard_files_changed %}
-> **注意**: 本 PR 修改了检查系统文件: {{ guard_files_changed | join(", ") }}
+> 🔧 **注意**: 本 PR 修改了检查系统文件: {{ guard_files_changed | join(", ") }}
 
 {% endif %}
 **{{ passed }}/{{ total }}** 项检查通过

--- a/src/ac_guard/reporter/channels/_http.py
+++ b/src/ac_guard/reporter/channels/_http.py
@@ -23,7 +23,7 @@ from ac_guard.reporter.channels.base import ChannelError
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-__all__ = ["RetryPolicy", "get_json", "post_json"]
+__all__ = ["RetryPolicy", "get_json", "patch_json", "post_json"]
 
 # HTTP status codes considered transient and worth retrying.
 _RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
@@ -111,6 +111,38 @@ def post_json(
     """
     return _do_request(
         _PreparedRequest(url=url, method="POST", headers=headers, body=body),
+        api_name=api_name,
+        retry=retry,
+    )
+
+
+def patch_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    body: dict | None = None,
+    api_name: str,
+    retry: RetryPolicy = _DEFAULT_RETRY,
+) -> dict | list | None:
+    """Issue a PATCH request with bounded retries and return parsed JSON.
+
+    Args:
+        url: Absolute URL to request.
+        headers: Fully built request headers (auth, accept, content-type).
+        body: Optional JSON-serializable request body.
+        api_name: Human-readable API name used in error messages.
+        retry: Retry/backoff policy.
+
+    Returns:
+        Parsed JSON body on success. Returns ``None`` when the response
+        body is empty.
+
+    Raises:
+        ChannelError: On non-retryable HTTP errors (4xx other than
+            408/429) or when retries are exhausted on retryable failures.
+    """
+    return _do_request(
+        _PreparedRequest(url=url, method="PATCH", headers=headers, body=body),
         api_name=api_name,
         retry=retry,
     )

--- a/src/ac_guard/reporter/channels/bitbucket.py
+++ b/src/ac_guard/reporter/channels/bitbucket.py
@@ -80,3 +80,11 @@ class BitbucketChannel(GitPlatformChannel):
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
+
+    def _list_comments_url(self, api_url: str, repo: str, pr_id: str) -> str:
+        return f"{api_url}/2.0/repositories/{repo}/pullrequests/{pr_id}/comments"
+
+    def _comment_update_url(
+        self, api_url: str, repo: str, pr_id: str, comment_id: str
+    ) -> str:
+        return f"{api_url}/2.0/repositories/{repo}/pullrequests/{pr_id}/comments/{comment_id}"

--- a/src/ac_guard/reporter/channels/git_platform.py
+++ b/src/ac_guard/reporter/channels/git_platform.py
@@ -24,8 +24,9 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
 from ac_guard.reporter.channels._git_info import get_remote_repo
-from ac_guard.reporter.channels._http import post_json
+from ac_guard.reporter.channels._http import get_json, patch_json, post_json
 from ac_guard.reporter.channels.base import ChannelError, ReportChannel
+from ac_guard.reporter.formatting import _MARKER
 
 if TYPE_CHECKING:
     from ac_guard.reporter.core import GitPlatformCfg
@@ -64,7 +65,10 @@ class GitPlatformChannel(ReportChannel):
     # ---- template method ---------------------------------------------------
 
     def output(self, payload: str) -> None:
-        """Post ``payload`` (Markdown) as a comment on the associated PR/MR.
+        """Post or update ``payload`` (Markdown) as a comment on the PR/MR.
+
+        If an existing comment bearing the ac-guard marker is found, it
+        is updated via PATCH. Otherwise a new comment is created via POST.
 
         Args:
             payload: Rendered Markdown string.
@@ -78,13 +82,52 @@ class GitPlatformChannel(ReportChannel):
         repo = self._resolve_repo()
         api_url = (self.config.api_url or self.DEFAULT_API_URL).rstrip("/")
         pr_id = self._resolve_pr(token, repo, api_url)
-        url = self._post_url(api_url, repo, pr_id)
-        post_json(
-            url,
-            headers=self._auth_headers(token),
-            body=self._wrap_body(payload),
-            api_name=self._api_name(),
-        )
+        headers = self._auth_headers(token)
+        api = self._api_name()
+
+        existing_id = self._find_existing_comment(api_url, repo, pr_id, headers, api)
+        if existing_id:
+            url = self._comment_update_url(api_url, repo, pr_id, existing_id)
+            patch_json(
+                url,
+                headers=headers,
+                body=self._wrap_body(payload),
+                api_name=api,
+            )
+        else:
+            url = self._post_url(api_url, repo, pr_id)
+            post_json(
+                url,
+                headers=headers,
+                body=self._wrap_body(payload),
+                api_name=api,
+            )
+
+    def _find_existing_comment(
+        self,
+        api_url: str,
+        repo: str,
+        pr_id: str,
+        headers: dict[str, str],
+        api_name: str,
+    ) -> str | None:
+        """Search for an existing comment bearing the ac-guard marker."""
+        url = self._list_comments_url(api_url, repo, pr_id)
+        try:
+            comments = get_json(url, headers=headers, api_name=api_name)
+            if not comments or not isinstance(comments, list):
+                return None
+            for comment in comments:
+                body = (
+                    comment.get("body", "")
+                    or comment.get("content", {}).get("raw", "")
+                    or ""
+                )
+                if _MARKER in body:
+                    return str(comment["id"])
+        except ChannelError:
+            pass
+        return None
 
     # ---- common helpers ----------------------------------------------------
 
@@ -220,4 +263,33 @@ class GitPlatformChannel(ReportChannel):
 
         Returns:
             Dict of request headers.
+        """
+
+    @abstractmethod
+    def _list_comments_url(self, api_url: str, repo: str, pr_id: str) -> str:
+        """Build the URL to list comments on a PR/MR.
+
+        Args:
+            api_url: API base URL (no trailing slash).
+            repo: Repository identifier.
+            pr_id: PR/MR identifier.
+
+        Returns:
+            Full URL for a GET request returning a JSON array of comments.
+        """
+
+    @abstractmethod
+    def _comment_update_url(
+        self, api_url: str, repo: str, pr_id: str, comment_id: str
+    ) -> str:
+        """Build the URL to update a specific comment.
+
+        Args:
+            api_url: API base URL (no trailing slash).
+            repo: Repository identifier.
+            pr_id: PR/MR identifier.
+            comment_id: Comment identifier.
+
+        Returns:
+            Full URL for a PATCH request to update the comment.
         """

--- a/src/ac_guard/reporter/channels/git_platform.py
+++ b/src/ac_guard/reporter/channels/git_platform.py
@@ -19,6 +19,7 @@ channel-implementation concern.
 from __future__ import annotations
 
 import os
+import subprocess
 from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
@@ -88,21 +89,39 @@ class GitPlatformChannel(ReportChannel):
     # ---- common helpers ----------------------------------------------------
 
     def _read_token(self) -> str:
-        """Read the API token from ``config.token_env``.
+        """Read the API token from ``config.token_env`` or ``gh`` CLI.
+
+        Priority:
+            1. ``config.token_env`` environment variable
+            2. ``gh auth token`` (local development fallback)
 
         Returns:
             The token string.
 
         Raises:
-            ChannelError: If the environment variable is not set.
+            ChannelError: If neither source provides a token.
         """
         token = os.environ.get(self.config.token_env)
-        if not token:
-            raise ChannelError(
-                f"{self._api_name()} token not found: set the "
-                f"{self.config.token_env} environment variable"
+        if token:
+            return token
+        # Fallback: gh CLI (local development)
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
             )
-        return token
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+        raise ChannelError(
+            f"{self._api_name()} token not found: set the "
+            f"{self.config.token_env} environment variable "
+            f"or run 'gh auth login'"
+        )
 
     def _resolve_repo(self) -> str:
         """Resolve the repository identifier.

--- a/src/ac_guard/reporter/channels/gitea.py
+++ b/src/ac_guard/reporter/channels/gitea.py
@@ -69,3 +69,11 @@ class GiteaChannel(GitPlatformChannel):
             "Authorization": f"token {token}",
             "Content-Type": "application/json",
         }
+
+    def _list_comments_url(self, api_url: str, repo: str, pr_id: str) -> str:
+        return f"{api_url}/api/v1/repos/{repo}/issues/{pr_id}/comments"
+
+    def _comment_update_url(
+        self, api_url: str, repo: str, pr_id: str, comment_id: str
+    ) -> str:
+        return f"{api_url}/api/v1/repos/{repo}/issues/comments/{comment_id}"

--- a/src/ac_guard/reporter/channels/github.py
+++ b/src/ac_guard/reporter/channels/github.py
@@ -100,3 +100,11 @@ class GitHubChannel(GitPlatformChannel):
             "Accept": "application/vnd.github+json",
             "Content-Type": "application/json",
         }
+
+    def _list_comments_url(self, api_url: str, repo: str, pr_id: str) -> str:
+        return f"{api_url}/repos/{repo}/issues/{pr_id}/comments"
+
+    def _comment_update_url(
+        self, api_url: str, repo: str, pr_id: str, comment_id: str
+    ) -> str:
+        return f"{api_url}/repos/{repo}/issues/comments/{comment_id}"

--- a/src/ac_guard/reporter/channels/github.py
+++ b/src/ac_guard/reporter/channels/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 
 from ac_guard.reporter.channels._git_info import get_current_branch
 from ac_guard.reporter.channels._http import get_json
@@ -48,7 +49,21 @@ class GitHubChannel(GitPlatformChannel):
         if match:
             return match.group(1)
 
-        # 3. API query by branch
+        # 3. gh CLI fallback (local development)
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", "--json", "number", "-q", ".number"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        # 4. API query by branch
         branch = get_current_branch()
         if branch:
             owner = repo.split("/")[0] if "/" in repo else repo

--- a/src/ac_guard/reporter/channels/gitlab.py
+++ b/src/ac_guard/reporter/channels/gitlab.py
@@ -89,3 +89,11 @@ class GitLabChannel(GitPlatformChannel):
             "PRIVATE-TOKEN": token,
             "Content-Type": "application/json",
         }
+
+    def _list_comments_url(self, api_url: str, repo: str, pr_id: str) -> str:
+        return f"{api_url}/api/v4/projects/{repo}/merge_requests/{pr_id}/notes"
+
+    def _comment_update_url(
+        self, api_url: str, repo: str, pr_id: str, comment_id: str
+    ) -> str:
+        return f"{api_url}/api/v4/projects/{repo}/merge_requests/{pr_id}/notes/{comment_id}"

--- a/src/ac_guard/reporter/formatting.py
+++ b/src/ac_guard/reporter/formatting.py
@@ -73,44 +73,67 @@ def _get_env() -> Environment:
 
 
 def format_terminal(report: Any, locale: str = "en") -> str:
-    """Format a StageOutcome for terminal display.
+    """Format a StageOutcome for terminal display with emojis and metrics.
 
-    Produces a multi-line rendering: stage heading, one ``[PASS]`` /
-    ``[FAIL]`` / ``[SKIP]`` indicator per check, inline violation list,
-    and a passed/total summary + total elapsed. Serves both CLI users
-    and Git-hook environments; callers decide whether to truncate.
+    Produces a multi-line rendering with enriched data: checklist,
+    metrics summary per check, and guard-file change detection.
 
     Args:
         report: Any to format.
-        locale: Label locale (``"en"`` or ``"zh-CN"``). Unknown locales
-            fall back to English. Only full-line headings are localized;
-            the ``[PASS] / [FAIL] / [SKIP]`` indicators and check names
-            stay as stable ASCII tokens to preserve alignment.
+        locale: Label locale (``"en"`` or ``"zh-CN"``).
 
     Returns:
         Formatted multi-line string for terminal output.
     """
+    from ac_guard.reporter.metrics import build_checklist, enrich_outcome
+
+    enriched = enrich_outcome(report)
+    checklist = build_checklist(enriched)
+
     labels = _labels_for(locale)
-    status = labels["passed"] if report.passed else labels["failed"]
+    status_emoji = "✅" if enriched.passed else "❌"
+    status = labels["passed"] if enriched.passed else labels["failed"]
 
     lines: list[str] = []
-    lines.append(f"{labels['stage']}: {report.stage} — {status}")
+    lines.append(f"🤖 {labels['stage']}: {enriched.stage} — {status_emoji} {status}")
     lines.append("")
 
-    for result in report.results:
-        indicator = _result_indicator(result)
+    # Checklist
+    if checklist:
+        lines.append("📋 Checklist:")
+        for item in checklist:
+            emoji = _status_emoji(item.status)
+            detail = f" {item.detail}" if item.detail else ""
+            lines.append(f"  {emoji} {item.label}{detail}")
+        lines.append("")
+
+    # Results
+    lines.append("📊 Results:")
+    for result in enriched.results:
+        emoji = _status_emoji(
+            "skip" if result.skipped else ("pass" if result.passed else "fail")
+        )
         duration = f" ({result.duration_ms}ms)" if result.duration_ms else ""
-        lines.append(f"  [{indicator}] {result.name}{duration}")
+        metrics = _metrics_summary(result)
+        metrics_str = f" | {metrics}" if metrics else ""
+        lines.append(f"  {emoji} {result.name}{duration}{metrics_str}")
         lines.extend(f"    {_format_violation(v)}" for v in result.violations)
 
     lines.append("")
-    passed = sum(1 for r in report.results if r.passed)
-    total = len(report.results)
+    passed = sum(1 for r in enriched.results if r.passed)
+    total = len(enriched.results)
     failed = total - passed
     lines.append(labels["summary"].format(passed=passed, total=total, failed=failed))
 
-    if report.duration_ms:
-        lines.append(f"{labels['total_time']}: {report.duration_ms}ms")
+    if enriched.duration_ms:
+        lines.append(f"{labels['total_time']}: {enriched.duration_ms}ms")
+
+    # Guard file changes
+    if enriched.guard_files_changed:
+        lines.append("")
+        lines.append(
+            f"🔧 Guard files changed: {', '.join(enriched.guard_files_changed)}"
+        )
 
     return "\n".join(lines)
 

--- a/src/ac_guard/reporter/formatting.py
+++ b/src/ac_guard/reporter/formatting.py
@@ -153,6 +153,9 @@ def _format_violation(v: Any) -> str:
 # Markdown format
 # ---------------------------------------------------------------------------
 
+_MARKER = "<!-- ac-guard-report -->"
+"""Hidden HTML marker prepended to PR comments for update-or-create."""
+
 
 def format_markdown(
     report: Any,
@@ -178,12 +181,13 @@ def format_markdown(
     passed = sum(1 for r in report.results if r.passed)
     total = len(report.results)
 
-    return template.render(
+    rendered = template.render(
         report=report,
         violations=violations,
         passed=passed,
         total=total,
     )
+    return _MARKER + "\n" + rendered
 
 
 # ---------------------------------------------------------------------------

--- a/src/ac_guard/reporter/formatting.py
+++ b/src/ac_guard/reporter/formatting.py
@@ -170,24 +170,56 @@ def format_markdown(
     Returns:
         Markdown-formatted string.
     """
+    from ac_guard.reporter.metrics import build_checklist, enrich_outcome
+
+    enriched = enrich_outcome(report)
+    checklist = build_checklist(enriched)
+
     template_name = _LOCALE_TEMPLATES.get(locale, "report_en.md.j2")
     env = _get_env()
     template = env.get_template(template_name)
 
     violations: list[Any] = []
-    for result in report.results:
+    for result in enriched.results:
         violations.extend(result.violations)
 
-    passed = sum(1 for r in report.results if r.passed)
-    total = len(report.results)
+    passed = sum(1 for r in enriched.results if r.passed)
+    total = len(enriched.results)
 
     rendered = template.render(
-        report=report,
+        report=enriched,
         violations=violations,
         passed=passed,
         total=total,
+        checklist=checklist,
+        guard_files_changed=enriched.guard_files_changed,
+        generated_at=enriched.generated_at,
+        status_emoji=_status_emoji,
+        metrics_summary=_metrics_summary,
     )
     return _MARKER + "\n" + rendered
+
+
+def _status_emoji(status: str) -> str:
+    """Map status string to emoji."""
+    return {"pass": "✅", "fail": "❌", "skip": "⏭️", "warn": "⚠️"}.get(status, "")
+
+
+def _metrics_summary(result: Any) -> str:
+    """Render compact metrics summary for a check result."""
+    if not result.metrics:
+        return ""
+    m = result.metrics
+    parts = []
+    if m.coverage_pct is not None:
+        parts.append(f"cov: {m.coverage_pct:.0f}%")
+    if m.tests_total is not None:
+        parts.append(f"{m.tests_passed}/{m.tests_total} tests")
+    if m.docstring_pct is not None:
+        parts.append(f"docs: {m.docstring_pct:.0f}%")
+    if m.static_analysis_issues is not None:
+        parts.append(f"{m.static_analysis_issues} issues")
+    return " | ".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ac_guard/reporter/metrics.py
+++ b/src/ac_guard/reporter/metrics.py
@@ -1,0 +1,299 @@
+"""Metrics extraction and enrichment for PR quality reports.
+
+Post-processes :class:`CheckResult.output` to extract structured metrics
+(coverage %, test counts, docstring %, etc.) without affecting the
+pass/fail determination (which remains exit-code-only per ADR-4).
+
+Also provides checklist building and guard-system file change detection.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ac_guard.domain.models import StageOutcome
+
+from dataclasses import dataclass
+
+from ac_guard.domain.models import CheckMetrics
+
+
+@dataclass
+class ChecklistItem:
+    """A single item in the quality checklist.
+
+    Attributes:
+        label: Human-readable label (e.g. "Code formatting").
+        status: Pass/fail/skip/warn status.
+        detail: Optional detail string (e.g. "85%", "129/129").
+    """
+
+    label: str
+    status: str  # "pass", "fail", "skip", "warn"
+    detail: str = ""
+
+
+__all__ = ["ChecklistItem", "build_checklist", "enrich_outcome"]
+
+# ---------------------------------------------------------------------------
+# Parser registry
+# ---------------------------------------------------------------------------
+
+_PARSERS: list[Callable[[str, str], CheckMetrics | None]] = []
+
+
+def _register_parser(fn: Callable[[str, str], CheckMetrics | None]) -> None:
+    """Register a metrics parser. Called at module import time."""
+    _PARSERS.append(fn)
+
+
+def _extract_metrics(name: str, output: str) -> CheckMetrics | None:
+    """Try all registered parsers, return first match."""
+    for parser in _PARSERS:
+        result = parser(name, output)
+        if result is not None:
+            return result
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Built-in parsers
+# ---------------------------------------------------------------------------
+
+# pytest summary line: "129 passed", "128 passed, 1 failed, 2 skipped"
+_PYTEST_SUMMARY_RE = re.compile(
+    r"(\d+)\s+passed"
+    r"(?:,\s*(\d+)\s+failed)?"
+    r"(?:,\s*(\d+)\s+skipped)?"
+)
+
+# coverage.py TOTAL line: "TOTAL    1234    567    85%"
+_COVERAGE_TOTAL_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
+
+
+def _parse_pytest(name: str, output: str) -> CheckMetrics | None:
+    """Parse pytest output for test counts and coverage."""
+    match = _PYTEST_SUMMARY_RE.search(output)
+    if not match:
+        return None
+
+    passed = int(match.group(1))
+    failed = int(match.group(2) or 0)
+    skipped = int(match.group(3) or 0)
+    total = passed + failed + skipped
+
+    coverage_match = _COVERAGE_TOTAL_RE.search(output)
+    coverage_pct = float(coverage_match.group(1)) if coverage_match else None
+
+    return CheckMetrics(
+        tests_total=total,
+        tests_passed=passed,
+        tests_failed=failed,
+        tests_skipped=skipped,
+        coverage_pct=coverage_pct,
+    )
+
+
+_register_parser(_parse_pytest)
+
+
+# interrogate output: "RESULT: PASSED (100.0%)"
+_INTERROGATE_RESULT_RE = re.compile(r"RESULT:\s*\w+\s*\((\d+\.?\d*)%\)")
+
+
+def _parse_interrogate(name: str, output: str) -> CheckMetrics | None:
+    """Parse interrogate output for docstring coverage percentage."""
+    match = _INTERROGATE_RESULT_RE.search(output)
+    if not match:
+        return None
+    return CheckMetrics(docstring_pct=float(match.group(1)))
+
+
+_register_parser(_parse_interrogate)
+
+
+# Matches ruff output: "Found 3 errors."
+_RUFF_ERRORS_RE = re.compile(r"Found\s+(\d+)\s+error")
+
+
+def _parse_ruff(name: str, output: str) -> CheckMetrics | None:
+    """Parse ruff output for lint issue count."""
+    match = _RUFF_ERRORS_RE.search(output)
+    if not match:
+        return None
+    count = int(match.group(1))
+    if count == 0:
+        return None
+    return CheckMetrics(static_analysis_issues=count)
+
+
+_register_parser(_parse_ruff)
+
+
+# bandit: "Total issues (by severity): ... High: 0 ... Low: 2"
+_BANDIT_TOTAL_RE = re.compile(
+    r"Total issues.*?High:\s*(\d+).*?Low:\s*(\d+)",
+    re.DOTALL,
+)
+
+
+def _parse_bandit(name: str, output: str) -> CheckMetrics | None:
+    """Parse bandit output for security issue count."""
+    match = _BANDIT_TOTAL_RE.search(output)
+    if not match:
+        return None
+    high = int(match.group(1))
+    low = int(match.group(2))
+    total = high + low
+    if total == 0:
+        return None
+    return CheckMetrics(static_analysis_issues=total)
+
+
+_register_parser(_parse_bandit)
+
+
+# ---------------------------------------------------------------------------
+# Checklist builder
+# ---------------------------------------------------------------------------
+
+_STATUS_EMOJI = {
+    "pass": "✅",
+    "fail": "❌",
+    "skip": "⏭️",
+    "warn": "⚠️",
+}
+
+
+def build_checklist(outcome: StageOutcome) -> list[ChecklistItem]:
+    """Build a human-readable quality checklist from check results."""
+    items: list[ChecklistItem] = []
+
+    for result in outcome.results:
+        if result.skipped:
+            continue
+
+        # Map check names to semantic labels
+        label = _check_label(result.name)
+        if label is None:
+            continue
+
+        # Determine status and detail
+        if result.metrics:
+            if result.metrics.coverage_pct is not None:
+                status = "pass" if result.passed else "fail"
+                detail = f"{result.metrics.coverage_pct:.0f}%"
+            elif result.metrics.tests_total is not None:
+                status = "pass" if result.passed else "fail"
+                m = result.metrics
+                detail = f"{m.tests_passed}/{m.tests_total}"
+            elif result.metrics.docstring_pct is not None:
+                status = "pass" if result.passed else "fail"
+                detail = f"{result.metrics.docstring_pct:.0f}%"
+            elif result.metrics.static_analysis_issues is not None:
+                status = "fail" if result.metrics.static_analysis_issues > 0 else "pass"
+                detail = f"{result.metrics.static_analysis_issues} issues"
+            else:
+                status = "pass" if result.passed else "fail"
+                detail = ""
+        else:
+            status = "pass" if result.passed else "fail"
+            detail = ""
+
+        items.append(ChecklistItem(label=label, status=status, detail=detail))
+
+    return items
+
+
+def _check_label(name: str) -> str | None:
+    """Map a check name to a human-readable label, or None to skip."""
+    lower = name.lower()
+    if "format" in lower:
+        return "Code formatting"
+    if "lint" in lower:
+        return "Linting"
+    if "test" in lower or "pytest" in lower:
+        return "Tests"
+    if "coverage" in lower:
+        return "Coverage"
+    if "interrogate" in lower or "docstring" in lower:
+        return "Docstring coverage"
+    if "bandit" in lower or "security" in lower:
+        return "Security analysis"
+    if "build" in lower:
+        return "Build"
+    if "forbid-noqa" in lower or "encoding" in lower:
+        return "Code quality"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Guard-system file change detection
+# ---------------------------------------------------------------------------
+
+_GUARD_FILE_PATTERNS = [
+    "guard.yaml",
+    ".pre-commit-config.yaml",
+    ".ac-guard/",
+    ".git/hooks/",
+    ".claude/",
+    ".cursor/",
+    "pyproject.toml",
+]
+
+
+def _detect_guard_changes(project_root: str | None = None) -> list[str]:
+    """Detect guard-system files changed in this branch vs main."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "origin/main..HEAD", "--name-only"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=project_root,
+        )
+        if result.returncode != 0:
+            return []
+        changed = [f for f in result.stdout.strip().split("\n") if f]
+        return [
+            f for f in changed if any(pattern in f for pattern in _GUARD_FILE_PATTERNS)
+        ]
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Enrichment entry point
+# ---------------------------------------------------------------------------
+
+
+def enrich_outcome(outcome: StageOutcome) -> StageOutcome:
+    """Enrich a StageOutcome with metrics and change detection.
+
+    This is the single entry point called by the formatter before
+    template rendering. It is idempotent — calling it twice on the
+    same outcome is safe (metrics are only extracted if not already set).
+    """
+    # Extract metrics for each check result
+    for result in outcome.results:
+        if result.metrics is not None:
+            continue  # Already enriched
+        if result.output:
+            result.metrics = _extract_metrics(result.name, result.output)
+
+    # Detect guard-system file changes
+    if not outcome.guard_files_changed:
+        outcome.guard_files_changed = _detect_guard_changes()
+
+    # Set generation timestamp
+    if not outcome.generated_at:
+        outcome.generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    return outcome

--- a/tests/integration/test_code_gate_e2e.py
+++ b/tests/integration/test_code_gate_e2e.py
@@ -516,7 +516,7 @@ class TestLocalePropagation:
         with patch("ac_guard.code_gate.core._get_changed_files", return_value=[]):
             r = runner.invoke(app, ["run", "--stage", "pre-commit", "-c", str(config)])
         assert r.exit_code == 0
-        assert "阶段: pre-commit — 通过" in r.output
+        assert "🤖 阶段: pre-commit — ✅ 通过" in r.output
         assert "项检查通过" in r.output
         assert "PASSED" not in r.output
 

--- a/tests/integration/test_m5_report_and_output.py
+++ b/tests/integration/test_m5_report_and_output.py
@@ -109,8 +109,26 @@ class TestPrReportFlow:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
+        # GET list (empty) + POST create
+        list_resp = MagicMock()
+        list_resp.status = 200
+        list_resp.read.return_value = b"[]"
+        list_resp.__enter__ = MagicMock(return_value=list_resp)
+        list_resp.__exit__ = MagicMock(return_value=False)
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return list_resp
+            return mock_resp
+
         with (
-            patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen,
+            patch(
+                "urllib.request.urlopen", side_effect=urlopen_side_effect
+            ) as mock_urlopen,
             patch.dict(
                 "os.environ",
                 {
@@ -128,8 +146,8 @@ class TestPrReportFlow:
                     locale="en",
                 ),
             )
-            mock_urlopen.assert_called_once()
-            req = mock_urlopen.call_args[0][0]
+            assert mock_urlopen.call_count == 2
+            req = mock_urlopen.call_args_list[-1][0][0]
             body = json.loads(req.data)
             assert "body" in body
             assert len(body["body"]) > 0

--- a/tests/unit/test_action_guard/test_core.py
+++ b/tests/unit/test_action_guard/test_core.py
@@ -387,6 +387,26 @@ class TestHooksNotInstalledEscalation:
         assert result.decision == Decision.ASK
         assert result.tier == "hooks_not_installed"
 
+    def test_ac_guard_hook_signature_allows_commit(self, tmp_path: Path) -> None:
+        """ac-guard's own generated hook should count as installed."""
+        policy = _standard_policy()
+        policy["behavior"]["execute"]["allow"].append(
+            {"pattern": "shell:git commit*", "source": "user"},
+        )
+        _write_policy(tmp_path, policy)
+        hooks = tmp_path / ".git" / "hooks"
+        hooks.mkdir(parents=True, exist_ok=True)
+        (hooks / "pre-commit").write_text(
+            "#!/bin/bash\n# AI Code Guard pre-commit hook\n"
+            "# Managed by ac-guard - do not edit manually\n"
+            'exec "/usr/bin/ac-guard" run --stage pre-commit\n',
+            encoding="utf-8",
+        )
+
+        result = evaluate("Bash", {"command": "git commit -m x"}, tmp_path)
+        assert result.decision == Decision.ALLOW
+        assert result.tier != "hooks_not_installed"
+
 
 def _policy_with_audit(enabled: bool) -> dict:
     policy = _standard_policy()

--- a/tests/unit/test_domain/test_models.py
+++ b/tests/unit/test_domain/test_models.py
@@ -48,6 +48,7 @@ class TestValueObjectExports:
         import ac_guard.domain.models as models
 
         assert set(models.__all__) == {
+            "CheckMetrics",
             "CheckResult",
             "FileSpec",
             "StageOutcome",
@@ -62,6 +63,7 @@ class TestPackageApi:
         import ac_guard.domain as domain
 
         assert set(domain.__all__) == {
+            "CheckMetrics",
             "CheckResult",
             "FileSpec",
             "StageOutcome",

--- a/tests/unit/test_reporter/test_channels/test_bitbucket.py
+++ b/tests/unit/test_reporter/test_channels/test_bitbucket.py
@@ -76,7 +76,13 @@ class TestBitbucketChannel:
         monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
         monkeypatch.setenv("BITBUCKET_PR_ID", "1")
 
-        with pytest.raises(ChannelError, match="token"):
+        with (
+            patch(
+                "ac_guard.reporter.channels.git_platform.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(ChannelError, match="token"),
+        ):
             BitbucketChannel(self._make_config()).output("report")
 
     def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_reporter/test_channels/test_bitbucket.py
+++ b/tests/unit/test_reporter/test_channels/test_bitbucket.py
@@ -197,10 +197,15 @@ class TestBitbucketChannel:
         monkeypatch.setenv("BITBUCKET_REPO_FULL_NAME", "workspace/repo")
         monkeypatch.setenv("BITBUCKET_PR_ID", "42")
 
-        side_effect = [URLError("transient"), self._mock_urlopen()]
+        # GET list (empty) → POST fails → POST retry succeeds
+        side_effect = [
+            self._mock_urlopen(body=b"[]"),  # GET list comments
+            URLError("transient"),  # POST fails
+            self._mock_urlopen(),  # POST retry succeeds
+        ]
         with (
             patch("urllib.request.urlopen", side_effect=side_effect) as m,
             patch("ac_guard.reporter.channels._http.time.sleep"),
         ):
             BitbucketChannel(self._make_config()).output("## Report")
-        assert m.call_count == 2
+        assert m.call_count == 3

--- a/tests/unit/test_reporter/test_channels/test_gitea.py
+++ b/tests/unit/test_reporter/test_channels/test_gitea.py
@@ -182,10 +182,15 @@ class TestGiteaChannel:
         monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
         monkeypatch.setenv("AI_GUARD_PR_NUMBER", "42")
 
-        side_effect = [URLError("transient"), self._mock_urlopen()]
+        # GET list (empty) → POST fails → POST retry succeeds
+        side_effect = [
+            self._mock_urlopen(body=b"[]"),  # GET list comments
+            URLError("transient"),  # POST fails
+            self._mock_urlopen(),  # POST retry succeeds
+        ]
         with (
             patch("urllib.request.urlopen", side_effect=side_effect) as m,
             patch("ac_guard.reporter.channels._http.time.sleep"),
         ):
             GiteaChannel(self._make_config()).output("## Report")
-        assert m.call_count == 2
+        assert m.call_count == 3

--- a/tests/unit/test_reporter/test_channels/test_gitea.py
+++ b/tests/unit/test_reporter/test_channels/test_gitea.py
@@ -73,7 +73,13 @@ class TestGiteaChannel:
         monkeypatch.setenv("GITEA_REPOSITORY", "owner/repo")
         monkeypatch.setenv("AI_GUARD_PR_NUMBER", "1")
 
-        with pytest.raises(ChannelError, match="token"):
+        with (
+            patch(
+                "ac_guard.reporter.channels.git_platform.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(ChannelError, match="token"),
+        ):
             GiteaChannel(self._make_config()).output("report")
 
     def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_reporter/test_channels/test_github.py
+++ b/tests/unit/test_reporter/test_channels/test_github.py
@@ -73,8 +73,35 @@ class TestGitHubChannel:
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/1/merge")
 
-        with pytest.raises(ChannelError, match="token"):
+        with (
+            patch(
+                "ac_guard.reporter.channels.git_platform.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(ChannelError, match="token"),
+        ):
             GitHubChannel(self._make_config()).output("report")
+
+    def test_token_from_gh_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: read token from `gh auth token`."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ghp_gh_cli_token\n"
+
+        with (
+            patch(
+                "ac_guard.reporter.channels.git_platform.subprocess.run",
+                return_value=mock_result,
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            GitHubChannel(self._make_config()).output("## Report")
+            req = m.call_args[0][0]
+            assert req.get_header("Authorization") == "Bearer ghp_gh_cli_token"
 
     def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
@@ -127,6 +154,10 @@ class TestGitHubChannel:
 
         with (
             patch(
+                "ac_guard.reporter.channels.github.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
                 "ac_guard.reporter.channels.github.get_current_branch",
                 return_value="feat/test",
             ),
@@ -136,6 +167,27 @@ class TestGitHubChannel:
             # Second call (POST) should use PR 77
             post_req = m.call_args_list[-1][0][0]
             assert "/issues/77/comments" in post_req.full_url
+
+    def test_pr_number_from_gh_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback: get PR number from `gh pr view`."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.delenv("GITHUB_REF", raising=False)
+        monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "55\n"
+
+        with (
+            patch(
+                "ac_guard.reporter.channels.github.subprocess.run",
+                return_value=mock_result,
+            ),
+            patch("urllib.request.urlopen", return_value=self._mock_urlopen()) as m,
+        ):
+            GitHubChannel(self._make_config()).output("r")
+            assert "/issues/55/comments" in m.call_args[0][0].full_url
 
     def test_repo_from_git_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Fallback: get repo from git remote when env var missing."""
@@ -176,6 +228,10 @@ class TestGitHubChannel:
 
         with (
             patch(
+                "ac_guard.reporter.channels.github.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
                 "ac_guard.reporter.channels.github.get_current_branch",
                 return_value=None,
             ),
@@ -194,6 +250,10 @@ class TestGitHubChannel:
 
         with (
             patch(
+                "ac_guard.reporter.channels.github.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
                 "ac_guard.reporter.channels.github.get_current_branch",
                 return_value=None,
             ),
@@ -211,6 +271,10 @@ class TestGitHubChannel:
         monkeypatch.delenv("AI_GUARD_PR_NUMBER", raising=False)
 
         with (
+            patch(
+                "ac_guard.reporter.channels.github.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
             patch(
                 "ac_guard.reporter.channels.github.get_current_branch",
                 return_value=None,

--- a/tests/unit/test_reporter/test_channels/test_github.py
+++ b/tests/unit/test_reporter/test_channels/test_github.py
@@ -293,10 +293,98 @@ class TestGitHubChannel:
         monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
         monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
 
-        side_effect = [URLError("transient"), self._mock_urlopen()]
+        # GET list (empty) → POST fails → POST retry succeeds
+        side_effect = [
+            self._mock_urlopen(body=b"[]"),  # GET list comments
+            URLError("transient"),  # POST fails
+            self._mock_urlopen(),  # POST retry succeeds
+        ]
         with (
             patch("urllib.request.urlopen", side_effect=side_effect) as m,
             patch("ac_guard.reporter.channels._http.time.sleep"),
         ):
             GitHubChannel(self._make_config()).output("## Report")
-        assert m.call_count == 2
+        assert m.call_count == 3
+
+    def test_output_updates_existing_comment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When a comment with the ac-guard marker exists, PATCH it."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        existing_comments = json.dumps(
+            [
+                {"id": 999, "body": "<!-- ac-guard-report -->\n## Old Report"},
+            ]
+        ).encode()
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET list comments — returns existing comment with marker
+                return self._mock_urlopen(body=existing_comments)
+            # PATCH update comment
+            return self._mock_urlopen()
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m:
+            GitHubChannel(self._make_config()).output("## New Report")
+            # Second call should be PATCH to /issues/comments/999
+            patch_req = m.call_args_list[-1][0][0]
+            assert patch_req.method == "PATCH"
+            assert "/issues/comments/999" in patch_req.full_url
+
+    def test_output_creates_when_no_existing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no comment with the marker exists, POST a new one."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET list comments — empty
+                return self._mock_urlopen(body=b"[]")
+            # POST new comment
+            return self._mock_urlopen()
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m:
+            GitHubChannel(self._make_config()).output("## Report")
+            post_req = m.call_args_list[-1][0][0]
+            assert post_req.method == "POST"
+            assert "/issues/42/comments" in post_req.full_url
+
+    def test_output_creates_on_list_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If listing comments fails, fall through to POST."""
+        from urllib.error import HTTPError
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+
+        call_count = 0
+
+        def urlopen_side_effect(req: MagicMock) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # GET list comments — fails
+                raise HTTPError("", 403, "Forbidden", None, None)
+            # POST new comment
+            return self._mock_urlopen()
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as m:
+            GitHubChannel(self._make_config()).output("## Report")
+            post_req = m.call_args_list[-1][0][0]
+            assert post_req.method == "POST"

--- a/tests/unit/test_reporter/test_channels/test_gitlab.py
+++ b/tests/unit/test_reporter/test_channels/test_gitlab.py
@@ -184,10 +184,15 @@ class TestGitLabChannel:
         monkeypatch.setenv("CI_PROJECT_ID", "12345")
         monkeypatch.setenv("CI_MERGE_REQUEST_IID", "42")
 
-        side_effect = [URLError("transient"), self._mock_urlopen()]
+        # GET list (empty) → POST fails → POST retry succeeds
+        side_effect = [
+            self._mock_urlopen(body=b"[]"),  # GET list comments
+            URLError("transient"),  # POST fails
+            self._mock_urlopen(),  # POST retry succeeds
+        ]
         with (
             patch("urllib.request.urlopen", side_effect=side_effect) as m,
             patch("ac_guard.reporter.channels._http.time.sleep"),
         ):
             GitLabChannel(self._make_config()).output("## Report")
-        assert m.call_count == 2
+        assert m.call_count == 3

--- a/tests/unit/test_reporter/test_channels/test_gitlab.py
+++ b/tests/unit/test_reporter/test_channels/test_gitlab.py
@@ -73,7 +73,13 @@ class TestGitLabChannel:
         monkeypatch.setenv("CI_PROJECT_ID", "12345")
         monkeypatch.setenv("CI_MERGE_REQUEST_IID", "1")
 
-        with pytest.raises(ChannelError, match="token"):
+        with (
+            patch(
+                "ac_guard.reporter.channels.git_platform.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(ChannelError, match="token"),
+        ):
             GitLabChannel(self._make_config()).output("report")
 
     def test_custom_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_reporter/test_core.py
+++ b/tests/unit/test_reporter/test_core.py
@@ -70,7 +70,7 @@ class TestValidDispatch:
         out = buf.getvalue()
         # Multi-line text rendering: stage heading + check indicator.
         assert "pre-commit" in out
-        assert "[PASS]" in out
+        assert "✅" in out
 
     def test_terminal_json(self) -> None:
         buf = io.StringIO()
@@ -90,7 +90,7 @@ class TestValidDispatch:
         )
         text = target.read_text(encoding="utf-8")
         assert "pre-commit" in text
-        assert "[PASS]" in text
+        assert "✅" in text
 
     def test_file_markdown(self, tmp_path: Path) -> None:
         target = tmp_path / "report.md"

--- a/tests/unit/test_reporter/test_formatting.py
+++ b/tests/unit/test_reporter/test_formatting.py
@@ -79,22 +79,22 @@ class TestFormatTerminal:
     """Tests for format_terminal (R1)."""
 
     def test_passed_report(self) -> None:
-        """Passing report shows PASSED."""
+        """Passing report shows PASSED with emoji."""
         output = format_terminal(_passed_report())
-        assert "PASSED" in output
+        assert "✅ PASSED" in output
         assert "pre-commit" in output
 
     def test_failed_report(self) -> None:
-        """Failing report shows FAILED and violation details."""
+        """Failing report shows FAILED with emoji and violation details."""
         output = format_terminal(_failed_report())
-        assert "FAILED" in output
+        assert "❌ FAILED" in output
         assert "src/main.py:10" in output
         assert "line too long" in output
 
     def test_skipped_checks(self) -> None:
-        """Skipped checks show SKIP indicator."""
+        """Skipped checks show ⏭️ indicator."""
         output = format_terminal(_skipped_report())
-        assert "SKIP" in output
+        assert "⏭️" in output
 
     def test_violations_shown(self) -> None:
         """Violation file, line, code are displayed."""
@@ -113,34 +113,34 @@ class TestFormatTerminal:
         assert "1/2" in output
 
     def test_default_locale_uses_english_labels(self) -> None:
-        """Default locale keeps existing English output verbatim."""
+        """Default locale uses English labels with emojis."""
         output = format_terminal(_passed_report())
-        assert "Stage: pre-commit — PASSED" in output
+        assert "🤖 Stage: pre-commit — ✅ PASSED" in output
         assert "2/2 checks passed, 0 failed" in output
         assert "Total time" in output
+        assert "📋 Checklist:" in output
+        assert "📊 Results:" in output
 
     def test_zh_cn_locale_localizes_headings(self) -> None:
         """zh-CN localizes stage / summary / total_time labels and status."""
         output = format_terminal(_passed_report(), locale="zh-CN")
-        assert "阶段: pre-commit — 通过" in output
+        assert "🤖 阶段: pre-commit — ✅ 通过" in output
         assert "2/2 项检查通过, 0 项失败" in output
         assert "总耗时" in output
-        # PASS / FAIL / SKIP indicators remain ASCII for alignment
-        assert "[PASS]" in output
         # English labels must not leak into zh-CN output
         assert "PASSED" not in output
         assert "Stage:" not in output
 
     def test_zh_cn_locale_failure_heading(self) -> None:
-        """zh-CN locale shows 失败 when the report fails."""
+        """zh-CN locale shows ❌ 失败 when the report fails."""
         output = format_terminal(_failed_report(), locale="zh-CN")
-        assert "阶段: pre-push — 失败" in output
+        assert "🤖 阶段: pre-push — ❌ 失败" in output
         assert "1/2 项检查通过, 1 项失败" in output
 
     def test_unknown_locale_falls_back_to_english(self) -> None:
         """Unknown locale behaves like the default English labels."""
         output = format_terminal(_passed_report(), locale="fr-FR")
-        assert "Stage: pre-commit — PASSED" in output
+        assert "🤖 Stage: pre-commit — ✅ PASSED" in output
         assert "2/2 checks passed, 0 failed" in output
 
 

--- a/tests/unit/test_reporter/test_metrics.py
+++ b/tests/unit/test_reporter/test_metrics.py
@@ -1,0 +1,237 @@
+"""Tests for reporter.metrics — metrics extraction and enrichment."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ac_guard.domain.models import CheckMetrics, CheckResult, StageOutcome
+from ac_guard.reporter.metrics import (
+    build_checklist,
+    enrich_outcome,
+)
+
+
+class TestPytestParser:
+    """Parse pytest output for test counts and coverage."""
+
+    def test_basic_summary(self) -> None:
+        output = "129 passed in 0.41s"
+        from ac_guard.reporter.metrics import _parse_pytest
+
+        result = _parse_pytest("pytest", output)
+        assert result is not None
+        assert result.tests_total == 129
+        assert result.tests_passed == 129
+        assert result.tests_failed == 0
+        assert result.tests_skipped == 0
+        assert result.coverage_pct is None
+
+    def test_summary_with_failures(self) -> None:
+        output = "128 passed, 1 failed, 2 skipped in 1.2s"
+        from ac_guard.reporter.metrics import _parse_pytest
+
+        result = _parse_pytest("pytest", output)
+        assert result is not None
+        assert result.tests_total == 131
+        assert result.tests_passed == 128
+        assert result.tests_failed == 1
+        assert result.tests_skipped == 2
+
+    def test_with_coverage(self) -> None:
+        output = (
+            "129 passed in 0.41s\n"
+            "---------- coverage: platform darwin ----------\n"
+            "Name                     Stmts   Miss  Cover\n"
+            "TOTAL                     1234    185    85%\n"
+        )
+        from ac_guard.reporter.metrics import _parse_pytest
+
+        result = _parse_pytest("pytest", output)
+        assert result is not None
+        assert result.tests_total == 129
+        assert result.coverage_pct == 85.0
+
+    def test_no_match(self) -> None:
+        from ac_guard.reporter.metrics import _parse_pytest
+
+        assert _parse_pytest("pytest", "some random output") is None
+
+
+class TestInterrogateParser:
+    """Parse interrogate output for docstring coverage."""
+
+    def test_passed_result(self) -> None:
+        output = "RESULT: PASSED (100.0%)"
+        from ac_guard.reporter.metrics import _parse_interrogate
+
+        result = _parse_interrogate("interrogate", output)
+        assert result is not None
+        assert result.docstring_pct == 100.0
+
+    def test_partial_result(self) -> None:
+        output = "RESULT: FAILED (53.6%)"
+        from ac_guard.reporter.metrics import _parse_interrogate
+
+        result = _parse_interrogate("interrogate", output)
+        assert result is not None
+        assert result.docstring_pct == 53.6
+
+    def test_no_match(self) -> None:
+        from ac_guard.reporter.metrics import _parse_interrogate
+
+        assert _parse_interrogate("interrogate", "no results here") is None
+
+
+class TestRuffParser:
+    """Parse ruff output for lint issue count."""
+
+    def test_errors_found(self) -> None:
+        output = "Found 3 errors."
+        from ac_guard.reporter.metrics import _parse_ruff
+
+        result = _parse_ruff("ruff", output)
+        assert result is not None
+        assert result.static_analysis_issues == 3
+
+    def test_no_errors(self) -> None:
+        output = "All checks passed!"
+        from ac_guard.reporter.metrics import _parse_ruff
+
+        assert _parse_ruff("ruff", output) is None
+
+
+class TestBanditParser:
+    """Parse bandit output for security issue count."""
+
+    def test_issues_found(self) -> None:
+        output = (
+            "Total issues (by severity):\n"
+            "        High: 1\n"
+            "        Medium: 0\n"
+            "        Low: 2\n"
+        )
+        from ac_guard.reporter.metrics import _parse_bandit
+
+        result = _parse_bandit("bandit", output)
+        assert result is not None
+        assert result.static_analysis_issues == 3
+
+    def test_no_issues(self) -> None:
+        output = (
+            "Total issues (by severity):\n"
+            "        High: 0\n"
+            "        Medium: 0\n"
+            "        Low: 0\n"
+        )
+        from ac_guard.reporter.metrics import _parse_bandit
+
+        assert _parse_bandit("bandit", output) is None
+
+
+class TestEnrichOutcome:
+    """enrich_outcome() populates metrics on CheckResult."""
+
+    def test_enriches_pytest_output(self) -> None:
+        outcome = StageOutcome(
+            stage="pre-push",
+            passed=True,
+            results=[
+                CheckResult(
+                    name="pytest",
+                    passed=True,
+                    output="129 passed in 0.41s",
+                ),
+            ],
+        )
+        enriched = enrich_outcome(outcome)
+        assert enriched.results[0].metrics is not None
+        assert enriched.results[0].metrics.tests_total == 129
+
+    def test_skips_already_enriched(self) -> None:
+        existing = CheckMetrics(tests_total=999)
+        outcome = StageOutcome(
+            stage="pre-push",
+            passed=True,
+            results=[
+                CheckResult(
+                    name="pytest",
+                    passed=True,
+                    output="129 passed in 0.41s",
+                    metrics=existing,
+                ),
+            ],
+        )
+        enriched = enrich_outcome(outcome)
+        assert enriched.results[0].metrics.tests_total == 999  # Not overwritten
+
+    def test_sets_generated_at(self) -> None:
+        outcome = StageOutcome(stage="pre-push", passed=True)
+        enriched = enrich_outcome(outcome)
+        assert enriched.generated_at != ""
+
+    def test_detects_guard_changes(self) -> None:
+        outcome = StageOutcome(stage="pre-push", passed=True)
+        with patch(
+            "ac_guard.reporter.metrics._detect_guard_changes",
+            return_value=["guard.yaml"],
+        ):
+            enriched = enrich_outcome(outcome)
+        assert enriched.guard_files_changed == ["guard.yaml"]
+
+
+class TestBuildChecklist:
+    """build_checklist() maps check results to checklist items."""
+
+    def test_format_and_lint(self) -> None:
+        outcome = StageOutcome(
+            stage="pre-commit",
+            passed=True,
+            results=[
+                CheckResult(name="format-python", passed=True),
+                CheckResult(name="lint-python", passed=True),
+            ],
+        )
+        items = build_checklist(outcome)
+        labels = [i.label for i in items]
+        assert "Code formatting" in labels
+        assert "Linting" in labels
+
+    def test_with_metrics(self) -> None:
+        outcome = StageOutcome(
+            stage="pre-push",
+            passed=True,
+            results=[
+                CheckResult(
+                    name="pytest",
+                    passed=True,
+                    metrics=CheckMetrics(tests_total=129, tests_passed=129),
+                ),
+            ],
+        )
+        items = build_checklist(outcome)
+        assert len(items) == 1
+        assert items[0].label == "Tests"
+        assert items[0].detail == "129/129"
+        assert items[0].status == "pass"
+
+    def test_skipped_checks_excluded(self) -> None:
+        outcome = StageOutcome(
+            stage="pre-push",
+            passed=True,
+            results=[
+                CheckResult(name="pytest", passed=True, skipped=True),
+            ],
+        )
+        items = build_checklist(outcome)
+        assert len(items) == 0
+
+    def test_unknown_check_excluded(self) -> None:
+        outcome = StageOutcome(
+            stage="pre-push",
+            passed=True,
+            results=[
+                CheckResult(name="unknown-tool", passed=True),
+            ],
+        )
+        items = build_checklist(outcome)
+        assert len(items) == 0


### PR DESCRIPTION
## Summary

- **feat(reporter): update-or-create PR comments** — Instead of creating a new comment on every push, now searches for an existing comment with `<!-- ac-guard-report -->` marker and updates it via PATCH. Falls back to POST if no existing comment is found.

- **feat(reporter): add gh CLI fallback for local PR comment posting** — `_read_token()` falls back to `gh auth token` when `GITHUB_TOKEN` is not set, and `_resolve_pr()` falls back to `gh pr view` for PR number resolution. This enables local developers to post PR comments automatically after running checks.

- **fix(hooks): bake venv PATH into generated git hooks** — Generated git hooks now export the venv bin directory to PATH, so tools like `ruff` are found when pre-commit framework runs hooks with `language=system`.

- **fix(action-guard): recognize ac-guard's own hook signature** — `_precommit_hook_installed()` now recognizes ac-guard's generated hooks (containing "AI Code Guard") in addition to pre-commit framework hooks. This prevents spurious confirmation dialogs on every git commit.

## Test plan

- [x] Unit tests for update-or-create (existing comment, no comment, list failure)
- [x] Unit tests for gh CLI token and PR number fallback
- [x] Unit tests for ac-guard hook signature recognition
- [x] All 129 reporter tests pass
- [x] All 129 action-guard tests pass
- [x] Pre-commit hooks pass (format, lint, etc.)
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)