### PR TITLE
fix(enforcer): block force-push to all branches, not just main/master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,16 @@ The following rules define what operations are permitted, blocked, or require ap
 ### Execute Operations
 
 **Forbidden** (blocked):
-- `shell:git commit --no-verify*` — --no-verify skips pre-commit checks- `shell:git push --no-verify*` — --no-verify skips pre-push checks- `shell:SKIP=\S+\s+git\s+(?:commit|push)\b.*` — SKIP= env-var bypasses pre-commit hooks- `shell:git\s+.*-c\s+core\.hooks[Pp]ath=\S+.*` — git -c core.hooksPath overrides the hook path- `shell:(?i)git\s+config\s.*core\.hookspath\s+\S+.*` — git config core.hooksPath permanently overrides the hook path- `shell:git\s+rebase\s+.*(?:--exec|-x\s+).*` — git rebase --exec can run arbitrary commands bypassing per-commit hooks- `shell:CI=\S+\s+git\s+(?:commit|push)\b.*` — CI= env-var can trick tools into skipping pre-commit checks- `shell:git\s+push\s+.*--force(?:-with-lease)?\b.*\b(?:main|master)\b.*` — force push to protected branch rewrites shared history- `shell:git\s+push\s+.*\b(?:main|master)\b.*--force(?:-with-lease)?\b.*` — force push to protected branch rewrites shared history- `shell:git\s+push\s+.*-f\b.*\b(?:main|master)\b.*` — force push (-f) to protected branch rewrites shared history- `shell:git\s+push\s+\S+\s+\+(?:main|master)\b.*` — git push <remote> +<branch> is an alias for force push to the protected branch
+- `shell:git commit --no-verify*` — --no-verify skips pre-commit checks
+- `shell:git push --no-verify*` — --no-verify skips pre-push checks
+- `shell:SKIP=\S+\s+git\s+(?:commit|push)\b.*` — SKIP= env-var bypasses pre-commit hooks
+- `shell:git\s+.*-c\s+core\.hooks[Pp]ath=\S+.*` — git -c core.hooksPath overrides the hook path
+- `shell:(?i)git\s+config\s.*core\.hookspath\s+\S+.*` — git config core.hooksPath permanently overrides the hook path
+- `shell:git\s+rebase\s+.*(?:--exec|-x\s+).*` — git rebase --exec can run arbitrary commands bypassing per-commit hooks
+- `shell:CI=\S+\s+git\s+(?:commit|push)\b.*` — CI= env-var can trick tools into skipping pre-commit checks
+- `shell:git\s+push\s+.*--force(?:-with-lease)?\b.*` — force push rewrites shared history
+- `shell:git\s+push\s+.*-f\b.*` — force push (-f) rewrites shared history
+- `shell:git\s+push\s+\S+\s+\+\S+.*` — git push +branch is force push
 
 
 

--- a/guard.yaml
+++ b/guard.yaml
@@ -9,9 +9,9 @@ project:
   language: "python"
 
 behavior:
-  # read/execute — use ac-guard defaults (Track A's 11 forbidden patterns:
+  # read/execute — use ac-guard defaults (Track A's 10 forbidden patterns:
   #   --no-verify / SKIP= / CI= / -c core.hooksPath / git config core.hooksPath /
-  #   git rebase --exec / --force / --force-with-lease / -f / +branch to main).
+  #   git rebase --exec / --force / --force-with-lease / -f / +branch).
   write:
     forbidden:
       - pattern: "file:.env*"

--- a/src/ac_guard/config/merger.py
+++ b/src/ac_guard/config/merger.py
@@ -129,32 +129,21 @@ _SYSTEM_EXECUTE_FORBIDDEN: list[dict[str, Any]] = [
         "reason": "CI= env-var can trick tools into skipping pre-commit checks",
     },
     {
-        "pattern": (
-            r"shell:git\s+push\s+.*--force(?:-with-lease)?\b.*"
-            r"\b(?:main|master)\b.*"
-        ),
+        "pattern": r"shell:git\s+push\s+.*--force(?:-with-lease)?\b.*",
         "regex": True,
-        "reason": "force push to protected branch rewrites shared history",
+        "reason": "force push rewrites shared history — use a human operator",
     },
     {
-        "pattern": (
-            r"shell:git\s+push\s+.*\b(?:main|master)\b.*"
-            r"--force(?:-with-lease)?\b.*"
-        ),
+        "pattern": r"shell:git\s+push\s+.*-f\b.*",
         "regex": True,
-        "reason": "force push to protected branch rewrites shared history",
+        "reason": "force push (-f) rewrites shared history — use a human operator",
     },
     {
-        "pattern": r"shell:git\s+push\s+.*-f\b.*\b(?:main|master)\b.*",
-        "regex": True,
-        "reason": "force push (-f) to protected branch rewrites shared history",
-    },
-    {
-        "pattern": r"shell:git\s+push\s+\S+\s+\+(?:main|master)\b.*",
+        "pattern": r"shell:git\s+push\s+\S+\s+\+\S+.*",
         "regex": True,
         "reason": (
-            "git push <remote> +<branch> is an alias for force push to the "
-            "protected branch"
+            "git push <remote> +<branch> is an alias for force push — "
+            "use a human operator"
         ),
     },
 ]

--- a/tests/integration/test_code_gate_e2e.py
+++ b/tests/integration/test_code_gate_e2e.py
@@ -428,20 +428,14 @@ class TestSystemExecuteRulesE2E:
         assert any("-c" in p and "hooks" in p for p in patterns)
         assert any("config" in p and "hookspath" in p.lower() for p in patterns)
         assert any("rebase" in p and "exec" in p for p in patterns)
-        # Hardening: CI= env-var + force-push variants (#105 follow-up)
+        # Hardening: CI= env-var + force-push variants (any branch)
         assert any("CI=" in p and "git" in p for p in patterns)
-        assert any(
-            "git" in p and "push" in p and "--force" in p and "main" in p
-            for p in patterns
-        )
-        assert any(
-            "git" in p and "push" in p and "+" in p and "main" in p for p in patterns
-        )
+        assert any("git" in p and "push" in p and "--force" in p for p in patterns)
+        assert any("git" in p and "push" in p and "+" in p for p in patterns)
         # Regex flag persists to runtime cache — 4 bypass patterns plus the
-        # 5 hardening additions (CI=, two --force orderings, -f short form,
-        # `+<branch>` shorthand).
+        # 4 hardening additions (CI=, --force, -f short form, +branch).
         regex_rules = [r for r in rules if r.get("regex")]
-        assert len(regex_rules) == 9
+        assert len(regex_rules) == 8
 
 
 class TestPrecommitArtifactE2E:

--- a/tests/unit/test_action_guard/test_core.py
+++ b/tests/unit/test_action_guard/test_core.py
@@ -202,30 +202,17 @@ def _bypass_policy() -> dict:
                         "source": "system",
                     },
                     {
-                        "pattern": (
-                            r"shell:git\s+push\s+.*--force(?:-with-lease)?\b.*"
-                            r"\b(?:main|master)\b.*"
-                        ),
+                        "pattern": r"shell:git\s+push\s+.*--force(?:-with-lease)?\b.*",
                         "regex": True,
                         "source": "system",
                     },
                     {
-                        "pattern": (
-                            r"shell:git\s+push\s+.*\b(?:main|master)\b.*"
-                            r"--force(?:-with-lease)?\b.*"
-                        ),
+                        "pattern": r"shell:git\s+push\s+.*-f\b.*",
                         "regex": True,
                         "source": "system",
                     },
                     {
-                        "pattern": (
-                            r"shell:git\s+push\s+.*-f\b.*\b(?:main|master)\b.*"
-                        ),
-                        "regex": True,
-                        "source": "system",
-                    },
-                    {
-                        "pattern": (r"shell:git\s+push\s+\S+\s+\+(?:main|master)\b.*"),
+                        "pattern": r"shell:git\s+push\s+\S+\s+\+\S+.*",
                         "regex": True,
                         "source": "system",
                     },
@@ -255,17 +242,22 @@ class TestSystemBypassPatterns:
             # CI= env-var bypass
             "CI=1 git commit -m x",
             "CI=true git push origin main",
-            # force push to protected branch, flag before branch
+            # force push (any branch), flag before branch
             "git push --force origin main",
             "git push --force-with-lease origin master",
+            "git push --force origin feature-x",
+            "git push --force-with-lease origin dev",
             # force push, flag after branch
             "git push origin main --force",
             "git push origin master --force-with-lease",
+            "git push origin feature --force",
             # -f short form
             "git push -f origin main",
+            "git push -f origin feature",
             # `+<branch>` shorthand
             "git push origin +main",
             "git push origin +master",
+            "git push origin +feature-x",
         ],
     )
     def test_bypass_command_denied(self, tmp_path: Path, cmd: str) -> None:
@@ -290,9 +282,6 @@ class TestSystemBypassPatterns:
             "git push origin feature",
             # CI= without git should pass through
             "CI=1 pytest",
-            # force push to feature branch (not protected) is fine
-            "git push --force origin feature-x",
-            "git push origin +feature-x",
         ],
     )
     def test_lookalike_command_allowed(self, tmp_path: Path, cmd: str) -> None:

--- a/tests/unit/test_config/test_merger.py
+++ b/tests/unit/test_config/test_merger.py
@@ -364,23 +364,16 @@ class TestSystemExecuteRules:
         assert any("CI=" in p and "git" in p for p in patterns)
 
     def test_execute_forbidden_has_force_push_patterns(self, tmp_path: Path) -> None:
-        """Regression: force push to main/master is blocked in all 4 forms."""
+        """Regression: force push is blocked for all branches."""
         path = _write_yaml(tmp_path, _minimal_guard())
         result = resolve_config(path)
         patterns = [r.pattern for r in result.behavior.execute.forbidden]
-        # --force / --force-with-lease with branch either side of the flag
-        assert any(
-            "git" in p and "push" in p and "--force" in p and "main" in p
-            for p in patterns
-        )
+        # --force / --force-with-lease
+        assert any("git" in p and "push" in p and "--force" in p for p in patterns)
         # -f short form
-        assert any(
-            "git" in p and "push" in p and "-f" in p and "main" in p for p in patterns
-        )
+        assert any("git" in p and "push" in p and "-f" in p for p in patterns)
         # `git push <remote> +<branch>` shorthand
-        assert any(
-            "git" in p and "push" in p and "+" in p and "main" in p for p in patterns
-        )
+        assert any("git" in p and "push" in p and "+" in p for p in patterns)
 
     def test_user_execute_rules_coexist_with_system_rules(self, tmp_path: Path) -> None:
         data = _minimal_guard(


### PR DESCRIPTION
## Summary

- force-push 是高危操作，无论哪个分支都不应该让 Agent 执行
- 将 4 条硬编码 `main|master` 的正则简化为 3 条，覆盖所有分支
- 净减少 26 行代码，规则更简单、覆盖更全面

## 改动

| 命令 | 修改前 | 修改后 |
|------|--------|--------|
| `git push --force origin main` | DENY | DENY |
| `git push --force origin feature-x` | ALLOW | **DENY** |
| `git push --force-with-lease origin dev` | ALLOW | **DENY** |
| `git push -f origin feature` | ALLOW | **DENY** |
| `git push origin +feature` | ALLOW | **DENY** |
| `git push origin main` | ALLOW | ALLOW |

## Test plan

- [x] 1252 tests passed, 98% coverage
- [x] pre-commit hooks 全部通过
- [x] pre-push 验证通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)